### PR TITLE
fix: fake is unable to return empty strings

### DIFF
--- a/src/fake.ts
+++ b/src/fake.ts
@@ -116,6 +116,10 @@ export class Fake {
     // replace the found tag with the returned fake value
     res = str.replace('{{' + token + '}}', result);
 
+    if (res === '') {
+      return '';
+    }
+
     // return the response recursively until we are done finding all tags
     return this.fake(res);
   }

--- a/test/fake.spec.ts
+++ b/test/fake.spec.ts
@@ -46,5 +46,9 @@ describe('fake', () => {
         Error('Invalid method: address.foo')
       );
     });
+
+    it('should be able to return empty strings', () => {
+      expect(faker.fake('{{helpers.repeatString}}')).toBe('');
+    });
   });
 });


### PR DESCRIPTION
Fake should behave exactly like the methods being called directly.
That is if the called method returns an empty string, then fake should do the same (and not fail like it does right now).