### PR TITLE
feat: use export default for locales

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { Hacker } from './hacker';
 import { Helpers } from './helpers';
 import { Image } from './image';
 import { Internet } from './internet';
+import allLocales from './locales';
 import { Lorem } from './lorem';
 import { Mersenne } from './mersenne';
 import { Music } from './music';
@@ -438,7 +439,7 @@ export class Faker {
 
 // since we are requiring the top level of faker, load all locales by default
 export const faker: Faker = new Faker({
-  locales: require('./locales'),
+  locales: allLocales,
 });
 
 export default faker;

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -115,4 +115,4 @@ const locales: { [lang: string]: LocaleDefinition } = {
   zu_ZA,
 };
 
-export = locales;
+export default locales;


### PR DESCRIPTION
This change is required to allow exporting types from the the locales/index.ts such as `KnownLocale`s.

Prerequisite for https://github.com/faker-js/faker/pull/248