### PR TITLE
fix: date.between typing

### DIFF
--- a/src/date.ts
+++ b/src/date.ts
@@ -68,9 +68,10 @@ export class _Date {
    * @param from
    * @param to
    */
-  between(from: string, to: string): Date {
-    const fromMilli = Date.parse(from);
-    const dateOffset = this.faker.datatype.number(Date.parse(to) - fromMilli);
+  between(from: string | Date, to: string | Date): Date {
+    const fromMilli = new Date(from).getTime();
+    const toMilli = new Date(to).getTime();
+    const dateOffset = this.faker.datatype.number(toMilli - fromMilli);
 
     const newDate = new Date(fromMilli + dateOffset);
 


### PR DESCRIPTION
Return the typing to the [original typing](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/291c346588768b8ea13472ff95bdacd659f67790/types/faker/v3/index.d.ts#L58) and in accordance with the [current spec](https://github.com/faker-js/faker/blob/main/test/date.spec.ts#L119-L131).