### PR TITLE
fix(types): fixed exampleEmail arguments types

### DIFF
--- a/src/internet.ts
+++ b/src/internet.ts
@@ -220,7 +220,7 @@ export class Internet {
    * @param firstName
    * @param lastName
    */
-  exampleEmail(firstName, lastName) {
+  exampleEmail(firstName?: string, lastName?: string) {
     const provider = this.faker.random.arrayElement(
       this.faker.definitions.internet.example_email
     );


### PR DESCRIPTION
The arguments for internet exampleEmail appear to be optional in the documentation, but is actually required in the `internet.d.ts` file.

ref: https://github.com/faker-js/faker/blob/main/docs/api/internet.md#example-e-mail-

Fixed each to optional string type.