### PR TITLE
fix(types): fixed datetime types for optional argument

### DIFF
--- a/src/datatype.ts
+++ b/src/datatype.ts
@@ -95,7 +95,7 @@ export class Datatype {
    * @method faker.datatype.datetime
    * @param options pass min OR max as number of milliseconds since 1. Jan 1970 UTC
    */
-  datetime(options): Date {
+  datetime(options?: number | { min?: number; max?: number}): Date {
     if (typeof options === 'number') {
       options = {
         max: options,


### PR DESCRIPTION
Datetime has an optional `options` argument  

source: https://github.com/faker-js/faker/blob/main/src/datatype.ts#L98
test: https://github.com/faker-js/faker/blob/d9b6e5d584f92da4ca059f2705530e609525265e/test/datatype.unit.js#L157