### PR TITLE
docs(fix): use named import

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -42,7 +42,7 @@ pnpm add @faker-js/faker --save-dev
 ### Node.js
 
 ```js
-import faker from '@faker-js/faker';
+import { faker } from '@faker-js/faker';
 
 const randomName = faker.name.findName(); // Rowan Nikolaus
 const randomEmail = faker.internet.email(); // Kassandra.Haley@erich.biz


### PR DESCRIPTION
If we import `faker` by default import as in the sample, we will get the following error.
```js
import faker from '@faker-js/faker';

const randomName = faker.name.findName(); // Rowan Nikolaus
// when using default import , we need to write like `faker.faker.name.findName()`
```

```shell
// result
const randomName = faker.name.findName();
                              ^
TypeError: Cannot read property 'findName' of undefined
```
This can be avoided by using named import.
