### PR TITLE
feat: migrate git

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,97 @@
+import type { Faker } from '.';
+
+export class Git {
+  private hexChars = [
+    '0',
+    '1',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    'a',
+    'b',
+    'c',
+    'd',
+    'e',
+    'f',
+  ];
+
+  constructor(private readonly faker: Faker) {}
+
+  /**
+   * branch
+   *
+   * @method faker.git.branch
+   */
+  branch() {
+    const noun = this.faker.hacker.noun().replace(' ', '-');
+    const verb = this.faker.hacker.verb().replace(' ', '-');
+    return noun + '-' + verb;
+  }
+
+  /**
+   * commitEntry
+   *
+   * @method faker.git.commitEntry
+   * @param options
+   */
+  commitEntry(options: { merge?: boolean } = {}) {
+    // TODO @Shinigami92 2022-01-11: We may want to make it configurable to use just `\n` instead of `\r\n`
+    let entry = 'commit {{git.commitSha}}\r\n';
+
+    if (options.merge || this.faker.datatype.number({ min: 0, max: 4 }) === 0) {
+      entry += 'Merge: {{git.shortSha}} {{git.shortSha}}\r\n';
+    }
+
+    entry +=
+      'Author: {{name.firstName}} {{name.lastName}} <{{internet.email}}>\r\n';
+    entry += 'Date: ' + this.faker.date.recent().toString() + '\r\n';
+    entry += '\r\n\xa0\xa0\xa0\xa0{{git.commitMessage}}\r\n';
+
+    return this.faker.fake(entry);
+  }
+
+  /**
+   * commitMessage
+   *
+   * @method faker.git.commitMessage
+   */
+  commitMessage() {
+    const format = '{{hacker.verb}} {{hacker.adjective}} {{hacker.noun}}';
+    return this.faker.fake(format);
+  }
+
+  /**
+   * commitSha
+   *
+   * @method faker.git.commitSha
+   */
+  commitSha() {
+    let commit = '';
+
+    for (let i = 0; i < 40; i++) {
+      commit += this.faker.random.arrayElement(this.hexChars);
+    }
+
+    return commit;
+  }
+
+  /**
+   * shortSha
+   *
+   * @method faker.git.shortSha
+   */
+  shortSha() {
+    let shortSha = '';
+
+    for (let i = 0; i < 7; i++) {
+      shortSha += this.faker.random.arrayElement(this.hexChars);
+    }
+
+    return shortSha;
+  }
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -35,7 +35,7 @@ export class Git {
    *
    * @method faker.git.branch
    */
-  branch() {
+  branch(): string {
     const noun = this.faker.hacker.noun().replace(' ', '-');
     const verb = this.faker.hacker.verb().replace(' ', '-');
     return noun + '-' + verb;
@@ -47,7 +47,7 @@ export class Git {
    * @method faker.git.commitEntry
    * @param options
    */
-  commitEntry(options: { merge?: boolean } = {}) {
+  commitEntry(options: { merge?: boolean } = {}): string {
     // TODO @Shinigami92 2022-01-11: We may want to make it configurable to use just `\n` instead of `\r\n`
     let entry = 'commit {{git.commitSha}}\r\n';
 
@@ -68,7 +68,7 @@ export class Git {
    *
    * @method faker.git.commitMessage
    */
-  commitMessage() {
+  commitMessage(): string {
     const format = '{{hacker.verb}} {{hacker.adjective}} {{hacker.noun}}';
     return this.faker.fake(format);
   }
@@ -78,7 +78,7 @@ export class Git {
    *
    * @method faker.git.commitSha
    */
-  commitSha() {
+  commitSha(): string {
     let commit = '';
 
     for (let i = 0; i < 40; i++) {
@@ -93,7 +93,7 @@ export class Git {
    *
    * @method faker.git.shortSha
    */
-  shortSha() {
+  shortSha(): string {
     let shortSha = '';
 
     for (let i = 0; i < 7; i++) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -20,7 +20,15 @@ export class Git {
     'f',
   ];
 
-  constructor(private readonly faker: Faker) {}
+  constructor(private readonly faker: Faker) {
+    // Bind `this` so namespaced is working correctly
+    for (const name of Object.getOwnPropertyNames(Git.prototype)) {
+      if (name === 'constructor' || typeof this[name] !== 'function') {
+        continue;
+      }
+      this[name] = this[name].bind(this);
+    }
+  }
 
   /**
    * branch

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Datatype } from './datatype';
 import { _Date } from './date';
+import { Git } from './git';
 import { Hacker } from './hacker';
 import { Helpers } from './helpers';
 import { Mersenne } from './mersenne';
@@ -171,7 +172,7 @@ export class Faker {
   readonly database = new (require('./database'))(this);
   readonly date: _Date = new _Date(this);
   readonly finance = new (require('./finance'))(this);
-  readonly git = new (require('./git'))(this);
+  readonly git: Git = new Git(this);
   readonly hacker: Hacker = new Hacker(this);
   // TODO @Shinigami92 2022-01-12: iban was not used
   // readonly iban = new (require('./iban'))(this);


### PR DESCRIPTION
This is based on top of other TS migrations like #72

We need to migrate `fake` (#79), `hacker` and `date` (#83) cause this module depends on them

test with `npm run build && npx mocha test/git.unit.js`