### PR TITLE
test: fix all_functional tests

### DIFF
--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -55,7 +55,12 @@ const modules = modulesList();
 describe('functional tests', () => {
   for (const locale in faker.locales) {
     describe(locale, () => {
-      faker.locale = locale;
+      // TODO: Enable after https://github.com/faker-js/faker/pull/269
+      //it('title', () => {
+      //  faker.locale = locale;
+      //  expect(faker.definitions.title).toBe(faker.locales[locale].title);
+      //});
+
       Object.keys(modules).forEach((module) => {
         describe(module, () => {
           // if there is nothing to test, create a dummy test so the test runner doesn't complain
@@ -65,6 +70,7 @@ describe('functional tests', () => {
 
           modules[module].forEach((meth) => {
             it(meth + '()', () => {
+              faker.locale = locale;
               const result = faker[module][meth]();
               if (meth === 'boolean') {
                 expect(result).toBeTypeOf('boolean');
@@ -96,7 +102,7 @@ describe('faker.fake functional tests', () => {
               const result = faker.fake('{{' + module + '.' + meth + '}}');
               // just make sure any result is returned
               // an undefined result usually means an error
-              expect(result).toBeDefined();
+              expect(result).toBeTypeOf('string');
               // if (meth === 'boolean') {
               //   expect(result).toBeTypeOf('boolean');
               // } else {

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -74,7 +74,7 @@ describe('functional tests', () => {
           modules[module].forEach((meth) => {
             const testAssertion = () => {
               faker.locale = locale;
-              faker.seed(1);
+              faker.seed(1); // TODO: Use random seed once there are no more failures
               const result = faker[module][meth]();
 
               if (meth === 'boolean') {

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -20,7 +20,7 @@ function isMethodOf(mod: string) {
 }
 
 const BROKEN_LOCALE_METHODS = {
-  // these are TODOs (usually broken locale files)
+  // TODO ST-DDT 2022-03-28: these are TODOs (usually broken locale files)
   address: {
     cityPrefix: ['pt_BR', 'pt_PT'],
     citySuffix: ['pt_PT'],
@@ -74,7 +74,8 @@ describe('functional tests', () => {
           modules[module].forEach((meth) => {
             const testAssertion = () => {
               faker.locale = locale;
-              faker.seed(1); // TODO: Use random seed once there are no more failures
+              // TODO ST-DDT 2022-03-28: Use random seed once there are no more failures
+              faker.seed(1);
               const result = faker[module][meth]();
 
               if (meth === 'boolean') {
@@ -87,7 +88,7 @@ describe('functional tests', () => {
             if (isWorkingLocaleForMethod(module, meth, locale)) {
               it(meth + '()', testAssertion);
             } else {
-              // TODO: Remove once there are no more failures
+              // TODO ST-DDT 2022-03-28: Remove once there are no more failures
               // We expect a failure here to ensure we remove the exclusions when fixed
               it.fails(meth + '()', testAssertion);
             }
@@ -106,7 +107,8 @@ describe('faker.fake functional tests', () => {
           modules[module].forEach((meth) => {
             it(meth + '()', () => {
               faker.locale = locale;
-              faker.seed(1); // TODO: Use random seed once there are no more failures
+              // TODO ST-DDT 2022-03-28: Use random seed once there are no more failures
+              faker.seed(1);
               const result = faker.fake('{{' + module + '.' + meth + '}}');
 
               expect(result).toBeTypeOf('string');

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -88,6 +88,7 @@ describe('functional tests', () => {
               it(meth + '()', testAssertion);
             } else {
               // TODO: Remove once there are no more failures
+              // We expect a failure here to ensure we remove the exclusions when fixed
               it.fails(meth + '()', testAssertion);
             }
           });

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -11,10 +11,6 @@ const IGNORED_MODULES = [
   'mersenne',
 ];
 
-const IGNORED_METHODS = {
-  system: ['directoryPath', 'filePath'], // these are TODOs
-};
-
 function isTestableModule(mod: string) {
   return IGNORED_MODULES.indexOf(mod) === -1;
 }
@@ -23,27 +19,45 @@ function isMethodOf(mod: string) {
   return (meth: string) => typeof faker[mod][meth] === 'function';
 }
 
-function isTestableMethod(mod: string) {
-  return (meth: string) =>
-    !(mod in IGNORED_METHODS && IGNORED_METHODS[mod].indexOf(meth) >= 0);
-}
+const BROKEN_LOCALE_METHODS = {
+  // these are TODOs (usually broken locale files)
+  address: {
+    cityPrefix: ['pt_BR', 'pt_PT'],
+    citySuffix: ['pt_PT'],
+    countryCode: ['he'],
+    state: ['az', 'cz', 'nb_NO', 'sk'],
+    stateAbbr: ['cz', 'sk'],
+  },
+  company: {
+    companySuffix: ['az'],
+  },
+  name: {
+    prefix: ['az', 'id_ID', 'ru'],
+    suffix: ['az', 'it', 'mk', 'pt_PT', 'ru'],
+  },
+};
 
-function both(
-  pred1: (meth: string) => boolean,
-  pred2: (meth: string) => boolean
-): (meth: string) => boolean {
-  return (value) => pred1(value) && pred2(value);
+function isWorkingLocaleForMethod(
+  mod: string,
+  meth: string,
+  locale: string
+): boolean {
+  return (BROKEN_LOCALE_METHODS[mod]?.[meth] ?? []).indexOf(locale) === -1;
 }
 
 // Basic smoke tests to make sure each method is at least implemented and returns a value.
 
 function modulesList(): { [module: string]: string[] } {
   const modules = Object.keys(faker)
+    .sort()
     .filter(isTestableModule)
     .reduce((result, mod) => {
-      result[mod] = Object.keys(faker[mod]).filter(
-        both(isMethodOf(mod), isTestableMethod(mod))
-      );
+      const methods = Object.keys(faker[mod]).filter(isMethodOf(mod));
+      if (methods.length) {
+        result[mod] = methods;
+      } else {
+        console.log(`Skipping ${mod} - No testable methods`);
+      }
       return result;
     }, {});
 
@@ -55,29 +69,27 @@ const modules = modulesList();
 describe('functional tests', () => {
   for (const locale in faker.locales) {
     describe(locale, () => {
-      // TODO: Enable after https://github.com/faker-js/faker/pull/269
-      //it('title', () => {
-      //  faker.locale = locale;
-      //  expect(faker.definitions.title).toBe(faker.locales[locale].title);
-      //});
-
       Object.keys(modules).forEach((module) => {
         describe(module, () => {
-          // if there is nothing to test, create a dummy test so the test runner doesn't complain
-          if (Object.keys(modules[module]).length === 0) {
-            it.todo(`${module} was empty`);
-          }
-
           modules[module].forEach((meth) => {
-            it(meth + '()', () => {
+            const testAssertion = () => {
               faker.locale = locale;
+              faker.seed(1);
               const result = faker[module][meth]();
+
               if (meth === 'boolean') {
                 expect(result).toBeTypeOf('boolean');
               } else {
                 expect(result).toBeTruthy();
               }
-            });
+            };
+
+            if (isWorkingLocaleForMethod(module, meth, locale)) {
+              it(meth + '()', testAssertion);
+            } else {
+              // TODO: Remove once there are no more failures
+              it.fails(meth + '()', testAssertion);
+            }
           });
         });
       });
@@ -88,26 +100,15 @@ describe('functional tests', () => {
 describe('faker.fake functional tests', () => {
   for (const locale in faker.locales) {
     describe(locale, () => {
-      faker.locale = locale;
-      faker.seed(1);
       Object.keys(modules).forEach((module) => {
         describe(module, () => {
-          // if there is nothing to test, create a dummy test so the test runner doesn't complain
-          if (Object.keys(modules[module]).length === 0) {
-            it.todo(`${module} was empty`);
-          }
-
           modules[module].forEach((meth) => {
             it(meth + '()', () => {
+              faker.locale = locale;
+              faker.seed(1); // TODO: Use random seed once there are no more failures
               const result = faker.fake('{{' + module + '.' + meth + '}}');
-              // just make sure any result is returned
-              // an undefined result usually means an error
+
               expect(result).toBeTypeOf('string');
-              // if (meth === 'boolean') {
-              //   expect(result).toBeTypeOf('boolean');
-              // } else {
-              //   expect(result).toBeTruthy();
-              // }
             });
           });
         });


### PR DESCRIPTION
The `all_functional.spec.ts` doesn't work as expected. We need to fix this eventually.
This conceals 20 errors:

````txt
 FAIL  test/all_functional.spec.ts > functional tests > az > address > state()
 FAIL  test/all_functional.spec.ts > functional tests > az > company > companySuffix()
 FAIL  test/all_functional.spec.ts > functional tests > az > name > prefix()
 FAIL  test/all_functional.spec.ts > functional tests > az > name > suffix()
 FAIL  test/all_functional.spec.ts > functional tests > cz > address > state()
 FAIL  test/all_functional.spec.ts > functional tests > cz > address > stateAbbr()
 FAIL  test/all_functional.spec.ts > functional tests > id_ID > name > prefix()
 FAIL  test/all_functional.spec.ts > functional tests > it > name > suffix()
 FAIL  test/all_functional.spec.ts > functional tests > mk > name > suffix()
 FAIL  test/all_functional.spec.ts > functional tests > pt_BR > address > cityPrefix()
 FAIL  test/all_functional.spec.ts > functional tests > pt_PT > address > cityPrefix()
 FAIL  test/all_functional.spec.ts > functional tests > pt_PT > address > citySuffix()
 FAIL  test/all_functional.spec.ts > functional tests > pt_PT > name > suffix()
 FAIL  test/all_functional.spec.ts > functional tests > ru > name > prefix()
 FAIL  test/all_functional.spec.ts > functional tests > ru > name > suffix()
 FAIL  test/all_functional.spec.ts > functional tests > sk > address > state()
 FAIL  test/all_functional.spec.ts > functional tests > sk > address > stateAbbr()
AssertionError: expected undefined to be truthy
 ❯ test/all_functional.spec.ts:78:31
 FAIL  test/all_functional.spec.ts > functional tests > he > address > countryCode()
 FAIL  test/all_functional.spec.ts > functional tests > nb_NO > address > state()
AssertionError: expected '' to be truthy
 ❯ test/all_functional.spec.ts:78:31
 FAIL  test/all_functional.spec.ts > functional tests > nb_NO > random > words()
Error: string parameter is required!
 ❯ Fake.fake src/fake.ts:51:12

````

We have to check how we fix these issues.
Some fixes require changes to the definitions, other require changes to the code itself.

The `fake()` test works as expected I just improved/narrowed the check.