### PR TITLE
ci: configure codecov patch threshold

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -14,4 +14,4 @@ coverage:
     patch:
       default:
         target: 95%
-        threshold: 2%
+        threshold: 1%

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -14,4 +14,4 @@ coverage:
     patch:
       default:
         target: 95%
-        threshold: 100%
+        threshold: 2%

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -10,4 +10,8 @@ coverage:
     project:
       default:
         target: 95%
+        threshold: 2%
+    patch:
+      default:
+        target: 95%
         threshold: 100%

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -10,4 +10,3 @@ coverage:
     project:
       default:
         target: 95%
-        threshold: 2%

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -10,3 +10,4 @@ coverage:
     project:
       default:
         target: 95%
+        threshold: 100%

--- a/src/fake.ts
+++ b/src/fake.ts
@@ -12,6 +12,12 @@ export class Fake {
       }
       this[name] = this[name].bind(this);
     }
+
+    if (Math.random() > 0) {
+      console.log('Make a random line-change that is not covered');
+    } else {
+      console.log('Make a random line-change that is not covered 42');
+    }
   }
 
   /**

--- a/src/fake.ts
+++ b/src/fake.ts
@@ -12,12 +12,6 @@ export class Fake {
       }
       this[name] = this[name].bind(this);
     }
-
-    if (Math.random() > 0) {
-      console.log('Make a random line-change that is not covered');
-    } else {
-      console.log('Make a random line-change that is not covered 42');
-    }
   }
 
   /**


### PR DESCRIPTION
The threshold is not useful as it only fails PRs that are successfully but the threshold is not meet.