### PR TITLE
fix: fix typescript types for the `unique` method

### DIFF
--- a/src/unique.ts
+++ b/src/unique.ts
@@ -25,9 +25,9 @@ export class Unique {
    *
    * @method unique
    */
-  unique<Method extends (args: Args) => string, Args extends any[]>(
+  unique<Method extends (...args: Args) => string, Args extends any[]>(
     method: Method,
-    args: Args,
+    args?: Args,
     opts?: {
       startTime?: number;
       maxTime?: number;

--- a/src/vendor/unique.ts
+++ b/src/vendor/unique.ts
@@ -44,10 +44,13 @@ function errorMessage(
 
 // TODO @Shinigami92 2022-01-24: We should investigate deeper into the types
 // Especially the `opts.compare` parameter and `Result` type
-export function exec<Method extends (args: Args) => string, Args extends any[]>(
+export function exec<
+  Method extends (...args: Args) => string,
+  Args extends any[]
+>(
   method: Method,
-  args: Args,
-  opts: {
+  args?: Args,
+  opts?: {
     maxTime?: number;
     maxRetries?: number;
     exclude?: string | string[];

--- a/test/unique.spec.ts
+++ b/test/unique.spec.ts
@@ -1,22 +1,46 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { faker } from '../dist/cjs';
 
 describe('unique', () => {
   describe('unique()', () => {
+    beforeEach(() => {
+      faker.seed(222);
+    });
+
     it('is able to call a function with no arguments and return a result', () => {
-      const result =
-        // @ts-expect-error
-        faker.unique(faker.internet.email);
+      const result = faker.unique(faker.internet.email);
       expect(typeof result).toBe('string');
     });
 
     it('is able to call a function with arguments and return a result', () => {
+      const spy_internet_email = vi.spyOn(faker.internet, 'email');
+      expect(spy_internet_email).toHaveBeenCalledTimes(0);
       const result = faker.unique(faker.internet.email, ['a', 'b', 'c']); // third argument is provider, or domain for email
+      expect(spy_internet_email).toHaveBeenCalledTimes(1);
       expect(result).toMatch(/\@c/);
     });
 
     it('is able to call same function with arguments and return a result', () => {
+      const spy_internet_email = vi.spyOn(faker.internet, 'email');
+      expect(spy_internet_email).toHaveBeenCalledTimes(0);
       const result = faker.unique(faker.internet.email, ['a', 'b', 'c']); // third argument is provider, or domain for email
+      expect(spy_internet_email).toHaveBeenCalledTimes(2);
+      expect(result).toMatch(/\@c/);
+    });
+
+    it('is able to call same function with arguments and return a result', () => {
+      const spy_internet_email = vi.spyOn(faker.internet, 'email');
+      expect(spy_internet_email).toHaveBeenCalledTimes(0);
+      const result = faker.unique(faker.internet.email, ['a', 'b', 'c']); // third argument is provider, or domain for email
+      expect(spy_internet_email).toHaveBeenCalledTimes(3);
+      expect(result).toMatch(/\@c/);
+    });
+
+    it('is able to call same function with arguments and return a result', () => {
+      const spy_internet_email = vi.spyOn(faker.internet, 'email');
+      expect(spy_internet_email).toHaveBeenCalledTimes(0);
+      const result = faker.unique(faker.internet.email, ['a', 'b', 'c']); // third argument is provider, or domain for email
+      expect(spy_internet_email).toHaveBeenCalledTimes(4);
       expect(result).toMatch(/\@c/);
     });
 


### PR DESCRIPTION
The type definitions were missing the rest operator.