### PR TITLE
docs: add yarn and pnpm install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,19 @@ Generate massive amounts of fake data in the Browser and Node.js.
 Please replace your `faker` dependency with `@faker-js/faker`. This is the official, stable fork of Faker.
 
 ```shell
-npm install @faker-js/faker -D
+npm install @faker-js/faker --save-dev
+```
+
+or
+
+```shell
+yarn add @faker-js/faker --dev
+```
+
+or
+
+```shell
+pnpm add @faker-js/faker --save-dev
 ```
 
 ### Typescript Support

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -24,9 +24,17 @@ Install it as a Dev Dependency using your favorite package manager.
 ```shell
 npm install @faker-js/faker --save-dev
 ```
+
 or
+
 ```shell
 yarn add @faker-js/faker --dev
+```
+
+or
+
+```shell
+pnpm add @faker-js/faker --save-dev
 ```
 
 ## Usage

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -24,6 +24,10 @@ Install it as a Dev Dependency using your favorite package manager.
 ```shell
 npm install @faker-js/faker --save-dev
 ```
+or
+```shell
+yarn add @faker-js/faker --dev
+```
 
 ## Usage
 


### PR DESCRIPTION
This might seem a bit unnecessary, but I think it would be a nice quality-of-life addition for the yarn users out there, they can just copy-paste from the doc.