### PR TITLE
test: use toBeTypeOf

### DIFF
--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -398,7 +398,7 @@ describe('address', () => {
           for (let i = 0; i < 100; i++) {
             const latitude = faker.address.latitude();
 
-            expect(typeof latitude).toBe('string');
+            expect(latitude).toBeTypeOf('string');
 
             const latitude_float = parseFloat(latitude);
 
@@ -411,7 +411,7 @@ describe('address', () => {
           for (let i = 0; i < 100; i++) {
             const latitude = faker.address.latitude(-5, 5);
 
-            expect(typeof latitude).toBe('string');
+            expect(latitude).toBeTypeOf('string');
             expect(
               latitude.split('.')[1].length,
               'The precision of latitude should be 4 digits'
@@ -428,7 +428,7 @@ describe('address', () => {
           for (let i = 0; i < 100; i++) {
             const latitude = faker.address.latitude(undefined, undefined, 7);
 
-            expect(typeof latitude).toBe('string');
+            expect(latitude).toBeTypeOf('string');
             expect(
               latitude.split('.')[1].length,
               'The precision of latitude should be 7 digits'
@@ -447,7 +447,7 @@ describe('address', () => {
           for (let i = 0; i < 100; i++) {
             const longitude = faker.address.longitude();
 
-            expect(typeof longitude).toBe('string');
+            expect(longitude).toBeTypeOf('string');
 
             const longitude_float = parseFloat(longitude);
 
@@ -460,7 +460,7 @@ describe('address', () => {
           for (let i = 0; i < 100; i++) {
             const longitude = faker.address.longitude(100, -30);
 
-            expect(typeof longitude).toBe('string');
+            expect(longitude).toBeTypeOf('string');
             expect(
               longitude.split('.')[1].length,
               'The precision of longitude should be 4 digits'
@@ -477,7 +477,7 @@ describe('address', () => {
           for (let i = 0; i < 100; i++) {
             const longitude = faker.address.longitude(undefined, undefined, 7);
 
-            expect(typeof longitude).toBe('string');
+            expect(longitude).toBeTypeOf('string');
             expect(
               longitude.split('.')[1].length,
               'The precision of longitude should be 7 digits'
@@ -499,9 +499,9 @@ describe('address', () => {
             'The abbreviation of direction when useAbbr is true should';
 
           expect(
-            typeof direction,
+            direction,
             `${prefixErrorMessage} be of type string. Current is ${typeof direction}`
-          ).toBe('string');
+          ).toBeTypeOf('string');
           expect(lengthDirection).lessThanOrEqual(2);
         });
       });
@@ -515,9 +515,9 @@ describe('address', () => {
             'The ordinal direction when useAbbr is true should';
 
           expect(
-            typeof ordinalDirection,
+            ordinalDirection,
             `${prefixErrorMessage} be equal ${expectedType}. Current is ${typeof ordinalDirection}`
-          ).toBe(expectedType);
+          ).toBeTypeOf(expectedType);
           expect(ordinalDirectionLength).lessThanOrEqual(2);
         });
       });
@@ -531,9 +531,9 @@ describe('address', () => {
             'The cardinal direction when useAbbr is true should';
 
           expect(
-            typeof cardinalDirection,
+            cardinalDirection,
             `${prefixErrorMessage} be of type ${expectedType}. Current is ${typeof cardinalDirection}`
-          ).toBe(expectedType);
+          ).toBeTypeOf(expectedType);
           expect(cardinalDirectionLength).lessThanOrEqual(2);
         });
       });
@@ -578,8 +578,8 @@ describe('address', () => {
             );
 
             expect(coordinate.length).toBe(2);
-            expect(typeof coordinate[0]).toBe('string');
-            expect(typeof coordinate[1]).toBe('string');
+            expect(coordinate[0]).toBeTypeOf('string');
+            expect(coordinate[1]).toBeTypeOf('string');
 
             const latFloat2 = parseFloat(coordinate[0]);
             expect(latFloat2).greaterThanOrEqual(-90.0);
@@ -616,8 +616,8 @@ describe('address', () => {
           );
 
           expect(coordinate.length).toBe(2);
-          expect(typeof coordinate[0]).toBe('string');
-          expect(typeof coordinate[1]).toBe('string');
+          expect(coordinate[0]).toBeTypeOf('string');
+          expect(coordinate[1]).toBeTypeOf('string');
 
           const distanceToTarget =
             Math.pow(coordinate[0] - latitude, 2) +
@@ -640,8 +640,8 @@ describe('address', () => {
           );
 
           expect(coordinate.length).toBe(2);
-          expect(typeof coordinate[0]).toBe('string');
-          expect(typeof coordinate[1]).toBe('string');
+          expect(coordinate[0]).toBeTypeOf('string');
+          expect(coordinate[1]).toBeTypeOf('string');
 
           // const distanceToTarget =
           //   Math.pow(coordinate[0] - latitude, 2) +

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -67,7 +67,7 @@ describe('functional tests', () => {
             it(meth + '()', () => {
               const result = faker[module][meth]();
               if (meth === 'boolean') {
-                expect(typeof result).toBe('boolean');
+                expect(result).toBeTypeOf('boolean');
               } else {
                 expect(result).toBeTruthy();
               }
@@ -98,7 +98,7 @@ describe('faker.fake functional tests', () => {
               // an undefined result usually means an error
               expect(result).toBeDefined();
               // if (meth === 'boolean') {
-              //   expect(typeof result).toBe('boolean');
+              //   expect(result).toBeTypeOf('boolean');
               // } else {
               //   expect(result).toBeTruthy();
               // }

--- a/test/company.spec.ts
+++ b/test/company.spec.ts
@@ -105,14 +105,14 @@ describe('company', () => {
           const actual = faker.company.companyName();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
         });
 
         it('should return a random company name with format 0', () => {
           const actual = faker.company.companyName(0);
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual).includes(' ');
         });
 
@@ -120,7 +120,7 @@ describe('company', () => {
           const actual = faker.company.companyName(1);
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual).includes(' - ');
         });
 
@@ -128,7 +128,7 @@ describe('company', () => {
           const actual = faker.company.companyName(2);
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual).includes(', ');
           expect(actual).includes(' and ');
         });
@@ -139,7 +139,7 @@ describe('company', () => {
           const actual = faker.company.companySuffix();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.company.suffix).toContain(actual);
         });
       });
@@ -149,7 +149,7 @@ describe('company', () => {
           const actual = faker.company.catchPhrase();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
 
           const parts = actual.split(' ');
 
@@ -162,7 +162,7 @@ describe('company', () => {
           const actual = faker.company.bs();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
 
           const parts = actual.split(' ');
 
@@ -175,7 +175,7 @@ describe('company', () => {
           const actual = faker.company.catchPhraseAdjective();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.company.adjective).toContain(actual);
         });
       });
@@ -185,7 +185,7 @@ describe('company', () => {
           const actual = faker.company.catchPhraseDescriptor();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.company.descriptor).toContain(actual);
         });
       });
@@ -195,7 +195,7 @@ describe('company', () => {
           const actual = faker.company.catchPhraseNoun();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.company.noun).toContain(actual);
         });
       });
@@ -205,7 +205,7 @@ describe('company', () => {
           const actual = faker.company.bsAdjective();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.company.bs_adjective).toContain(actual);
         });
       });
@@ -215,7 +215,7 @@ describe('company', () => {
           const actual = faker.company.bsBuzz();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.company.bs_verb).toContain(actual);
         });
       });
@@ -225,7 +225,7 @@ describe('company', () => {
           const actual = faker.company.bsNoun();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.company.bs_noun).toContain(actual);
         });
       });

--- a/test/database.spec.ts
+++ b/test/database.spec.ts
@@ -62,7 +62,7 @@ describe('database', () => {
         it('should return a column name from array', () => {
           const column = faker.database.column();
           expect(column).toBeTruthy();
-          expect(typeof column).toBe('string');
+          expect(column).toBeTypeOf('string');
           expect(faker.definitions.database.column).toContain(column);
         });
       });
@@ -71,7 +71,7 @@ describe('database', () => {
         it('should return a collation from array', () => {
           const collation = faker.database.collation();
           expect(collation).toBeTruthy();
-          expect(typeof collation).toBe('string');
+          expect(collation).toBeTypeOf('string');
           expect(faker.definitions.database.collation).toContain(collation);
         });
       });
@@ -80,7 +80,7 @@ describe('database', () => {
         it('should return an engine from array', () => {
           const engine = faker.database.engine();
           expect(engine).toBeTruthy();
-          expect(typeof engine).toBe('string');
+          expect(engine).toBeTypeOf('string');
           expect(faker.definitions.database.engine).toContain(engine);
         });
       });
@@ -89,7 +89,7 @@ describe('database', () => {
         it('should return a column type from array', () => {
           const type = faker.database.type();
           expect(type).toBeTruthy();
-          expect(typeof type).toBe('string');
+          expect(type).toBeTypeOf('string');
           expect(faker.definitions.database.type).toContain(type);
         });
       });

--- a/test/datatype.spec.ts
+++ b/test/datatype.spec.ts
@@ -236,7 +236,7 @@ describe('datatype', () => {
             faker.seed(seed);
 
             const actual = faker.datatype.datetime();
-            expect(typeof actual).toBe('object');
+            expect(actual).toBeTypeOf('object');
           });
           continue;
         }
@@ -533,7 +533,7 @@ describe('datatype', () => {
       describe('datetime', () => {
         it('check validity of date and if returned value is created by Date()', () => {
           const date = faker.datatype.datetime();
-          expect(typeof date).toBe('object');
+          expect(date).toBeTypeOf('object');
           expect(date.getTime()).not.toBeNaN();
           expect(Object.prototype.toString.call(date)).toBe('[object Date]');
         });
@@ -542,7 +542,7 @@ describe('datatype', () => {
       describe('string', () => {
         it('should generate a string value', () => {
           const generatedString = faker.datatype.string();
-          expect(typeof generatedString).toBe('string');
+          expect(generatedString).toBeTypeOf('string');
           expect(generatedString).toHaveLength(10);
         });
 
@@ -563,7 +563,7 @@ describe('datatype', () => {
       describe('boolean', () => {
         it('generates a boolean value', () => {
           const bool = faker.datatype.boolean();
-          expect(typeof bool).toBe('boolean');
+          expect(bool).toBeTypeOf('boolean');
         });
       });
 
@@ -593,7 +593,7 @@ describe('datatype', () => {
       describe('json', () => {
         it('generates a valid json object', () => {
           const jsonObject = faker.datatype.json();
-          expect(typeof jsonObject).toBe('string');
+          expect(jsonObject).toBeTypeOf('string');
           expect(JSON.parse(jsonObject)).toBeTruthy();
         });
       });
@@ -614,7 +614,7 @@ describe('datatype', () => {
       describe('bigInt', () => {
         it('should generate a bigInt value', () => {
           const generateBigInt = faker.datatype.bigInt();
-          expect(typeof generateBigInt).toBe('bigint');
+          expect(generateBigInt).toBeTypeOf('bigint');
         });
       });
     }

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -157,13 +157,13 @@ describe('finance', () => {
         const accountName = faker.finance.accountName();
 
         expect(accountName).toBeTruthy();
-        expect(typeof accountName).toBe('string');
+        expect(accountName).toBeTypeOf('string');
       });
 
       describe('routingNumber()', () => {
         const routingNumber = faker.finance.routingNumber();
 
-        expect(typeof routingNumber).toBe('string');
+        expect(routingNumber).toBeTypeOf('string');
       });
 
       describe('mask()', () => {
@@ -254,7 +254,7 @@ describe('finance', () => {
           const amount = faker.finance.amount(100, 100, 0);
 
           expect(amount).toBeTruthy();
-          expect(typeof amount, 'the amount type should be string').toBe(
+          expect(amount, 'the amount type should be string').toBeTypeOf(
             'string'
           );
         });
@@ -297,26 +297,26 @@ describe('finance', () => {
       describe('transactionType()', () => {
         const transactionType = faker.finance.transactionType();
 
-        expect(typeof transactionType).toBe('string');
+        expect(transactionType).toBeTypeOf('string');
       });
 
       describe('currencyCode()', () => {
         const currencyCode = faker.finance.currencyCode();
 
-        expect(typeof currencyCode).toBe('string');
+        expect(currencyCode).toBeTypeOf('string');
         expect(currencyCode).match(/^[A-Z]{3}$/);
       });
 
       describe('currencyName()', () => {
         const currencyName = faker.finance.currencyName();
 
-        expect(typeof currencyName).toBe('string');
+        expect(currencyName).toBeTypeOf('string');
       });
 
       describe('currencySymbol()', () => {
         const currencySymbol = faker.finance.currencySymbol();
 
-        expect(typeof currencySymbol).toBe('string');
+        expect(currencySymbol).toBeTypeOf('string');
       });
 
       describe('bitcoinAddress()', () => {
@@ -327,14 +327,14 @@ describe('finance', () => {
          */
 
         expect(bitcoinAddress).toBeTruthy();
-        expect(typeof bitcoinAddress).toBe('string');
+        expect(bitcoinAddress).toBeTypeOf('string');
         expect(bitcoinAddress).match(/^[13][a-km-zA-HJ-NP-Z1-9]{24,33}$/);
       });
 
       describe('litecoinAddress()', () => {
         const litecoinAddress = faker.finance.litecoinAddress();
 
-        expect(typeof litecoinAddress).toBe('string');
+        expect(litecoinAddress).toBeTypeOf('string');
         expect(litecoinAddress).match(/^[LM3][1-9a-km-zA-HJ-NP-Z]{25,32}$/);
       });
 
@@ -413,7 +413,7 @@ describe('finance', () => {
       describe('creditCardCVV()', () => {
         const cvv = faker.finance.creditCardCVV();
 
-        expect(typeof cvv).toBe('string');
+        expect(cvv).toBeTypeOf('string');
         expect(cvv).match(/\d{3}/);
         expect(
           cvv,
@@ -424,7 +424,7 @@ describe('finance', () => {
       describe('ethereumAddress()', () => {
         const ethereumAddress = faker.finance.ethereumAddress();
 
-        expect(typeof ethereumAddress).toBe('string');
+        expect(ethereumAddress).toBeTypeOf('string');
         expect(ethereumAddress).match(/^(0x)[0-9a-f]{40}$/);
       });
 
@@ -468,7 +468,7 @@ describe('finance', () => {
             'i'
           );
 
-          expect(typeof bic).toBe('string');
+          expect(bic).toBeTypeOf('string');
           expect(bic).match(expr);
         });
       });
@@ -476,7 +476,7 @@ describe('finance', () => {
       describe('transactionDescription()', () => {
         const transactionDescription = faker.finance.transactionDescription();
 
-        expect(typeof transactionDescription).toBe('string');
+        expect(transactionDescription).toBeTypeOf('string');
       });
     }
   });

--- a/test/git.spec.ts
+++ b/test/git.spec.ts
@@ -108,7 +108,7 @@ describe('git', () => {
           const branch = faker.git.branch();
 
           expect(branch).toBeTruthy();
-          expect(typeof branch).toBe('string');
+          expect(branch).toBeTypeOf('string');
           expect(branch).satisfy(validator.isSlug);
         });
       });
@@ -118,7 +118,7 @@ describe('git', () => {
           const commitEntry = faker.git.commitEntry();
 
           expect(commitEntry).toBeTruthy();
-          expect(typeof commitEntry).toBe('string');
+          expect(commitEntry).toBeTypeOf('string');
 
           const parts = commitEntry.split(/\r?\n/);
 
@@ -146,7 +146,7 @@ describe('git', () => {
           const commitMessage = faker.git.commitMessage();
 
           expect(commitMessage).toBeTruthy();
-          expect(typeof commitMessage).toBe('string');
+          expect(commitMessage).toBeTypeOf('string');
 
           const parts = commitMessage.split(' ');
           expect(parts.length).greaterThanOrEqual(3);
@@ -158,7 +158,7 @@ describe('git', () => {
           const commitSha = faker.git.commitSha();
 
           expect(commitSha).toBeTruthy();
-          expect(typeof commitSha).toBe('string');
+          expect(commitSha).toBeTypeOf('string');
           expect(commitSha).satisfy(validator.isHexadecimal);
           expect(commitSha).toHaveLength(40);
         });
@@ -169,7 +169,7 @@ describe('git', () => {
           const shortSha = faker.git.shortSha();
 
           expect(shortSha).toBeTruthy();
-          expect(typeof shortSha).toBe('string');
+          expect(shortSha).toBeTypeOf('string');
           expect(shortSha).satisfy(validator.isHexadecimal);
           expect(shortSha).toHaveLength(7);
         });

--- a/test/hacker.spec.ts
+++ b/test/hacker.spec.ts
@@ -118,7 +118,7 @@ describe('name', () => {
         it('should return a random abbreviation from array', () => {
           const abbreviation = faker.hacker.abbreviation();
 
-          expect(typeof abbreviation).toBe('string');
+          expect(abbreviation).toBeTypeOf('string');
           expect(abbreviation.length).greaterThan(0);
           expect(faker.definitions.hacker.abbreviation).toContain(abbreviation);
         });
@@ -132,7 +132,7 @@ describe('name', () => {
         it('should return a random adjective from array', () => {
           const adjective = faker.hacker.adjective();
 
-          expect(typeof adjective).toBe('string');
+          expect(adjective).toBeTypeOf('string');
           expect(adjective.length).greaterThan(0);
           expect(faker.definitions.hacker.adjective).toContain(adjective);
         });
@@ -146,7 +146,7 @@ describe('name', () => {
         it('should return a random noun from array', () => {
           const noun = faker.hacker.noun();
 
-          expect(typeof noun).toBe('string');
+          expect(noun).toBeTypeOf('string');
           expect(noun.length).greaterThan(0);
           expect(faker.definitions.hacker.noun).toContain(noun);
         });
@@ -160,7 +160,7 @@ describe('name', () => {
         it('should return a random verb from array', () => {
           const verb = faker.hacker.verb();
 
-          expect(typeof verb).toBe('string');
+          expect(verb).toBeTypeOf('string');
           expect(verb.length).greaterThan(0);
           expect(faker.definitions.hacker.verb).toContain(verb);
         });
@@ -174,7 +174,7 @@ describe('name', () => {
         it('should return a random ingverb from array', () => {
           const ingverb = faker.hacker.ingverb();
 
-          expect(typeof ingverb).toBe('string');
+          expect(ingverb).toBeTypeOf('string');
           expect(ingverb.length).greaterThan(0);
           expect(faker.definitions.hacker.ingverb).toContain(ingverb);
         });
@@ -188,7 +188,7 @@ describe('name', () => {
         it('should return a random phrase from array', () => {
           const phrase = faker.hacker.phrase();
 
-          expect(typeof phrase).toBe('string');
+          expect(phrase).toBeTypeOf('string');
           expect(phrase.length).greaterThan(0);
         });
       });

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -733,20 +733,20 @@ describe('helpers', () => {
       describe('createCard()', () => {
         it('returns an object', () => {
           const card = faker.helpers.createCard();
-          expect(typeof card).toBe('object');
+          expect(card).toBeTypeOf('object');
         });
       });
 
       describe('contextualCard()', () => {
         it('returns an object', () => {
           const card = faker.helpers.contextualCard();
-          expect(typeof card).toBe('object');
+          expect(card).toBeTypeOf('object');
         });
       });
       describe('userCard()', () => {
         it('returns an object', () => {
           const card = faker.helpers.userCard();
-          expect(typeof card).toBe('object');
+          expect(card).toBeTypeOf('object');
         });
       });
 

--- a/test/internet.spec.ts
+++ b/test/internet.spec.ts
@@ -129,7 +129,7 @@ describe('internet', () => {
           const avatar = faker.internet.avatar();
 
           expect(avatar).toBeTruthy();
-          expect(typeof avatar).toBe('string');
+          expect(avatar).toBeTypeOf('string');
           expect(avatar).satisfy(validator.isURL);
           expect(avatar).match(
             /^https:\/\/cloudflare-ipfs.com\/ipfs\/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye\/avatar\/\d+.jpg$/
@@ -142,7 +142,7 @@ describe('internet', () => {
           const email = faker.internet.email();
 
           expect(email).toBeTruthy();
-          expect(typeof email).toBe('string');
+          expect(email).toBeTypeOf('string');
           expect(email).satisfy(validator.isEmail);
 
           const [, suffix] = email.split('@');
@@ -155,7 +155,7 @@ describe('internet', () => {
           const email = faker.internet.email('Aiden.Harann55');
 
           expect(email).toBeTruthy();
-          expect(typeof email).toBe('string');
+          expect(email).toBeTypeOf('string');
           expect(email).satisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
@@ -168,7 +168,7 @@ describe('internet', () => {
           const email = faker.internet.email('Aiden', 'Harann');
 
           expect(email).toBeTruthy();
-          expect(typeof email).toBe('string');
+          expect(email).toBeTypeOf('string');
           expect(email).satisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
@@ -181,7 +181,7 @@ describe('internet', () => {
           const email = faker.internet.email('思源_唐3');
 
           expect(email).toBeTruthy();
-          expect(typeof email).toBe('string');
+          expect(email).toBeTypeOf('string');
           expect(email).satisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
@@ -196,7 +196,7 @@ describe('internet', () => {
           const email = faker.internet.exampleEmail();
 
           expect(email).toBeTruthy();
-          expect(typeof email).toBe('string');
+          expect(email).toBeTypeOf('string');
           expect(email).satisfy(validator.isEmail);
 
           const suffix = email.split('@')[1];
@@ -209,7 +209,7 @@ describe('internet', () => {
           const email = faker.internet.exampleEmail('Aiden.Harann55');
 
           expect(email).toBeTruthy();
-          expect(typeof email).toBe('string');
+          expect(email).toBeTypeOf('string');
           expect(email).satisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
@@ -223,7 +223,7 @@ describe('internet', () => {
           const email = faker.internet.exampleEmail('Aiden', 'Harann');
 
           expect(email).toBeTruthy();
-          expect(typeof email).toBe('string');
+          expect(email).toBeTypeOf('string');
           expect(email).satisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
@@ -237,7 +237,7 @@ describe('internet', () => {
           const email = faker.internet.exampleEmail('思源_唐3');
 
           expect(email).toBeTruthy();
-          expect(typeof email).toBe('string');
+          expect(email).toBeTypeOf('string');
           expect(email).satisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
@@ -253,7 +253,7 @@ describe('internet', () => {
           const username = faker.internet.userName();
 
           expect(username).toBeTruthy();
-          expect(typeof username).toBe('string');
+          expect(username).toBeTypeOf('string');
           expect(username).match(/\w/);
         });
 
@@ -261,7 +261,7 @@ describe('internet', () => {
           const username = faker.internet.userName('Aiden');
 
           expect(username).toBeTruthy();
-          expect(typeof username).toBe('string');
+          expect(username).toBeTypeOf('string');
           expect(username).match(/\w/);
           expect(username).includes('Aiden');
         });
@@ -270,7 +270,7 @@ describe('internet', () => {
           const username = faker.internet.userName('Aiden', 'Harann');
 
           expect(username).toBeTruthy();
-          expect(typeof username).toBe('string');
+          expect(username).toBeTypeOf('string');
           expect(username).match(/\w/);
           expect(username).includes('Aiden');
           // FIXME christopher 2022-02-11: The lastName is sometimes not taken
@@ -281,7 +281,7 @@ describe('internet', () => {
         it('should return a valid protocol', () => {
           const protocol = faker.internet.protocol();
           expect(protocol).toBeTruthy();
-          expect(typeof protocol).toBe('string');
+          expect(protocol).toBeTypeOf('string');
           expect(protocol).toMatch(/^https?$/);
         });
       });
@@ -301,7 +301,7 @@ describe('internet', () => {
           const httpMethod = faker.internet.httpMethod();
 
           expect(httpMethod).toBeTruthy();
-          expect(typeof httpMethod).toBe('string');
+          expect(httpMethod).toBeTypeOf('string');
           expect(httpMethods).toContain(httpMethod);
         });
       });
@@ -311,7 +311,7 @@ describe('internet', () => {
           const url = faker.internet.url();
 
           expect(url).toBeTruthy();
-          expect(typeof url).toBe('string');
+          expect(url).toBeTypeOf('string');
           expect(url).satisfy(validator.isURL);
         });
       });
@@ -321,7 +321,7 @@ describe('internet', () => {
           const domainName = faker.internet.domainName();
 
           expect(domainName).toBeTruthy();
-          expect(typeof domainName).toBe('string');
+          expect(domainName).toBeTypeOf('string');
           expect(domainName).satisfy(validator.isFQDN);
 
           const [prefix, suffix] = domainName.split('.');
@@ -336,7 +336,7 @@ describe('internet', () => {
           const domainSuffix = faker.internet.domainSuffix();
 
           expect(domainSuffix).toBeTruthy();
-          expect(typeof domainSuffix).toBe('string');
+          expect(domainSuffix).toBeTypeOf('string');
           expect(faker.definitions.internet.domain_suffix).toContain(
             domainSuffix
           );
@@ -348,7 +348,7 @@ describe('internet', () => {
           const domainWord = faker.internet.domainWord();
 
           expect(domainWord).toBeTruthy();
-          expect(typeof domainWord).toBe('string');
+          expect(domainWord).toBeTypeOf('string');
           expect(domainWord).satisfy(validator.isSlug);
           expect(domainWord).satisfy((value: string) =>
             validator.isFQDN(value, { require_tld: false })
@@ -361,7 +361,7 @@ describe('internet', () => {
           const ip = faker.internet.ip();
 
           expect(ip).toBeTruthy();
-          expect(typeof ip).toBe('string');
+          expect(ip).toBeTypeOf('string');
           expect(ip).satisfy((value: string) => validator.isIP(value, 4));
 
           const parts = ip.split('.');
@@ -381,7 +381,7 @@ describe('internet', () => {
           const ipv6 = faker.internet.ipv6();
 
           expect(ipv6).toBeTruthy();
-          expect(typeof ipv6).toBe('string');
+          expect(ipv6).toBeTypeOf('string');
           expect(ipv6).satisfy((value: string) => validator.isIP(value, 6));
 
           const parts = ipv6.split(':');
@@ -394,7 +394,7 @@ describe('internet', () => {
         it('should return a random port number', () => {
           const port = faker.internet.port();
 
-          expect(typeof port).toBe('number');
+          expect(port).toBeTypeOf('number');
           expect(port).greaterThanOrEqual(0);
           expect(port).lessThanOrEqual(65535);
           expect(String(port)).satisfy(validator.isPort);
@@ -406,7 +406,7 @@ describe('internet', () => {
           const ua = faker.internet.userAgent();
 
           expect(ua).toBeTruthy();
-          expect(typeof ua).toBe('string');
+          expect(ua).toBeTypeOf('string');
           // TODO @Shinigami92 2022-02-11: Make tests more strict
         });
       });
@@ -416,7 +416,7 @@ describe('internet', () => {
           const color = faker.internet.color();
 
           expect(color).toBeTruthy();
-          expect(typeof color).toBe('string');
+          expect(color).toBeTypeOf('string');
           expect(color).satisfy(validator.isHexColor);
         });
 
@@ -425,7 +425,7 @@ describe('internet', () => {
           const color = faker.internet.color(100, 100, 100);
 
           expect(color).toBeTruthy();
-          expect(typeof color).toBe('string');
+          expect(color).toBeTypeOf('string');
           expect(color).satisfy(validator.isHexColor);
         });
       });
@@ -435,7 +435,7 @@ describe('internet', () => {
           const mac = faker.internet.mac();
 
           expect(mac).toBeTruthy();
-          expect(typeof mac).toBe('string');
+          expect(mac).toBeTypeOf('string');
           expect(mac).toHaveLength(17);
           expect(mac).match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/);
           expect(mac).satisfy(validator.isMACAddress);
@@ -445,7 +445,7 @@ describe('internet', () => {
           const mac = faker.internet.mac('-');
 
           expect(mac).toBeTruthy();
-          expect(typeof mac).toBe('string');
+          expect(mac).toBeTypeOf('string');
           expect(mac).toHaveLength(17);
           expect(mac).match(/^([a-f0-9]{2}-){5}[a-f0-9]{2}$/);
           expect(mac).satisfy(validator.isMACAddress);
@@ -455,7 +455,7 @@ describe('internet', () => {
           const mac = faker.internet.mac('');
 
           expect(mac).toBeTruthy();
-          expect(typeof mac).toBe('string');
+          expect(mac).toBeTypeOf('string');
           expect(mac).satisfy(validator.isHexadecimal);
           expect(mac).toHaveLength(12);
           // It's not a valid MAC address
@@ -467,7 +467,7 @@ describe('internet', () => {
             const mac = faker.internet.mac(separator);
 
             expect(mac).toBeTruthy();
-            expect(typeof mac).toBe('string');
+            expect(mac).toBeTypeOf('string');
             expect(mac).toHaveLength(17);
             expect(mac).match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/);
             expect(mac).satisfy(validator.isMACAddress);
@@ -480,7 +480,7 @@ describe('internet', () => {
           const password = faker.internet.password();
 
           expect(password).toBeTruthy();
-          expect(typeof password).toBe('string');
+          expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(15);
           expect(password).match(/^\w{15}$/);
         });
@@ -491,7 +491,7 @@ describe('internet', () => {
             const password = faker.internet.password(length);
 
             expect(password).toBeTruthy();
-            expect(typeof password).toBe('string');
+            expect(password).toBeTypeOf('string');
             expect(password).toHaveLength(length);
             expect(password).match(/^\w+$/);
           }
@@ -501,7 +501,7 @@ describe('internet', () => {
           const password = faker.internet.password(12, true);
 
           expect(password).toBeTruthy();
-          expect(typeof password).toBe('string');
+          expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(12);
           expect(password).match(/^\w{12}$/);
         });
@@ -510,7 +510,7 @@ describe('internet', () => {
           const password = faker.internet.password(12, false);
 
           expect(password).toBeTruthy();
-          expect(typeof password).toBe('string');
+          expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(12);
           expect(password).match(/^\w{12}$/);
           // TODO @Shinigami92 2022-02-11: I would say a non memorable password should satisfy `validator.isStrongPassword`, but it does not currently
@@ -525,7 +525,7 @@ describe('internet', () => {
           );
 
           expect(password).toBeTruthy();
-          expect(typeof password).toBe('string');
+          expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(32);
           // TODO @Shinigami92 2022-02-11: This should definitely be a strong password, but it doesn't :(
           //expect(password).satisfy(validator.isStrongPassword);
@@ -540,7 +540,7 @@ describe('internet', () => {
           );
 
           expect(password).toBeTruthy();
-          expect(typeof password).toBe('string');
+          expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(32);
           expect(password).match(/^a!G6/);
           expect(password).satisfy(validator.isStrongPassword);

--- a/test/lorem.spec.ts
+++ b/test/lorem.spec.ts
@@ -111,7 +111,7 @@ describe('lorem', () => {
           const actual = faker.lorem[functionName]();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual).toEqual(expectations[functionName]);
         });
       }
@@ -128,7 +128,7 @@ describe('lorem', () => {
           const actual = faker.lorem.word();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.lorem.words).toContain(actual);
         });
 
@@ -139,7 +139,7 @@ describe('lorem', () => {
             const actual = faker.lorem.word(length);
 
             expect(actual).toBeTruthy();
-            expect(typeof actual).toBe('string');
+            expect(actual).toBeTypeOf('string');
             expect(faker.definitions.lorem.words).toContain(actual);
             expect(actual).toHaveLength(length);
           }
@@ -151,7 +151,7 @@ describe('lorem', () => {
           const actual = faker.lorem.words();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
 
           const words = actual.split(' ');
 
@@ -168,7 +168,7 @@ describe('lorem', () => {
             const actual = faker.lorem.words(num);
 
             expect(actual).toBeTruthy();
-            expect(typeof actual).toBe('string');
+            expect(actual).toBeTypeOf('string');
 
             const words = actual.split(' ');
 
@@ -186,7 +186,7 @@ describe('lorem', () => {
           const actual = faker.lorem.sentence();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual[actual.length - 1]).toBe('.');
         });
 
@@ -196,7 +196,7 @@ describe('lorem', () => {
             const actual = faker.lorem.sentence(wordCount);
 
             expect(actual).toBeTruthy();
-            expect(typeof actual).toBe('string');
+            expect(actual).toBeTypeOf('string');
             expect(actual[actual.length - 1]).toBe('.');
 
             const words = actual.split(' ');
@@ -211,7 +211,7 @@ describe('lorem', () => {
           const actual = faker.lorem.slug();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual).satisfy(validator.isSlug);
         });
 
@@ -221,7 +221,7 @@ describe('lorem', () => {
             const actual = faker.lorem.slug(wordCount);
 
             expect(actual).toBeTruthy();
-            expect(typeof actual).toBe('string');
+            expect(actual).toBeTypeOf('string');
 
             const words = actual.split('-');
 
@@ -239,7 +239,7 @@ describe('lorem', () => {
           const actual = faker.lorem.sentences();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual[actual.length - 1]).toBe('.');
         });
 
@@ -247,7 +247,7 @@ describe('lorem', () => {
           const actual = faker.lorem.sentences(sentenceCount);
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual[actual.length - 1]).toBe('.');
 
           const sentences = actual.split('. ');
@@ -262,7 +262,7 @@ describe('lorem', () => {
             const actual = faker.lorem.sentences(sentenceCount, separator);
 
             expect(actual).toBeTruthy();
-            expect(typeof actual).toBe('string');
+            expect(actual).toBeTypeOf('string');
             expect(actual[actual.length - 1]).toBe('.');
 
             const sentences = actual.split(separator);
@@ -281,7 +281,7 @@ describe('lorem', () => {
           const actual = faker.lorem.paragraph();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual[actual.length - 1]).toBe('.');
         });
 
@@ -291,7 +291,7 @@ describe('lorem', () => {
             const actual = faker.lorem.paragraph(sentenceCount);
 
             expect(actual).toBeTruthy();
-            expect(typeof actual).toBe('string');
+            expect(actual).toBeTypeOf('string');
             expect(actual[actual.length - 1]).toBe('.');
 
             const sentences = actual.split('. ');
@@ -307,7 +307,7 @@ describe('lorem', () => {
           const actual = faker.lorem.paragraphs();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual[actual.length - 1]).toBe('.');
         });
 
@@ -315,7 +315,7 @@ describe('lorem', () => {
           const actual = faker.lorem.paragraphs(paragraphCount);
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual[actual.length - 1]).toBe('.');
 
           const paragraphs = actual.split('\n \r');
@@ -330,7 +330,7 @@ describe('lorem', () => {
             const actual = faker.lorem.paragraphs(paragraphCount, separator);
 
             expect(actual).toBeTruthy();
-            expect(typeof actual).toBe('string');
+            expect(actual).toBeTypeOf('string');
             expect(actual[actual.length - 1]).toBe('.');
 
             const paragraphs = actual.split(separator);
@@ -345,7 +345,7 @@ describe('lorem', () => {
           const actual = faker.lorem.text();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
         });
       });
 
@@ -354,14 +354,14 @@ describe('lorem', () => {
           const actual = faker.lorem.lines();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
         });
 
         it.each(times(25))('should return %i lines', (lineCount) => {
           const actual = faker.lorem.lines(lineCount);
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
 
           const lines = actual.split('\n');
 

--- a/test/mersenne.spec.ts
+++ b/test/mersenne.spec.ts
@@ -175,7 +175,7 @@ describe('mersenne twister', () => {
         describe('rand', () => {
           it('should return a random number without given min / max arguments', () => {
             const randomNumber = mersenne.rand();
-            expect(typeof randomNumber).toBe('number');
+            expect(randomNumber).toBeTypeOf('number');
           });
 
           it('should return random number from interval [min, max)', () => {

--- a/test/music.spec.ts
+++ b/test/music.spec.ts
@@ -61,7 +61,7 @@ describe('music', () => {
           const genre = faker.music.genre();
 
           expect(genre).toBeTruthy();
-          expect(typeof genre).toBe('string');
+          expect(genre).toBeTypeOf('string');
           expect(faker.definitions.music.genre).toContain(genre);
         });
       });

--- a/test/name.spec.ts
+++ b/test/name.spec.ts
@@ -175,7 +175,7 @@ describe('name', () => {
         it('should return a random first name', () => {
           const first_name = faker.name.firstName();
 
-          expect(typeof first_name).toBe('string');
+          expect(first_name).toBeTypeOf('string');
           expect(first_name.length).greaterThan(0);
         });
 
@@ -206,7 +206,7 @@ describe('name', () => {
         it('should return a random last name', () => {
           const last_name = faker.name.lastName();
 
-          expect(typeof last_name).toBe('string');
+          expect(last_name).toBeTypeOf('string');
           expect(last_name.length).greaterThan(0);
         });
 
@@ -241,7 +241,7 @@ describe('name', () => {
         it('should return a random middle name', () => {
           const middle_name = faker.name.middleName();
 
-          expect(typeof middle_name).toBe('string');
+          expect(middle_name).toBeTypeOf('string');
           expect(middle_name.length).greaterThan(0);
         });
 
@@ -276,7 +276,7 @@ describe('name', () => {
         it('should return a name with firstName and lastName', () => {
           const fullName = faker.name.findName();
 
-          expect(typeof fullName).toBe('string');
+          expect(fullName).toBeTypeOf('string');
           expect(fullName).toContain(' ');
         });
 
@@ -361,7 +361,7 @@ describe('name', () => {
         it('should return a job title consisting of a descriptor, area, and type', () => {
           const jobTitle = faker.name.jobTitle();
 
-          expect(typeof jobTitle).toBe('string');
+          expect(jobTitle).toBeTypeOf('string');
 
           const [descriptor, level, job] = jobTitle.split(' ');
 
@@ -379,14 +379,14 @@ describe('name', () => {
         it('should return a default gender', () => {
           const gender = faker.name.gender();
 
-          expect(typeof gender).toBe('string');
+          expect(gender).toBeTypeOf('string');
           expect(faker.definitions.name.gender).toContain(gender);
         });
 
         it('should return a binary gender', () => {
           const gender = faker.name.gender(true);
 
-          expect(typeof gender).toBe('string');
+          expect(gender).toBeTypeOf('string');
           expect(faker.definitions.name.binary_gender).toContain(gender);
         });
       });
@@ -399,7 +399,7 @@ describe('name', () => {
         it('should return a prefix', () => {
           const prefix = faker.name.prefix();
 
-          expect(typeof prefix).toBe('string');
+          expect(prefix).toBeTypeOf('string');
           expect(faker.definitions.name.prefix).toContain(prefix);
         });
 
@@ -408,7 +408,7 @@ describe('name', () => {
 
           const prefix = faker.name.prefix(0);
 
-          expect(typeof prefix).toBe('string');
+          expect(prefix).toBeTypeOf('string');
           expect(faker.definitions.name.male_prefix).toContain(prefix);
         });
 
@@ -418,7 +418,7 @@ describe('name', () => {
 
           const prefix = faker.name.prefix('male');
 
-          expect(typeof prefix).toBe('string');
+          expect(prefix).toBeTypeOf('string');
           expect(faker.definitions.name.male_prefix).toContain(prefix);
         });
 
@@ -427,7 +427,7 @@ describe('name', () => {
 
           const prefix = faker.name.prefix(1);
 
-          expect(typeof prefix).toBe('string');
+          expect(prefix).toBeTypeOf('string');
           expect(faker.definitions.name.female_prefix).toContain(prefix);
         });
 
@@ -437,7 +437,7 @@ describe('name', () => {
 
           const prefix = faker.name.prefix('female');
 
-          expect(typeof prefix).toBe('string');
+          expect(prefix).toBeTypeOf('string');
           expect(faker.definitions.name.female_prefix).toContain(prefix);
         });
       });
@@ -450,7 +450,7 @@ describe('name', () => {
         it('should return a suffix', () => {
           const suffix = faker.name.suffix();
 
-          expect(typeof suffix).toBe('string');
+          expect(suffix).toBeTypeOf('string');
           expect(faker.definitions.name.suffix).toContain(suffix);
         });
       });
@@ -463,7 +463,7 @@ describe('name', () => {
         it('should return a title consisting of a descriptor, area, and type', () => {
           const title = faker.name.title();
 
-          expect(typeof title).toBe('string');
+          expect(title).toBeTypeOf('string');
 
           const [descriptor, level, job] = title.split(' ');
 
@@ -482,7 +482,7 @@ describe('name', () => {
         it('should return a descriptor', () => {
           const descriptor = faker.name.jobDescriptor();
 
-          expect(typeof descriptor).toBe('string');
+          expect(descriptor).toBeTypeOf('string');
 
           expect(faker.definitions.name.title.descriptor).toContain(descriptor);
         });
@@ -496,7 +496,7 @@ describe('name', () => {
         it('should return a level', () => {
           const level = faker.name.jobArea();
 
-          expect(typeof level).toBe('string');
+          expect(level).toBeTypeOf('string');
 
           expect(faker.definitions.name.title.level).toContain(level);
         });
@@ -510,7 +510,7 @@ describe('name', () => {
         it('should return a job', () => {
           const job = faker.name.jobType();
 
-          expect(typeof job).toBe('string');
+          expect(job).toBeTypeOf('string');
 
           expect(faker.definitions.name.title.job).toContain(job);
         });

--- a/test/random.spec.ts
+++ b/test/random.spec.ts
@@ -82,7 +82,7 @@ describe('random', () => {
       const actual = faker.random.word();
 
       expect(actual).toBeTruthy();
-      expect(typeof actual).toBe('string');
+      expect(actual).toBeTypeOf('string');
     });
   });
 
@@ -91,7 +91,7 @@ describe('random', () => {
       const actual = faker.random.words();
 
       expect(actual).toBeTruthy();
-      expect(typeof actual).toBe('string');
+      expect(actual).toBeTypeOf('string');
 
       const words = actual.split(' ');
       expect(words.length).greaterThanOrEqual(1);
@@ -102,7 +102,7 @@ describe('random', () => {
       const actual = faker.random.words(5);
 
       expect(actual).toBeTruthy();
-      expect(typeof actual).toBe('string');
+      expect(actual).toBeTypeOf('string');
 
       const words = actual.split(' ');
       expect(words).toHaveLength(5);
@@ -114,7 +114,7 @@ describe('random', () => {
       const actual = faker.random.locale();
 
       expect(actual).toBeTruthy();
-      expect(typeof actual).toBe('string');
+      expect(actual).toBeTypeOf('string');
       expect(Object.keys(faker.locales)).toContain(actual);
     });
   });

--- a/test/time.spec.ts
+++ b/test/time.spec.ts
@@ -41,7 +41,7 @@ describe('time', () => {
           faker.seed(seed);
 
           const actual = faker.time[functionName]();
-          expect(typeof actual).toEqual(expectations[functionName].noArgs);
+          expect(actual).toBeTypeOf(expectations[functionName].noArgs);
         });
       }
     });
@@ -55,22 +55,22 @@ describe('time', () => {
       describe('recent()', () => {
         it('should return the recent timestamp in unix time format by default', () => {
           const date = faker.time.recent();
-          expect(typeof date).toBe('number');
+          expect(date).toBeTypeOf('number');
         });
 
         it('should return the recent timestamp in full time string format', () => {
           const date = faker.time.recent('wide');
-          expect(typeof date).toBe('string');
+          expect(date).toBeTypeOf('string');
         });
 
         it('should return the recent timestamp in abbreviated string format', () => {
           const date = faker.time.recent('abbr');
-          expect(typeof date).toBe('string');
+          expect(date).toBeTypeOf('string');
         });
 
         it('should return the recent timestamp in unix time format', () => {
           const date = faker.time.recent('unix');
-          expect(typeof date).toBe('number');
+          expect(date).toBeTypeOf('number');
         });
       });
     }

--- a/test/unique.spec.ts
+++ b/test/unique.spec.ts
@@ -87,7 +87,7 @@ describe('unique', () => {
       describe('unique()', () => {
         it('should be possible to call a function with no arguments and return a result', () => {
           const result = faker.unique(faker.internet.email);
-          expect(typeof result).toBe('string');
+          expect(result).toBeTypeOf('string');
         });
 
         it('should be possible to call a function with arguments and return a result', () => {

--- a/test/vehicle.spec.ts
+++ b/test/vehicle.spec.ts
@@ -88,7 +88,7 @@ describe('vehicle', () => {
           const vehicle = faker.vehicle.vehicle();
 
           expect(vehicle).toBeTruthy();
-          expect(typeof vehicle).toBe('string');
+          expect(vehicle).toBeTypeOf('string');
           expect(vehicle.split(' ').length).toBeGreaterThanOrEqual(2);
         });
       });
@@ -98,7 +98,7 @@ describe('vehicle', () => {
           const manufacturer = faker.vehicle.manufacturer();
 
           expect(manufacturer).toBeTruthy();
-          expect(typeof manufacturer).toBe('string');
+          expect(manufacturer).toBeTypeOf('string');
           expect(faker.definitions.vehicle.manufacturer).toContain(
             manufacturer
           );
@@ -110,7 +110,7 @@ describe('vehicle', () => {
           const model = faker.vehicle.model();
 
           expect(model).toBeTruthy();
-          expect(typeof model).toBe('string');
+          expect(model).toBeTypeOf('string');
           expect(faker.definitions.vehicle.model).toContain(model);
         });
       });
@@ -120,7 +120,7 @@ describe('vehicle', () => {
           const type = faker.vehicle.type();
 
           expect(type).toBeTruthy();
-          expect(typeof type).toBe('string');
+          expect(type).toBeTypeOf('string');
           expect(faker.definitions.vehicle.type).toContain(type);
         });
       });
@@ -130,7 +130,7 @@ describe('vehicle', () => {
           const fuel = faker.vehicle.fuel();
 
           expect(fuel).toBeTruthy();
-          expect(typeof fuel).toBe('string');
+          expect(fuel).toBeTypeOf('string');
           expect(faker.definitions.vehicle.fuel).toContain(fuel);
         });
       });
@@ -140,7 +140,7 @@ describe('vehicle', () => {
           const vin = faker.vehicle.vin();
 
           expect(vin).toBeTruthy();
-          expect(typeof vin).toBe('string');
+          expect(vin).toBeTypeOf('string');
           expect(vin).match(
             /^([A-HJ-NPR-Z0-9]{10}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-9]{1}\d{5})$/
           );
@@ -152,7 +152,7 @@ describe('vehicle', () => {
           const color = faker.vehicle.color();
 
           expect(color).toBeTruthy();
-          expect(typeof color).toBe('string');
+          expect(color).toBeTypeOf('string');
           expect(faker.definitions.commerce.color).toContain(color);
         });
       });
@@ -162,7 +162,7 @@ describe('vehicle', () => {
           const vrm = faker.vehicle.vrm();
 
           expect(vrm).toBeTruthy();
-          expect(typeof vrm).toBe('string');
+          expect(vrm).toBeTypeOf('string');
           expect(vrm).match(/^[A-Z]{2}[0-9]{2}[A-Z]{3}$/);
         });
       });
@@ -172,7 +172,7 @@ describe('vehicle', () => {
           const bicycle = faker.vehicle.bicycle();
 
           expect(bicycle).toBeTruthy();
-          expect(typeof bicycle).toBe('string');
+          expect(bicycle).toBeTypeOf('string');
           expect(faker.definitions.vehicle.bicycle_type).toContain(bicycle);
         });
       });

--- a/test/word.spec.ts
+++ b/test/word.spec.ts
@@ -150,7 +150,7 @@ describe('word', () => {
           const actual = faker.word[functionName]();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual).toEqual(expectations[functionName].noArgs);
         });
 
@@ -160,7 +160,7 @@ describe('word', () => {
           const actual = faker.word[functionName](10);
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual).toEqual(expectations[functionName].length10);
         });
 
@@ -170,7 +170,7 @@ describe('word', () => {
           const actual = faker.word[functionName](20);
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(actual).toEqual(expectations[functionName].length20);
         });
       }
@@ -187,7 +187,7 @@ describe('word', () => {
           const actual = faker.word.adjective();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.word.adjective).toContain(actual);
         });
       });
@@ -197,7 +197,7 @@ describe('word', () => {
           const actual = faker.word.adverb();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.word.adverb).toContain(actual);
         });
       });
@@ -207,7 +207,7 @@ describe('word', () => {
           const actual = faker.word.conjunction();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.word.conjunction).toContain(actual);
         });
       });
@@ -217,7 +217,7 @@ describe('word', () => {
           const actual = faker.word.interjection();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.word.interjection).toContain(actual);
         });
       });
@@ -227,7 +227,7 @@ describe('word', () => {
           const actual = faker.word.noun();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.word.noun).toContain(actual);
         });
       });
@@ -237,7 +237,7 @@ describe('word', () => {
           const actual = faker.word.preposition();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.word.preposition).toContain(actual);
         });
       });
@@ -247,7 +247,7 @@ describe('word', () => {
           const actual = faker.word.verb();
 
           expect(actual).toBeTruthy();
-          expect(typeof actual).toBe('string');
+          expect(actual).toBeTypeOf('string');
           expect(faker.definitions.word.verb).toContain(actual);
         });
       });


### PR DESCRIPTION
I used regex replacement in VSCode

```
expect\(typeof (.+)\).toBe\('(.+)'\);
->
expect($1).toBeTypeOf('$2');
```

In a second step I replaced all missing manually

---

The benefit is, that it produces a more readable, consistent and specific use case message when the runner fails with it