### PR TITLE
fix: removed node v12 from the pipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [12, 14, 16, 17]
+        node_version: [14, 16, 17]
         include:
           - os: macos-latest
             node_version: 16

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
   },
   "packageManager": "pnpm@6.26.1",
   "engines": {
-    "node": ">=12.0.0",
+    "node": ">=14.0.0",
     "npm": ">=7.0.0"
   }
 }


### PR DESCRIPTION
Because vitest is not supporting this version.