### PR TITLE
chore(test): Add locale to test description

### DIFF
--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -31,13 +31,13 @@ function isTestableMethod(mod: string) {
 function both(
   pred1: (meth: string) => boolean,
   pred2: (meth: string) => boolean
-) {
+): (meth: string) => boolean {
   return (value) => pred1(value) && pred2(value);
 }
 
 // Basic smoke tests to make sure each method is at least implemented and returns a value.
 
-function modulesList() {
+function modulesList(): { [module: string]: string[] } {
   const modules = Object.keys(faker)
     .filter(isTestableModule)
     .reduce((result, mod) => {
@@ -54,22 +54,24 @@ const modules = modulesList();
 
 describe('functional tests', () => {
   for (const locale in faker.locales) {
-    faker.locale = locale;
-    Object.keys(modules).forEach((module) => {
-      describe(module, () => {
-        // if there is nothing to test, create a dummy test so the test runner doesn't complain
-        if (Object.keys(modules[module]).length === 0) {
-          it.todo(`${module} was empty`);
-        }
+    describe(locale, () => {
+      faker.locale = locale;
+      Object.keys(modules).forEach((module) => {
+        describe(module, () => {
+          // if there is nothing to test, create a dummy test so the test runner doesn't complain
+          if (Object.keys(modules[module]).length === 0) {
+            it.todo(`${module} was empty`);
+          }
 
-        modules[module].forEach((meth) => {
-          it(meth + '()', () => {
-            const result = faker[module][meth]();
-            if (meth === 'boolean') {
-              expect(typeof result).toBe('boolean');
-            } else {
-              expect(result).toBeTruthy();
-            }
+          modules[module].forEach((meth) => {
+            it(meth + '()', () => {
+              const result = faker[module][meth]();
+              if (meth === 'boolean') {
+                expect(typeof result).toBe('boolean');
+              } else {
+                expect(result).toBeTruthy();
+              }
+            });
           });
         });
       });
@@ -79,26 +81,28 @@ describe('functional tests', () => {
 
 describe('faker.fake functional tests', () => {
   for (const locale in faker.locales) {
-    faker.locale = locale;
-    faker.seed(1);
-    Object.keys(modules).forEach((module) => {
-      describe(module, () => {
-        // if there is nothing to test, create a dummy test so the test runner doesn't complain
-        if (Object.keys(modules[module]).length === 0) {
-          it.todo(`${module} was empty`);
-        }
+    describe(locale, () => {
+      faker.locale = locale;
+      faker.seed(1);
+      Object.keys(modules).forEach((module) => {
+        describe(module, () => {
+          // if there is nothing to test, create a dummy test so the test runner doesn't complain
+          if (Object.keys(modules[module]).length === 0) {
+            it.todo(`${module} was empty`);
+          }
 
-        modules[module].forEach((meth) => {
-          it(meth + '()', () => {
-            const result = faker.fake('{{' + module + '.' + meth + '}}');
-            // just make sure any result is returned
-            // an undefined result usually means an error
-            expect(result).toBeDefined();
-            // if (meth === 'boolean') {
-            //   expect(typeof result).toBe('boolean');
-            // } else {
-            //   expect(result).toBeTruthy();
-            // }
+          modules[module].forEach((meth) => {
+            it(meth + '()', () => {
+              const result = faker.fake('{{' + module + '.' + meth + '}}');
+              // just make sure any result is returned
+              // an undefined result usually means an error
+              expect(result).toBeDefined();
+              // if (meth === 'boolean') {
+              //   expect(typeof result).toBe('boolean');
+              // } else {
+              //   expect(result).toBeTruthy();
+              // }
+            });
           });
         });
       });


### PR DESCRIPTION
This improves the generic tests by adding the locale to the the test description.

Before:

````txt
stdout | test/all_functional.spec.ts > functional tests > random > hexaDecimal()
````

After:

````txt
stdout | test/all_functional.spec.ts > functional tests > en_AU_ocker > random > hexaDecimal()
````

This PR can be reviewed best without showing whitespace changes. (There is a button for  that in the github ui)