### PR TITLE
feat: deprecate avatar generator

### DIFF
--- a/lib/internet.js
+++ b/lib/internet.js
@@ -7,23 +7,6 @@ var random_ua = require('../vendor/user-agent');
 var Internet = function (faker) {
   var self = this;
   /**
-   * avatar
-   *
-   * @method faker.internet.avatar
-   */
-  self.avatar = function () {
-    return (
-      'https://cdn.fakercloud.com/avatars/' +
-      faker.random.arrayElement(faker.definitions.internet.avatar_uri)
-    );
-  };
-
-  self.avatar.schema = {
-    description: 'Generates a URL for an avatar.',
-    sampleResults: ['https://cdn.fakercloud.com/avatars/sydlawrence_128.jpg'],
-  };
-
-  /**
    * email
    *
    * @method faker.internet.email

--- a/test/image.unit.js
+++ b/test/image.unit.js
@@ -41,11 +41,6 @@ describe("image.js", function () {
         assert.strictEqual(imageUrl, 'https://picsum.photos/seed/picsum/100/100');
       });
     });
-    describe("avatar()", function () {
-      it("return a random avatar from FakerCloud", function () {
-        assert.notStrictEqual(-1, faker.image.lorempicsum.avatar().indexOf('cdn.fakercloud.com/avatars'));
-      })
-    });
 
     describe("imageGrayscale()", function () {
       it("returns a random URL with grayscale image", function () {
@@ -87,11 +82,6 @@ describe("image.js", function () {
 
         assert.strictEqual(imageUrl, 'https://lorempixel.com/100/100/abstract');
       });
-    });
-    describe("avatar()", function () {
-      it("return a random avatar from FakerCloud", function () {
-        assert.notStrictEqual(-1, faker.image.lorempixel.avatar().indexOf('cdn.fakercloud.com/avatars'));
-      })
     });
     describe("abstract()", function () {
       it("returns a random abstract image url", function () {


### PR DESCRIPTION
Since fakercloud.com is not active anymore, the `avatar` feature is broke.

I propose changes to remove it for now.

Also it's not related to fake data, much like kind of generator.