### PR TITLE
chore: swap funding to be sent through the open collective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,8 +1,8 @@
 # These are supported funding model platforms
 
-github: marak
+github: # Replace with the open collective's name https://docs.opencollective.com/help/collectives/osc-verification/github-sponsors
 patreon: # Replace with a single Patreon username
-open_collective: # fakerjs
+open_collective: fakerjs
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/package.json
+++ b/package.json
@@ -2,12 +2,9 @@
   "name": "faker",
   "description": "Generate massive amounts of fake contextual data",
   "version": "5.5.3",
-  "contributors": [
-    "Marak Squires <marak.squires@gmail.com>"
-  ],
   "repository": {
     "type": "git",
-    "url": "http://github.com/Marak/Faker.js.git"
+    "url": "https://github.com/faker-js/faker.git"
   },
   "scripts": {
     "browser": "./node_modules/.bin/gulp browser",


### PR DESCRIPTION
Deals with #75 and #15 .

Removing the maintainers field is common and is what lodash and a few other projects do. Better to let NPM and Github show who all has committed to the repo.