### PR TITLE
chore: removed unused param

### DIFF
--- a/scripts/apidoc.ts
+++ b/scripts/apidoc.ts
@@ -156,7 +156,7 @@ async function build(): Promise<void> {
 `;
 
         // typeParameters
-        typeParameters.forEach((parameter, index) => {
+        typeParameters.forEach((parameter) => {
           const parameterName = parameter.name;
 
           signatureTypeParameters.push(parameterName);


### PR DESCRIPTION
As per GitHub Checks linting, this is an unused parameter

<img width="888" alt="Screen Shot 2022-01-29 at 1 31 35 PM" src="https://user-images.githubusercontent.com/68196762/151673325-5130cda2-c01a-4dab-9748-472853d9df59.png">
