### PR TITLE
fix: jalapeño typo

### DIFF
--- a/src/locales/en/word/noun.ts
+++ b/src/locales/en/word/noun.ts
@@ -3249,7 +3249,7 @@ export default [
   'jaguar',
   'jail',
   'jailhouse',
-  'jalapeÃ±o',
+  'jalapeño',
   'jam',
   'jar',
   'jasmine',


### PR DESCRIPTION
Found during the implementation of https://github.com/faker-js/faker/pull/258