### PR TITLE
docs: show union options parameters

### DIFF
--- a/scripts/apidoc/signature.ts
+++ b/scripts/apidoc/signature.ts
@@ -190,12 +190,9 @@ function analyzeParameterOptions(
   parameterType: SomeType
 ): MethodParameter[] {
   if (parameterType.type === 'union') {
-    return [];
-    // TODO ST-DDT 2022-02-26: Currently not supported by typedoc
-    // https://github.com/TypeStrong/typedoc/issues/1876
-    // return parameterType.types.flatMap((type) =>
-    //   analyzeParameterOptions(name, type)
-    // );
+    return parameterType.types.flatMap((type) =>
+      analyzeParameterOptions(name, type)
+    );
   } else if (parameterType.type === 'reflection') {
     const properties = parameterType.declaration.getChildrenByKind(
       ReflectionKind.Property


### PR DESCRIPTION
Displays the nested options when used as union:

**Old:**
![grafik](https://user-images.githubusercontent.com/1579362/157092722-5a4d1d01-e9e0-4d83-929d-e3133d07a9f6.png)
**New:**
![grafik](https://user-images.githubusercontent.com/1579362/157092780-d5327795-b46a-4ed5-962a-a0bf0af7cd6a.png)

This is now possible thanks to:
https://github.com/TypeStrong/typedoc/issues/1876
