### PR TITLE
chore(docs): Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Faker provides many useful utility functions.
   | abbreviation | Generates a random hacker abbreviation |
   | adjective    | Generates a random hacker adjective    |
   | noun         | Generates a random hacker noun         |
-  | verb         | Generates a random hacker noun         |
+  | verb         | Generates a random hacker verb         |
   | ingverb      | Generates a random hacker ingverb      |
   | phrase       | Generates a random hacker phrase       |
 


### PR DESCRIPTION
The "verb" method on the faker.hacker API is supposed to generate a random hacker verb, not  a random hacker noun.