### PR TITLE
fix: add missing fakers for existing locales

### DIFF
--- a/src/locale/fr_BE.ts
+++ b/src/locale/fr_BE.ts
@@ -1,0 +1,14 @@
+import { Faker } from '..';
+import fr_BE from '../locales/fr_BE';
+import en from '../locales/en';
+
+const faker = new Faker({
+  locale: 'fr_BE',
+  localeFallback: 'en',
+  locales: {
+    fr_BE,
+    en,
+  },
+});
+
+export = faker;

--- a/src/locale/lv.ts
+++ b/src/locale/lv.ts
@@ -1,0 +1,14 @@
+import { Faker } from '..';
+import lv from '../locales/lv';
+import en from '../locales/en';
+
+const faker = new Faker({
+  locale: 'lv',
+  localeFallback: 'en',
+  locales: {
+    lv,
+    en,
+  },
+});
+
+export = faker;


### PR DESCRIPTION
This change was originally proposed as part of https://github.com/faker-js/faker/pull/252, but has been extracted to be merged as part of the next release.