### PR TITLE
ci: use cypress install binary flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Install deps
         run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
 
       - name: Build
         run: pnpm run build
@@ -85,6 +87,8 @@ jobs:
 
       - name: Install deps
         run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
 
       - name: Lint
         run: pnpm run lint


### PR DESCRIPTION
https://docs.cypress.io/guides/getting-started/installing-cypress#Environment-variables

This skippes the install process of Cypress binaries

![image](https://user-images.githubusercontent.com/7195563/152030939-9cbee87f-c054-4aef-8fe3-0664533b7e09.png)

https://github.com/faker-js/faker/runs/5026306806?check_suite_focus=true#step:5:24

We only need Cypress for E2E docs tests