### PR TITLE
refactor: date accept number input

### DIFF
--- a/src/date.ts
+++ b/src/date.ts
@@ -17,19 +17,6 @@ function toDate(date?: string | Date | number): Date {
 }
 
 /**
- * Converts date passed as a string or Date to milliseconds. If nothing passed, takes current date.
- *
- * @param date Date
- */
-function toMilliseconds(date?: string | Date): number {
-  if (date != null) {
-    return date instanceof Date ? date.getTime() : Date.parse(date);
-  }
-
-  return new Date().getTime();
-}
-
-/**
  * Module to generate dates.
  */
 export class _Date {
@@ -106,9 +93,9 @@ export class _Date {
    * @example
    * faker.date.between('2020-01-01T00:00:00.000Z', '2030-01-01T00:00:00.000Z') // '2026-05-16T02:22:53.002Z'
    */
-  between(from: string | Date, to: string | Date): Date {
-    const fromMs = toMilliseconds(from);
-    const toMs = toMilliseconds(to);
+  between(from: string | Date | number, to: string | Date | number): Date {
+    const fromMs = toDate(from).getTime();
+    const toMs = toDate(to).getTime();
     const dateOffset = this.faker.datatype.number(toMs - fromMs);
 
     return new Date(fromMs + dateOffset);

--- a/src/date.ts
+++ b/src/date.ts
@@ -118,14 +118,18 @@ export class _Date {
    * faker.date.betweens('2020-01-01T00:00:00.000Z', '2030-01-01T00:00:00.000Z', 2)
    * // [ 2023-05-02T16:00:00.000Z, 2026-09-01T08:00:00.000Z ]
    */
-  betweens(from: string | Date, to: string | Date, num?: number): Date[] {
+  betweens(
+    from: string | Date | number,
+    to: string | Date | number,
+    num?: number
+  ): Date[] {
     if (typeof num === 'undefined') {
       num = 3;
     }
 
     const dates: Date[] = [];
 
-    for (let i = 0; i < num; i++) {
+    while (dates.length < num) {
       dates.push(this.between(from, to));
     }
 

--- a/src/date.ts
+++ b/src/date.ts
@@ -176,7 +176,7 @@ export class _Date {
    * faker.date.soon(10) // '2022-02-11T05:14:39.138Z'
    * faker.date.soon(10, '2020-01-01T00:00:00.000Z') // '2020-01-01T02:40:44.990Z'
    */
-  soon(days?: number, refDate?: string | Date): Date {
+  soon(days?: number, refDate?: string | Date | number): Date {
     const date = toDate(refDate);
     const range = {
       min: 1000,

--- a/src/date.ts
+++ b/src/date.ts
@@ -2,12 +2,12 @@ import type { Faker } from '.';
 import type { DateEntryDefinition } from './definitions';
 
 /**
- * Converts date passed as a string or Date to a Date object.
+ * Converts date passed as a string, number or Date to a Date object.
  * If nothing or a non parseable value is passed, takes current date.
  *
  * @param date Date
  */
-function toDate(date?: string | Date): Date {
+function toDate(date?: string | Date | number): Date {
   date = new Date(date);
   if (isNaN(date.valueOf())) {
     date = new Date();

--- a/src/date.ts
+++ b/src/date.ts
@@ -83,7 +83,7 @@ export class _Date {
    * faker.date.future(10) // '2030-11-23T09:38:28.710Z'
    * faker.date.future(10, '2020-01-01T00:00:00.000Z') // '2020-12-13T22:45:10.252Z'
    */
-  future(years?: number, refDate?: string | Date): Date {
+  future(years?: number, refDate?: string | Date | number): Date {
     const date = toDate(refDate);
     const range = {
       min: 1000,

--- a/src/date.ts
+++ b/src/date.ts
@@ -149,7 +149,7 @@ export class _Date {
    * faker.date.recent(10) // '2022-01-29T06:12:12.829Z'
    * faker.date.recent(10, '2020-01-01T00:00:00.000Z') // '2019-12-27T18:11:19.117Z'
    */
-  recent(days?: number, refDate?: string | Date): Date {
+  recent(days?: number, refDate?: string | Date | number): Date {
     const date = toDate(refDate);
     const range = {
       min: 1000,

--- a/src/date.ts
+++ b/src/date.ts
@@ -2,16 +2,18 @@ import type { Faker } from '.';
 import type { DateEntryDefinition } from './definitions';
 
 /**
- * Converts date passed as a string or Date to a Date object. If nothing passed, takes current date.
+ * Converts date passed as a string or Date to a Date object.
+ * If nothing or a non parseable value is passed, takes current date.
  *
  * @param date Date
  */
 function toDate(date?: string | Date): Date {
-  if (date != null) {
-    return new Date(date instanceof Date ? date : Date.parse(date));
+  date = new Date(date);
+  if (isNaN(date.valueOf())) {
+    date = new Date();
   }
 
-  return new Date();
+  return date;
 }
 
 /**

--- a/src/date.ts
+++ b/src/date.ts
@@ -56,7 +56,7 @@ export class _Date {
    * faker.date.past(10) // '2017-10-25T21:34:19.488Z'
    * faker.date.past(10, '2020-01-01T00:00:00.000Z') // '2017-08-18T02:59:12.350Z'
    */
-  past(years?: number, refDate?: string | Date): Date {
+  past(years?: number, refDate?: string | Date | number): Date {
     const date = toDate(refDate);
     const range = {
       min: 1000,

--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -103,6 +103,12 @@ const seededRuns = [
   },
 ];
 
+const converterMap = [
+  (d: Date) => d,
+  (d: Date) => d.toISOString(),
+  (d: Date) => d.valueOf(),
+];
+
 const NON_SEEDED_BASED_RUN = 5;
 
 describe('date', () => {
@@ -384,20 +390,18 @@ describe('date', () => {
           expect(date).lessThan(refDate);
         });
 
-        it('should return a past date relative to given refDate', () => {
-          const refDate = new Date();
-          refDate.setFullYear(refDate.getFullYear() + 5);
+        it.each(converterMap)(
+          'should return a past date relative to given refDate',
+          (converter) => {
+            const refDate = new Date();
+            refDate.setFullYear(refDate.getFullYear() + 5);
 
-          let date = faker.date.past(5, refDate);
+            const date = faker.date.past(5, converter(refDate));
 
-          expect(date).lessThan(refDate);
-          expect(date).greaterThan(new Date());
-
-          date = faker.date.past(5, refDate.toISOString());
-
-          expect(date).lessThan(refDate);
-          expect(date).greaterThan(new Date());
-        });
+            expect(date).lessThan(refDate);
+            expect(date).greaterThan(new Date());
+          }
+        );
       });
 
       describe('future()', () => {
@@ -414,59 +418,50 @@ describe('date', () => {
           expect(date).greaterThan(refDate); // date should be after the date given
         });
 
-        it('should return a date 75 years after the date given', () => {
-          const refDate = new Date(1880, 11, 9, 10, 0, 0, 0); // set the date beyond the usual calculation (to make sure this is working correctly)
+        it.each(converterMap)(
+          'should return a date 75 years after the date given',
+          (converter) => {
+            const refDate = new Date(1880, 11, 9, 10, 0, 0, 0); // set the date beyond the usual calculation (to make sure this is working correctly)
 
-          let date = faker.date.future(75, refDate);
+            const date = faker.date.future(75, converter(refDate));
 
-          // date should be after the date given, but before the current time
-          expect(date).greaterThan(refDate);
-          expect(date).lessThan(new Date());
-
-          date = faker.date.future(75, refDate.toISOString());
-
-          // date should be after the date given, but before the current time
-          expect(date).greaterThan(refDate);
-          expect(date).lessThan(new Date());
-        });
+            // date should be after the date given, but before the current time
+            expect(date).greaterThan(refDate);
+            expect(date).lessThan(new Date());
+          }
+        );
       });
 
       describe('between()', () => {
-        it('should return a random date between the dates given', () => {
-          const from = new Date(1990, 5, 7, 9, 11, 0, 0);
-          const to = new Date(2000, 6, 8, 10, 12, 0, 0);
+        it.each(converterMap)(
+          'should return a random date between the dates given',
+          (converter) => {
+            const from = new Date(1990, 5, 7, 9, 11, 0, 0);
+            const to = new Date(2000, 6, 8, 10, 12, 0, 0);
 
-          let date = faker.date.between(from, to);
+            const date = faker.date.between(converter(from), converter(to));
 
-          expect(date).greaterThan(from);
-          expect(date).lessThan(to);
-
-          date = faker.date.between(from.toISOString(), to.toISOString());
-
-          expect(date).greaterThan(from);
-          expect(date).lessThan(to);
-        });
+            expect(date).greaterThan(from);
+            expect(date).lessThan(to);
+          }
+        );
       });
 
       describe('betweens()', () => {
-        it('should return an array of 3 dates ( by default ) of sorted randoms dates between the dates given', () => {
-          const from = new Date(1990, 5, 7, 9, 11, 0, 0);
-          const to = new Date(2000, 6, 8, 10, 12, 0, 0);
+        it.each(converterMap)(
+          'should return an array of 3 dates ( by default ) of sorted randoms dates between the dates given',
+          (converter) => {
+            const from = new Date(1990, 5, 7, 9, 11, 0, 0);
+            const to = new Date(2000, 6, 8, 10, 12, 0, 0);
 
-          let dates = faker.date.betweens(from, to);
+            const dates = faker.date.betweens(converter(from), converter(to));
 
-          expect(dates[0]).greaterThan(from);
-          expect(dates[0]).lessThan(to);
-          expect(dates[1]).greaterThan(dates[0]);
-          expect(dates[2]).greaterThan(dates[1]);
-
-          dates = faker.date.betweens(from.toISOString(), to.toISOString());
-
-          expect(dates[0]).greaterThan(from);
-          expect(dates[0]).lessThan(to);
-          expect(dates[1]).greaterThan(dates[0]);
-          expect(dates[2]).greaterThan(dates[1]);
-        });
+            expect(dates[0]).greaterThan(from);
+            expect(dates[0]).lessThan(to);
+            expect(dates[1]).greaterThan(dates[0]);
+            expect(dates[2]).greaterThan(dates[1]);
+          }
+        );
       });
 
       describe('recent()', () => {
@@ -476,36 +471,28 @@ describe('date', () => {
           expect(date).lessThanOrEqual(new Date());
         });
 
-        it('should return a date N days from the recent past, starting from refDate', () => {
-          const days = 30;
-          const refDate = new Date(2120, 11, 9, 10, 0, 0, 0); // set the date beyond the usual calculation (to make sure this is working correctly)
+        it.each(converterMap)(
+          'should return a date N days from the recent past, starting from refDate',
+          (converter) => {
+            const days = 30;
+            const refDate = new Date(2120, 11, 9, 10, 0, 0, 0); // set the date beyond the usual calculation (to make sure this is working correctly)
 
-          const lowerBound = new Date(
-            refDate.getTime() - days * 24 * 60 * 60 * 1000
-          );
+            const lowerBound = new Date(
+              refDate.getTime() - days * 24 * 60 * 60 * 1000
+            );
 
-          let date = faker.date.recent(days, refDate);
+            const date = faker.date.recent(days, converter(refDate));
 
-          expect(
-            lowerBound,
-            '`recent()` date should not be further back than `n` days ago'
-          ).lessThanOrEqual(date);
-          expect(
-            date,
-            '`recent()` date should not be ahead of the starting date reference'
-          ).lessThanOrEqual(refDate);
-
-          date = faker.date.recent(days, refDate.toISOString());
-
-          expect(
-            lowerBound,
-            '`recent()` date should not be further back than `n` days ago'
-          ).lessThanOrEqual(date);
-          expect(
-            date,
-            '`recent()` date should not be ahead of the starting date reference'
-          ).lessThanOrEqual(refDate);
-        });
+            expect(
+              lowerBound,
+              '`recent()` date should not be further back than `n` days ago'
+            ).lessThanOrEqual(date);
+            expect(
+              date,
+              '`recent()` date should not be ahead of the starting date reference'
+            ).lessThanOrEqual(refDate);
+          }
+        );
       });
 
       describe('soon()', () => {
@@ -515,36 +502,28 @@ describe('date', () => {
           expect(date).greaterThanOrEqual(new Date());
         });
 
-        it('should return a date N days from the recent future, starting from refDate', () => {
-          const days = 30;
-          const refDate = new Date(1880, 11, 9, 10, 0, 0, 0); // set the date beyond the usual calculation (to make sure this is working correctly)
+        it.each(converterMap)(
+          'should return a date N days from the recent future, starting from refDate',
+          (converter) => {
+            const days = 30;
+            const refDate = new Date(1880, 11, 9, 10, 0, 0, 0); // set the date beyond the usual calculation (to make sure this is working correctly)
 
-          const upperBound = new Date(
-            refDate.getTime() + days * 24 * 60 * 60 * 1000
-          );
+            const upperBound = new Date(
+              refDate.getTime() + days * 24 * 60 * 60 * 1000
+            );
 
-          let date = faker.date.soon(days, refDate);
+            const date = faker.date.soon(days, converter(refDate));
 
-          expect(
-            date,
-            '`soon()` date should not be further ahead than `n` days ago'
-          ).lessThanOrEqual(upperBound);
-          expect(
-            refDate,
-            '`soon()` date should not be behind the starting date reference'
-          ).lessThanOrEqual(date);
-
-          date = faker.date.soon(days, refDate.toISOString());
-
-          expect(
-            date,
-            '`soon()` date should not be further ahead than `n` days ago'
-          ).lessThanOrEqual(upperBound);
-          expect(
-            refDate,
-            '`soon()` date should not be behind the starting date reference'
-          ).lessThanOrEqual(date);
-        });
+            expect(
+              date,
+              '`soon()` date should not be further ahead than `n` days ago'
+            ).lessThanOrEqual(upperBound);
+            expect(
+              refDate,
+              '`soon()` date should not be behind the starting date reference'
+            ).lessThanOrEqual(date);
+          }
+        );
       });
 
       describe('month()', () => {


### PR DESCRIPTION
Reopen of #576 in favor of cleaner git history.

Created in relation to https://github.com/faker-js/faker/issues/394.

I changed the way dates are created from the `Date.parse` method to the `Date.constructor` since it uses that under the hood ([MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#parameters)). 
Invalid dates were not handled before.