### PR TITLE
chore: do not exit when committing a merge

### DIFF
--- a/scripts/verifyCommit.ts
+++ b/scripts/verifyCommit.ts
@@ -11,7 +11,9 @@ const releaseRE = /^v\d/;
 const commitRE =
   /^(revert: )?(feat|fix|docs|dx|refactor|perf|test|workflow|build|ci|chore|types|wip|release|deps)(\(.+\))?: .{1,50}/;
 
-if (!releaseRE.test(msg) && !commitRE.test(msg)) {
+const isMergeCommit = msg.startsWith('Merge remote-tracking-branch');
+
+if (!isMergeCommit && !releaseRE.test(msg) && !commitRE.test(msg)) {
   console.log();
   console.error(
     `  ${colors.bgRed(colors.white(' ERROR '))} ${colors.red(


### PR DESCRIPTION
The pre-commit hooks verifying the commit message format (in `verifyCommit.ts`) do not support merge commits.

This PR ensures that you can do merge commits.