### PR TITLE
docs: fix page meta

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -62,27 +62,42 @@ export default defineConfig({
     [
       'meta',
       {
-        property: 'og:description',
+        name: 'og:description',
         content: description,
       },
+    ],
+    [
+      'meta',
       {
         name: 'twitter:description',
         content: description,
       },
+    ],
+    [
+      'meta',
       {
         name: 'description',
         content: description,
       },
+    ],
+    [
+      'meta',
       {
-        property: 'og:image',
+        name: 'og:image',
         content: image,
       },
+    ],
+    [
+      'meta',
       {
-        property: 'twitter:image',
+        name: 'twitter:image',
         content: image,
       },
+    ],
+    [
+      'meta',
       {
-        property: 'twitter:card',
+        name: 'twitter:card',
         content: 'summary_large_image',
       },
     ],


### PR DESCRIPTION
I used https://github.com/kevcodez/intheloop/issues/2 as a hint which names are probably correct.

Spec: https://wiki.selfhtml.org/wiki/HTML/Elemente/meta

<details>
<summary><strong>Old (Prod)</strong></summary>

![grafik](https://user-images.githubusercontent.com/1579362/159571036-602391b4-e32e-4bdb-9cb6-c6e3e677ded6.png)

</details>

<details>
<summary><strong>Old (Dev)</strong></summary>

![grafik](https://user-images.githubusercontent.com/1579362/159571354-8873aa05-00ba-45e5-b9ec-edf17b69b790.png)

</details>

<details>
<summary><strong>New</strong></summary>

![grafik](https://user-images.githubusercontent.com/1579362/159570900-13df834f-5626-4a2d-b226-dca3d90ef243.png)

</details>

What about the other tags mentioned in the issue?