### PR TITLE
Remove GitHub Sponsors link to original maintainer

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: marak
+github: # Replace with a new sponsors name
 patreon: # Replace with a single Patreon username
 open_collective: # fakerjs
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
Prospective sponsors who come to the new repository will be directed to sponsor Marek unless this file is updated. This change should at least prevent this from happening until new funding links are set up. 

cf. #2 
cf. #44