### PR TITLE
feat: migrate hacker

### DIFF
--- a/src/hacker.ts
+++ b/src/hacker.ts
@@ -1,0 +1,84 @@
+import type { Faker } from '.';
+
+export class Hacker {
+  constructor(private readonly faker: Faker) {
+    // Bind `this` so namespaced is working correctly
+    for (const name of Object.getOwnPropertyNames(Hacker.prototype)) {
+      if (name === 'constructor' || typeof this[name] !== 'function') {
+        continue;
+      }
+      this[name] = this[name].bind(this);
+    }
+  }
+
+  /**
+   * abbreviation
+   *
+   * @method faker.hacker.abbreviation
+   */
+  abbreviation() {
+    return this.faker.random.arrayElement(
+      this.faker.definitions.hacker.abbreviation
+    );
+  }
+
+  /**
+   * adjective
+   *
+   * @method faker.hacker.adjective
+   */
+  adjective() {
+    return this.faker.random.arrayElement(
+      this.faker.definitions.hacker.adjective
+    );
+  }
+
+  /**
+   * noun
+   *
+   * @method faker.hacker.noun
+   */
+  noun() {
+    return this.faker.random.arrayElement(this.faker.definitions.hacker.noun);
+  }
+
+  /**
+   * verb
+   *
+   * @method faker.hacker.verb
+   */
+  verb() {
+    return this.faker.random.arrayElement(this.faker.definitions.hacker.verb);
+  }
+
+  /**
+   * ingverb
+   *
+   * @method faker.hacker.ingverb
+   */
+  ingverb() {
+    return this.faker.random.arrayElement(
+      this.faker.definitions.hacker.ingverb
+    );
+  }
+
+  /**
+   * phrase
+   *
+   * @method faker.hacker.phrase
+   */
+  phrase() {
+    const data = {
+      abbreviation: this.abbreviation,
+      adjective: this.adjective,
+      ingverb: this.ingverb,
+      noun: this.noun,
+      verb: this.verb,
+    };
+
+    const phrase = this.faker.random.arrayElement(
+      this.faker.definitions.hacker.phrase
+    );
+    return this.faker.helpers.mustache(phrase, data);
+  }
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -289,13 +289,24 @@ export class Helpers {
    * @param str
    * @param data
    */
-  mustache(str: string | undefined, data: Record<string, string>): string {
+  mustache(
+    str: string | undefined,
+    data: Record<
+      string,
+      string | ((substring: string, ...args: any[]) => string)
+    >
+  ): string {
     if (typeof str === 'undefined') {
       return '';
     }
     for (const p in data) {
       const re = new RegExp('{{' + p + '}}', 'g');
-      str = str.replace(re, data[p]);
+      str = str.replace(
+        re,
+        // TODO christopher 2022-01-14: Try to improve the type or maybe use `if`
+        // @ts-expect-error
+        data[p]
+      );
     }
     return str;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Datatype } from './datatype';
 import { _Date } from './date';
+import { Hacker } from './hacker';
 import { Helpers } from './helpers';
 import { Mersenne } from './mersenne';
 import { Random } from './random';
@@ -171,7 +172,7 @@ export class Faker {
   readonly date: _Date = new _Date(this);
   readonly finance = new (require('./finance'))(this);
   readonly git = new (require('./git'))(this);
-  readonly hacker = new (require('./hacker'))(this);
+  readonly hacker: Hacker = new Hacker(this);
   // TODO @Shinigami92 2022-01-12: iban was not used
   // readonly iban = new (require('./iban'))(this);
   readonly image = new (require('./image'))(this);


### PR DESCRIPTION
This is based on top of other TS migrations like #72

We need to migrate `helpers` cause this module depends on it

Also this module needs the `definitions` structure :thinking: I think we should try to create this dynamically instead of like it is currently (#84)

test with `npm run build && npx mocha test/hacker.unit.js`