### PR TITLE
refactor: set seed directly

### DIFF
--- a/src/datatype.ts
+++ b/src/datatype.ts
@@ -4,14 +4,7 @@ import type { Faker } from '.';
  * Module to generate various primitive values and data types.
  */
 export class Datatype {
-  constructor(private readonly faker: Faker, seed?: number | number[]) {
-    // Use a user provided seed if it is an array or number
-    if (Array.isArray(seed) && seed.length) {
-      this.faker.mersenne.seed_array(seed);
-    } else if (!Array.isArray(seed) && !isNaN(seed)) {
-      this.faker.mersenne.seed(seed);
-    }
-
+  constructor(private readonly faker: Faker) {
     // Bind `this` so namespaced is working correctly
     for (const name of Object.getOwnPropertyNames(Datatype.prototype)) {
       if (name === 'constructor' || typeof this[name] !== 'function') {

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -129,10 +129,13 @@ export class Faker {
     });
   }
 
-  seed(value?: number | number[]): void {
-    this.seedValue = value;
-    this.random = new Random(this, this.seedValue);
-    this.datatype = new Datatype(this, this.seedValue);
+  seed(seed?: number | number[]): void {
+    this.seedValue = seed;
+    if (Array.isArray(seed) && seed.length) {
+      this.mersenne.seed_array(seed);
+    } else if (!Array.isArray(seed) && !isNaN(seed)) {
+      this.mersenne.seed(seed);
+    }
   }
 
   /**

--- a/src/random.ts
+++ b/src/random.ts
@@ -18,14 +18,7 @@ function arrayRemove<T>(arr: T[], values: T[]): T[] {
  * Generates random values of different kinds. Some methods are deprecated and have been moved to dedicated modules.
  */
 export class Random {
-  constructor(private readonly faker: Faker, seed?: number | number[]) {
-    // Use a user provided seed if it is an array or number
-    if (Array.isArray(seed) && seed.length) {
-      this.faker.mersenne.seed_array(seed);
-    } else if (!Array.isArray(seed) && !isNaN(seed)) {
-      this.faker.mersenne.seed(seed);
-    }
-
+  constructor(private readonly faker: Faker) {
     // Bind `this` so namespaced is working correctly
     for (const name of Object.getOwnPropertyNames(Random.prototype)) {
       if (name === 'constructor' || typeof this[name] !== 'function') {

--- a/test/faker.spec.ts
+++ b/test/faker.spec.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { faker } from '../src';
+
+describe('faker', () => {
+  beforeEach(() => {
+    faker.locale = 'en';
+  });
+
+  // This is only here for coverage
+  // The actual test is in mersenne.spec.ts
+  describe('seed()', () => {
+    it('seed(number)', () => {
+      faker.seed(1);
+
+      const actual = faker.animal.cat();
+      expect(actual).toBe('Korat');
+    });
+
+    it('seed(number[])', () => {
+      faker.seed([1, 2, 3]);
+
+      const actual = faker.animal.cat();
+      expect(actual).toBe('Oriental');
+    });
+  });
+});


### PR DESCRIPTION
Instead of abusing two constructors to call a method, we could just call the method directly.