### PR TITLE
feat: export locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,40 @@ See our documentation for a list of [provided languages](https://fakerjs.dev/api
 
 ### Individual Localization Packages
 
-Faker supports incremental loading of locales.
+Faker supports loading of individual locales.
 
 ```js
 // loads only de locale
 const { faker } = require('@faker-js/faker/locale/de');
+```
+
+Faker supports adding locale fallback.
+cjs:
+
+```cjs
+const { Faker } = require('@faker-js/faker');
+const { default: de } = require("@faker-js/faker/locale/de");
+const { default: fr } = require("@faker-js/faker/locale/fr");
+
+consta faker =   new Faker({
+  locales: { de, fr },
+  locale: "de",
+  localeFallback: "fr",
+});
+```
+
+esm:
+
+```mjs
+import { Faker } from '@faker-js/faker';
+import de from "@faker-js/faker/locale/de";
+import fr from "@faker-js/faker/locale/fr";
+
+consta faker =   new Faker({
+  locales: { de, fr },
+  locale: "de",
+  localeFallback: "fr",
+});
 ```
 
 ## Setting a randomness seed

--- a/src/locale/af_ZA.ts
+++ b/src/locale/af_ZA.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import af_ZA from '../locales/af_ZA';
 import en from '../locales/en';
 
+export { default } from '../locales/af_ZA';
+
 export const faker = new Faker({
   locale: 'af_ZA',
   localeFallback: 'en',

--- a/src/locale/ar.ts
+++ b/src/locale/ar.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import ar from '../locales/ar';
 import en from '../locales/en';
 
+export { default } from '../locales/ar';
+
 export const faker = new Faker({
   locale: 'ar',
   localeFallback: 'en',

--- a/src/locale/az.ts
+++ b/src/locale/az.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import az from '../locales/az';
 import en from '../locales/en';
 
+export { default } from '../locales/az';
+
 export const faker = new Faker({
   locale: 'az',
   localeFallback: 'en',

--- a/src/locale/cz.ts
+++ b/src/locale/cz.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import cz from '../locales/cz';
 import en from '../locales/en';
 
+export { default } from '../locales/cz';
+
 export const faker = new Faker({
   locale: 'cz',
   localeFallback: 'en',

--- a/src/locale/de.ts
+++ b/src/locale/de.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import de from '../locales/de';
 import en from '../locales/en';
 
+export { default } from '../locales/de';
+
 export const faker = new Faker({
   locale: 'de',
   localeFallback: 'en',

--- a/src/locale/de_AT.ts
+++ b/src/locale/de_AT.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import de_AT from '../locales/de_AT';
 import en from '../locales/en';
 
+export { default } from '../locales/de_AT';
+
 export const faker = new Faker({
   locale: 'de_AT',
   localeFallback: 'en',

--- a/src/locale/de_CH.ts
+++ b/src/locale/de_CH.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import de_CH from '../locales/de_CH';
 import en from '../locales/en';
 
+export { default } from '../locales/de_CH';
+
 export const faker = new Faker({
   locale: 'de_CH',
   localeFallback: 'en',

--- a/src/locale/el.ts
+++ b/src/locale/el.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import el from '../locales/el';
 import en from '../locales/en';
 
+export { default } from '../locales/el';
+
 export const faker = new Faker({
   locale: 'el',
   localeFallback: 'en',

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -6,6 +6,8 @@
 import { Faker } from '../faker';
 import en from '../locales/en';
 
+export { default } from '../locales/en';
+
 export const faker = new Faker({
   locale: 'en',
   localeFallback: 'en',

--- a/src/locale/en_AU.ts
+++ b/src/locale/en_AU.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_AU from '../locales/en_AU';
 
+export { default } from '../locales/en_AU';
+
 export const faker = new Faker({
   locale: 'en_AU',
   localeFallback: 'en',

--- a/src/locale/en_AU_ocker.ts
+++ b/src/locale/en_AU_ocker.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_AU_ocker from '../locales/en_AU_ocker';
 
+export { default } from '../locales/en_AU_ocker';
+
 export const faker = new Faker({
   locale: 'en_AU_ocker',
   localeFallback: 'en',

--- a/src/locale/en_BORK.ts
+++ b/src/locale/en_BORK.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_BORK from '../locales/en_BORK';
 
+export { default } from '../locales/en_BORK';
+
 export const faker = new Faker({
   locale: 'en_BORK',
   localeFallback: 'en',

--- a/src/locale/en_CA.ts
+++ b/src/locale/en_CA.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_CA from '../locales/en_CA';
 
+export { default } from '../locales/en_CA';
+
 export const faker = new Faker({
   locale: 'en_CA',
   localeFallback: 'en',

--- a/src/locale/en_GB.ts
+++ b/src/locale/en_GB.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_GB from '../locales/en_GB';
 
+export { default } from '../locales/en_GB';
+
 export const faker = new Faker({
   locale: 'en_GB',
   localeFallback: 'en',

--- a/src/locale/en_GH.ts
+++ b/src/locale/en_GH.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_GH from '../locales/en_GH';
 
+export { default } from '../locales/en_GH';
+
 export const faker = new Faker({
   locale: 'en_GH',
   localeFallback: 'en',

--- a/src/locale/en_IE.ts
+++ b/src/locale/en_IE.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_IE from '../locales/en_IE';
 
+export { default } from '../locales/en_IE';
+
 export const faker = new Faker({
   locale: 'en_IE',
   localeFallback: 'en',

--- a/src/locale/en_IND.ts
+++ b/src/locale/en_IND.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_IND from '../locales/en_IND';
 
+export { default } from '../locales/en_IND';
+
 export const faker = new Faker({
   locale: 'en_IND',
   localeFallback: 'en',

--- a/src/locale/en_NG.ts
+++ b/src/locale/en_NG.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_NG from '../locales/en_NG';
 
+export { default } from '../locales/en_NG';
+
 export const faker = new Faker({
   locale: 'en_NG',
   localeFallback: 'en',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_US from '../locales/en_US';
 
+export { default } from '../locales/en_US';
+
 export const faker = new Faker({
   locale: 'en_US',
   localeFallback: 'en',

--- a/src/locale/en_ZA.ts
+++ b/src/locale/en_ZA.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import en_ZA from '../locales/en_ZA';
 
+export { default } from '../locales/en_ZA';
+
 export const faker = new Faker({
   locale: 'en_ZA',
   localeFallback: 'en',

--- a/src/locale/es.ts
+++ b/src/locale/es.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import es from '../locales/es';
 
+export { default } from '../locales/es';
+
 export const faker = new Faker({
   locale: 'es',
   localeFallback: 'en',

--- a/src/locale/es_MX.ts
+++ b/src/locale/es_MX.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import es_MX from '../locales/es_MX';
 
+export { default } from '../locales/es_MX';
+
 export const faker = new Faker({
   locale: 'es_MX',
   localeFallback: 'en',

--- a/src/locale/fa.ts
+++ b/src/locale/fa.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import fa from '../locales/fa';
 
+export { default } from '../locales/fa';
+
 export const faker = new Faker({
   locale: 'fa',
   localeFallback: 'en',

--- a/src/locale/fi.ts
+++ b/src/locale/fi.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import fi from '../locales/fi';
 
+export { default } from '../locales/fi';
+
 export const faker = new Faker({
   locale: 'fi',
   localeFallback: 'en',

--- a/src/locale/fr.ts
+++ b/src/locale/fr.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import fr from '../locales/fr';
 
+export { default } from '../locales/fr';
+
 export const faker = new Faker({
   locale: 'fr',
   localeFallback: 'en',

--- a/src/locale/fr_BE.ts
+++ b/src/locale/fr_BE.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import fr_BE from '../locales/fr_BE';
 
+export { default } from '../locales/fr_BE';
+
 export const faker = new Faker({
   locale: 'fr_BE',
   localeFallback: 'en',

--- a/src/locale/fr_CA.ts
+++ b/src/locale/fr_CA.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import fr_CA from '../locales/fr_CA';
 
+export { default } from '../locales/fr_CA';
+
 export const faker = new Faker({
   locale: 'fr_CA',
   localeFallback: 'en',

--- a/src/locale/fr_CH.ts
+++ b/src/locale/fr_CH.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import fr_CH from '../locales/fr_CH';
 
+export { default } from '../locales/fr_CH';
+
 export const faker = new Faker({
   locale: 'fr_CH',
   localeFallback: 'en',

--- a/src/locale/ge.ts
+++ b/src/locale/ge.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import ge from '../locales/ge';
 
+export { default } from '../locales/ge';
+
 export const faker = new Faker({
   locale: 'ge',
   localeFallback: 'en',

--- a/src/locale/he.ts
+++ b/src/locale/he.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import he from '../locales/he';
 
+export { default } from '../locales/he';
+
 export const faker = new Faker({
   locale: 'he',
   localeFallback: 'en',

--- a/src/locale/hr.ts
+++ b/src/locale/hr.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import hr from '../locales/hr';
 
+export { default } from '../locales/hr';
+
 export const faker = new Faker({
   locale: 'hr',
   localeFallback: 'en',

--- a/src/locale/hu.ts
+++ b/src/locale/hu.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import hu from '../locales/hu';
 
+export { default } from '../locales/hu';
+
 export const faker = new Faker({
   locale: 'hu',
   localeFallback: 'en',

--- a/src/locale/hy.ts
+++ b/src/locale/hy.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import hy from '../locales/hy';
 
+export { default } from '../locales/hy';
+
 export const faker = new Faker({
   locale: 'hy',
   localeFallback: 'en',

--- a/src/locale/id_ID.ts
+++ b/src/locale/id_ID.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import id_ID from '../locales/id_ID';
 
+export { default } from '../locales/id_ID';
+
 export const faker = new Faker({
   locale: 'id_ID',
   localeFallback: 'en',

--- a/src/locale/it.ts
+++ b/src/locale/it.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import it from '../locales/it';
 
+export { default } from '../locales/it';
+
 export const faker = new Faker({
   locale: 'it',
   localeFallback: 'en',

--- a/src/locale/ja.ts
+++ b/src/locale/ja.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import ja from '../locales/ja';
 
+export { default } from '../locales/ja';
+
 export const faker = new Faker({
   locale: 'ja',
   localeFallback: 'en',

--- a/src/locale/ko.ts
+++ b/src/locale/ko.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import ko from '../locales/ko';
 
+export { default } from '../locales/ko';
+
 export const faker = new Faker({
   locale: 'ko',
   localeFallback: 'en',

--- a/src/locale/lv.ts
+++ b/src/locale/lv.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import lv from '../locales/lv';
 
+export { default } from '../locales/lv';
+
 export const faker = new Faker({
   locale: 'lv',
   localeFallback: 'en',

--- a/src/locale/mk.ts
+++ b/src/locale/mk.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import mk from '../locales/mk';
 
+export { default } from '../locales/mk';
+
 export const faker = new Faker({
   locale: 'mk',
   localeFallback: 'en',

--- a/src/locale/nb_NO.ts
+++ b/src/locale/nb_NO.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import nb_NO from '../locales/nb_NO';
 
+export { default } from '../locales/nb_NO';
+
 export const faker = new Faker({
   locale: 'nb_NO',
   localeFallback: 'en',

--- a/src/locale/ne.ts
+++ b/src/locale/ne.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import ne from '../locales/ne';
 
+export { default } from '../locales/ne';
+
 export const faker = new Faker({
   locale: 'ne',
   localeFallback: 'en',

--- a/src/locale/nl.ts
+++ b/src/locale/nl.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import nl from '../locales/nl';
 
+export { default } from '../locales/nl';
+
 export const faker = new Faker({
   locale: 'nl',
   localeFallback: 'en',

--- a/src/locale/nl_BE.ts
+++ b/src/locale/nl_BE.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import nl_BE from '../locales/nl_BE';
 
+export { default } from '../locales/nl_BE';
+
 export const faker = new Faker({
   locale: 'nl_BE',
   localeFallback: 'en',

--- a/src/locale/pl.ts
+++ b/src/locale/pl.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import pl from '../locales/pl';
 
+export { default } from '../locales/pl';
+
 export const faker = new Faker({
   locale: 'pl',
   localeFallback: 'en',

--- a/src/locale/pt_BR.ts
+++ b/src/locale/pt_BR.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import pt_BR from '../locales/pt_BR';
 
+export { default } from '../locales/pt_BR';
+
 export const faker = new Faker({
   locale: 'pt_BR',
   localeFallback: 'en',

--- a/src/locale/pt_PT.ts
+++ b/src/locale/pt_PT.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import pt_PT from '../locales/pt_PT';
 
+export { default } from '../locales/pt_PT';
+
 export const faker = new Faker({
   locale: 'pt_PT',
   localeFallback: 'en',

--- a/src/locale/ro.ts
+++ b/src/locale/ro.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import ro from '../locales/ro';
 
+export { default } from '../locales/ro';
+
 export const faker = new Faker({
   locale: 'ro',
   localeFallback: 'en',

--- a/src/locale/ru.ts
+++ b/src/locale/ru.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import ru from '../locales/ru';
 
+export { default } from '../locales/ru';
+
 export const faker = new Faker({
   locale: 'ru',
   localeFallback: 'en',

--- a/src/locale/sk.ts
+++ b/src/locale/sk.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import sk from '../locales/sk';
 
+export { default } from '../locales/sk';
+
 export const faker = new Faker({
   locale: 'sk',
   localeFallback: 'en',

--- a/src/locale/sv.ts
+++ b/src/locale/sv.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import sv from '../locales/sv';
 
+export { default } from '../locales/sv';
+
 export const faker = new Faker({
   locale: 'sv',
   localeFallback: 'en',

--- a/src/locale/tr.ts
+++ b/src/locale/tr.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import tr from '../locales/tr';
 
+export { default } from '../locales/tr';
+
 export const faker = new Faker({
   locale: 'tr',
   localeFallback: 'en',

--- a/src/locale/uk.ts
+++ b/src/locale/uk.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import uk from '../locales/uk';
 
+export { default } from '../locales/uk';
+
 export const faker = new Faker({
   locale: 'uk',
   localeFallback: 'en',

--- a/src/locale/ur.ts
+++ b/src/locale/ur.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import ur from '../locales/ur';
 
+export { default } from '../locales/ur';
+
 export const faker = new Faker({
   locale: 'ur',
   localeFallback: 'en',

--- a/src/locale/vi.ts
+++ b/src/locale/vi.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import vi from '../locales/vi';
 
+export { default } from '../locales/vi';
+
 export const faker = new Faker({
   locale: 'vi',
   localeFallback: 'en',

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import zh_CN from '../locales/zh_CN';
 
+export { default } from '../locales/zh_CN';
+
 export const faker = new Faker({
   locale: 'zh_CN',
   localeFallback: 'en',

--- a/src/locale/zh_TW.ts
+++ b/src/locale/zh_TW.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import zh_TW from '../locales/zh_TW';
 
+export { default } from '../locales/zh_TW';
+
 export const faker = new Faker({
   locale: 'zh_TW',
   localeFallback: 'en',

--- a/src/locale/zu_ZA.ts
+++ b/src/locale/zu_ZA.ts
@@ -7,6 +7,8 @@ import { Faker } from '../faker';
 import en from '../locales/en';
 import zu_ZA from '../locales/zu_ZA';
 
+export { default } from '../locales/zu_ZA';
+
 export const faker = new Faker({
   locale: 'zu_ZA',
   localeFallback: 'en',

--- a/test/locale-imports.spec.ts
+++ b/test/locale-imports.spec.ts
@@ -2,37 +2,54 @@ import { describe, expect, it } from 'vitest';
 import allLocales from '../src/locales';
 
 describe('locale imports', () => {
-  for (const locale in allLocales) {
-    it(`should be possible to directly require('@faker-js/faker/locale/${locale}')`, () => {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { faker } = require(`../dist/cjs/locale/${locale}`);
+  for (const localeName in allLocales) {
+    it(`should be possible to directly require('@faker-js/faker/locale/${localeName}')`, () => {
+      const {
+        faker,
+        default: locale,
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+      } = require(`../dist/cjs/locale/${localeName}`);
 
       expect(faker).toBeDefined();
-      expect(faker.locale).toBe(locale);
+      expect(locale).toBeDefined();
+      expect(faker.locale).toBe(localeName);
     });
 
-    it(`should be possible to directly import('@faker-js/faker/locale/${locale}')`, async () => {
-      const { faker } = await import(`../dist/esm/locale/${locale}`);
+    it(`should be possible to directly import('@faker-js/faker/locale/${localeName}')`, async () => {
+      const {
+        faker,
+        default: locale,
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+      } = await import(`../dist/esm/locale/${localeName}`);
 
       expect(faker).toBeDefined();
-      expect(faker.locale).toBe(locale);
+      expect(locale).toBeDefined();
+      expect(faker.locale).toBe(localeName);
     });
 
     describe('Internal tests to cover `src/locale/*.ts`', () => {
-      it(`should be possible to directly require('../locale/${locale}')`, () => {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { faker } = require(`../locale/${locale}`);
+      it(`should be possible to directly require('../locale/${localeName}')`, () => {
+        const {
+          faker,
+          default: locale,
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+        } = require(`../locale/${localeName}`);
 
         expect(faker).toBeDefined();
-        expect(faker.locale).toBe(locale);
+        expect(locale).toBeDefined();
+        expect(faker.locale).toBe(localeName);
       });
 
-      it(`should be possible to directly import('../src/locale/${locale}')`, async () => {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { faker } = await import(`../src/locale/${locale}`);
+      it(`should be possible to directly import('../src/locale/${localeName}')`, async () => {
+        const {
+          faker,
+          default: locale,
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+        } = await import(`../src/locale/${localeName}`);
 
         expect(faker).toBeDefined();
-        expect(faker.locale).toBe(locale);
+        expect(locale).toBeDefined();
+        expect(faker.locale).toBe(localeName);
       });
     });
   }


### PR DESCRIPTION
Locales should be exported otherwise the only way to have localeFallback is to use the default exported Faker instance.

Example:
```js
const en = require('@fakerjs/faker/locale/en');
const pt_BR = require('@fakerjs/faker/locale/pt_BR');
const { Faker } = require('@fakerjs/faker');

const faker = new Faker({ locales: {en, pt_BR}, locale: 'pt_BR', fallbackLocale: 'en' });
```