### PR TITLE
docs: use html tables instead of md tables to account for ::: v-pre

### DIFF
--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -1,0 +1,4 @@
+
+table td * {
+  display: inline;
+}

--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -1,4 +1,3 @@
-
 table td * {
   display: inline;
 }

--- a/docs/.vitepress/theme/index.mjs
+++ b/docs/.vitepress/theme/index.mjs
@@ -1,4 +1,4 @@
-import './index.css'
+import './index.css';
 import GlobalComponents from './components';
 import DefaultTheme from 'vitepress/theme';
 

--- a/docs/.vitepress/theme/index.mjs
+++ b/docs/.vitepress/theme/index.mjs
@@ -1,3 +1,4 @@
+import './index.css'
 import GlobalComponents from './components';
 import DefaultTheme from 'vitepress/theme';
 


### PR DESCRIPTION
We have to disable processing for parameters as well to avoid issues with potential examples `{{name.first_name}}` in there.

You can test this by adding a js like this:

````ts
 * @param format This does some crazy stuff `{{name}}`
````

Example output:

````md
<table>
  <thead>
    <tr>
      <th>Name</th>
      <th>Type</th>
      <th>Default</th>
      <th>Description</th>
    </tr>
  </thead>
  <tbody>
<tr>
  <td>format?</td>
  <td>string</td>
  <td></td>
  <td>

::: v-pre

This does some crazy stuff `{{name}}`

:::

  </td>
</tr>
  </tbody>
</table>
````


@Shinigami92 

I decided to use `::: v-pre` (with space) as used in the [official documentation](https://vuepress.vuejs.org/guide/using-vue.html#escaping).
I will split any "omit ::: v-pre if unnecessary"  optimizations into later PRs.

