### PR TITLE
ci: fix coverage patch threshold

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -10,4 +10,4 @@ coverage:
     project:
       default:
         target: 95%
-        threshold: 2%
+        threshold: 5%


### PR DESCRIPTION
The threshold should be `100% - target` to not confuse the `coverage/patch` ci job