### PR TITLE
test: remove todo for number conversion

### DIFF
--- a/test/commerce.spec.ts
+++ b/test/commerce.spec.ts
@@ -121,8 +121,7 @@ describe('commerce', () => {
           const price = faker.commerce.price();
 
           expect(price).toBeTruthy();
-
-          // TODO @Shinigami92 2022-01-20: I converted the price string to number to satisfy TS
+          expect(price).toBeTypeOf('string');
           expect(+price).greaterThan(0);
           expect(+price).lessThanOrEqual(1000);
         });
@@ -154,8 +153,7 @@ describe('commerce', () => {
           const amount = faker.commerce.price(-200, -1);
 
           expect(amount).toBeTruthy();
-          // TODO @Shinigami92 2022-01-20: I converted the price string to number to satisfy TS
-          expect(+amount === 0.0, 'the amount should equal 0').toBe(true);
+          expect(amount, 'the amount should equal 0').toBe('0');
         });
 
         it('should handle argument dec', () => {

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -205,6 +205,7 @@ describe('finance', () => {
           const amount = faker.finance.amount();
 
           expect(amount).toBeTruthy();
+          expect(amount).toBeTypeOf('string');
           expect(+amount, 'the amount should be greater than 0').greaterThan(0);
           expect(+amount, 'the amount should be less than 1001').lessThan(1001);
         });
@@ -234,6 +235,7 @@ describe('finance', () => {
           const amount = faker.finance.amount(-200, -1);
 
           expect(amount).toBeTruthy();
+          expect(amount).toBeTypeOf('string');
           expect(+amount, 'the amount should be less than 0').lessThan(0);
           expect(+amount, 'the amount should be greater than -201').greaterThan(
             -201


### PR DESCRIPTION
It is expected to get strings in this situations due to fixed precisions for e.g. prices