### PR TITLE
fix: optional args on faker.finance.iban()

### DIFF
--- a/src/finance.ts
+++ b/src/finance.ts
@@ -293,7 +293,7 @@ export class Finance {
    *
    * @method faker.finance.iban
    */
-  iban(formatted: boolean = false, countryCode: string): string {
+  iban(formatted: boolean = false, countryCode?: string): string {
     let ibanFormat: {
       bban: Array<{ type: string; count: number }>;
       country: string;


### PR DESCRIPTION
`faker.finance.iban()` is a valid use of Faker. However in TypeScript you get a type error because the optional `formatted` and `countryCode` args are not marked as optional like in other functions.

Tests are written against the cjs bundle without types so did not catch the error.