### PR TITLE
fix: add docs to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,7 @@ build/build/*
 !build/build/faker.js
 !build/build/faker.min.js
 doc/
+docs/
 examples/
 meteor/
 test/


### PR DESCRIPTION
Closes #135 

This PR adds `docs/` to .npmignore file to prevent it to be published to npm.