### PR TITLE
fix: fix unique method types

### DIFF
--- a/src/unique.ts
+++ b/src/unique.ts
@@ -1,4 +1,5 @@
 import * as uniqueExec from './vendor/unique';
+import type { RecordKey } from './vendor/unique';
 
 /**
  * Module to generate unique entries.
@@ -38,20 +39,20 @@ export class Unique {
    * @param opts.compare The function used to determine whether a value was already returned.
    *
    * @example
-   * faker.unique(faker.name.firstName())
+   * faker.unique(faker.name.firstName)
    */
-  unique<Method extends (args: Args) => string, Args extends any[]>(
+  unique<Method extends (...parameters) => RecordKey>(
     method: Method,
-    args: Args,
+    args?: Parameters<Method>,
     opts?: {
       startTime?: number;
       maxTime?: number;
       maxRetries?: number;
       currentIterations?: number;
-      exclude?: string | string[];
-      compare?: (obj: Record<string, string>, key: string) => 0 | -1;
+      exclude?: RecordKey | RecordKey[];
+      compare?: (obj: Record<RecordKey, RecordKey>, key: RecordKey) => 0 | -1;
     }
-  ): string {
+  ): ReturnType<Method> {
     opts = opts || {};
     opts.startTime = new Date().getTime();
     if (typeof opts.maxTime !== 'number') {

--- a/src/vendor/unique.ts
+++ b/src/vendor/unique.ts
@@ -4,7 +4,7 @@ export type RecordKey = string | number | symbol;
 // currently uniqueness is global to entire faker instance
 // this means that faker should currently *never* return duplicate values across all API methods when using `Faker.unique`
 // it's possible in the future that some users may want to scope found per function call instead of faker instance
-const found: Record<RecordKey, RecordKey> = {}; // global exclude list of results
+const found: Record<RecordKey, RecordKey> = {};
 
 // global exclude list of results
 // defaults to nothing excluded

--- a/test/unique.spec.ts
+++ b/test/unique.spec.ts
@@ -5,19 +5,25 @@ const seededRuns = [
   {
     seed: 42,
     expectations: {
-      withMethod: 'Test-188',
+      withCustomMethod: 'Test-188',
+      withNumberMethod: 37454,
+      withNumberMethodAndArgs: 19,
     },
   },
   {
     seed: 1337,
     expectations: {
-      withMethod: 'Test-132',
+      withCustomMethod: 'Test-132',
+      withNumberMethod: 26202,
+      withNumberMethodAndArgs: 13,
     },
   },
   {
     seed: 1211,
     expectations: {
-      withMethod: 'Test-465',
+      withCustomMethod: 'Test-465',
+      withNumberMethod: 92852,
+      withNumberMethodAndArgs: 47,
     },
   },
 ];
@@ -29,7 +35,7 @@ const MOCK_ARRAY = Array.from(
   (_, index) => `Test-${index + 1}`
 );
 
-function method(prefix: string = ''): string {
+function customMethod(prefix: string = ''): string {
   const element = faker.random.arrayElement(MOCK_ARRAY);
   return `${prefix}${element}`;
 }
@@ -41,20 +47,34 @@ describe('unique', () => {
 
   for (const { seed, expectations } of seededRuns) {
     describe(`seed: ${seed}`, () => {
-      it(`unique(method)`, () => {
+      it(`unique(customMethod)`, () => {
         faker.seed(seed);
 
-        const actual = faker.unique(method);
-        expect(actual).toEqual(expectations.withMethod);
+        const actual = faker.unique(customMethod);
+        expect(actual).toEqual(expectations.withCustomMethod);
       });
 
-      it(`unique(method, args)`, () => {
+      it(`unique(customMethod, args)`, () => {
         faker.seed(seed);
 
         const prefix = 'prefix-1-';
 
-        const actual = faker.unique(method, [prefix]);
-        expect(actual).toEqual(prefix + expectations.withMethod);
+        const actual = faker.unique(customMethod, [prefix]);
+        expect(actual).toEqual(prefix + expectations.withCustomMethod);
+      });
+
+      it(`unique(() => number)`, () => {
+        faker.seed(seed);
+
+        const actual = faker.unique(faker.datatype.number);
+        expect(actual).toEqual(expectations.withNumberMethod);
+      });
+
+      it(`unique(() => number), args)`, () => {
+        faker.seed(seed);
+
+        const actual = faker.unique(faker.datatype.number, [50]);
+        expect(actual).toEqual(expectations.withNumberMethodAndArgs);
       });
     });
   }


### PR DESCRIPTION
Fixes #456 

**Note:** There is a slight imprecision I couldn't remove.
It is possible to omit the parameters, although the referenced method requires them.
If I fix that, it is no longer possible to omit the empty parameter array.