### PR TITLE
refactor: Use datatype.number() function instead of random.number()

### DIFF
--- a/src/internet.ts
+++ b/src/internet.ts
@@ -187,7 +187,7 @@ export class Internet {
   avatar(): string {
     return (
       'https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/' +
-      this.faker.random.number(1249) +
+      this.faker.datatype.number(1249) +
       '.jpg'
     );
   }


### PR DESCRIPTION
Use `datatype.number()` function to generate a number in [src/internet.ts](https://github.com/faker-js/faker/pull/183/files#diff-6ec5c644d528743506612d7d96511ba25dd360836c2139e73d772fe10a25be73), instead of the deprecated `random.number()` function.