### PR TITLE
build: add redirect aliases for cjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ versions.json
 /docs/.vitepress/dist
 /docs/api/typedoc.json
 /lib
+/locale
 
 # Faker
 TAGS

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "CHANGELOG.md",
     "CHANGELOG_old.md",
     "dist",
+    "locale",
     "tsconfig.json"
   ],
   "scripts": {

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -1,8 +1,24 @@
 import { buildSync } from 'esbuild';
 import { sync as globSync } from 'glob';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import locales from '../src/locales';
 
 console.log('Building dist for node (cjs)...');
+
+// Generate entry-points for cjs compatibility
+const localeDir = 'locale';
+if (existsSync(localeDir)) {
+  rmSync(localeDir, { recursive: true, force: true });
+}
+mkdirSync(localeDir);
+for (const locale of Object.keys(locales)) {
+  writeFileSync(
+    `${localeDir}/${locale}.js`,
+    `module.exports = require('../dist/cjs/locale/${locale}');\n`,
+    { encoding: 'utf8' }
+  );
+}
+
 buildSync({
   entryPoints: globSync('./src/**/*.ts'),
   // We can use the following entry points when esbuild supports cjs+splitting


### PR DESCRIPTION
Our `package.json`s `exports` field seems not to work for any case :thinking: 
This creates a `locale/<locale>.js` file for every locale when bundling for cjs so node/npm versions that does not support the exports field can use these redirects.

At least this should work for now and we can release a 6.0.0 soon