### PR TITLE
refactor: drop usage of `fake` for internal calls

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -61,18 +61,17 @@ export class Git {
    */
   commitEntry(options: { merge?: boolean } = {}): string {
     // TODO @Shinigami92 2022-01-11: We may want to make it configurable to use just `\n` instead of `\r\n`
-    let entry = 'commit {{git.commitSha}}\r\n';
+    let entry = `commit ${this.commitSha()}\r\n`;
 
     if (options.merge || this.faker.datatype.number({ min: 0, max: 4 }) === 0) {
-      entry += 'Merge: {{git.shortSha}} {{git.shortSha}}\r\n';
+      entry += `Merge: ${this.shortSha()}} ${this.shortSha()}\r\n`;
     }
 
-    entry +=
-      'Author: {{name.firstName}} {{name.lastName}} <{{internet.email}}>\r\n';
-    entry += 'Date: ' + this.faker.date.recent().toString() + '\r\n';
-    entry += '\r\n\xa0\xa0\xa0\xa0{{git.commitMessage}}\r\n';
+    entry += `Author: ${this.faker.name.firstName()} ${this.faker.name.lastName()} <${this.faker.internet.email()}>\r\n`;
+    entry += `Date: ${this.faker.date.recent().toString()}\r\n`;
+    entry += `\r\n\xa0\xa0\xa0\xa0${this.commitMessage()}\r\n`;
 
-    return this.faker.fake(entry);
+    return entry;
   }
 
   /**
@@ -82,8 +81,7 @@ export class Git {
    * faker.git.commitMessage() // 'reboot cross-platform driver'
    */
   commitMessage(): string {
-    const format = '{{hacker.verb}} {{hacker.adjective}} {{hacker.noun}}';
-    return this.faker.fake(format);
+    return `${this.faker.hacker.verb()} ${this.faker.hacker.adjective()} ${this.faker.hacker.noun()}`;
   }
 
   /**

--- a/src/lorem.ts
+++ b/src/lorem.ts
@@ -175,17 +175,19 @@ export class Lorem {
    * // Dolor tempora iusto.'
    */
   text(): string {
-    const loremMethods = [
-      'lorem.word',
-      'lorem.words',
-      'lorem.sentence',
-      'lorem.sentences',
-      'lorem.paragraph',
-      'lorem.paragraphs',
-      'lorem.lines',
+    const methods: Array<keyof Lorem> = [
+      'word',
+      'words',
+      'sentence',
+      'sentences',
+      'paragraph',
+      'paragraphs',
+      'lines',
     ];
-    const randomLoremMethod = this.faker.random.arrayElement(loremMethods);
-    return this.faker.fake(`{{${randomLoremMethod}}}`);
+
+    const method = this.faker.random.arrayElement(methods);
+
+    return `${this[method]()}`;
   }
 
   /**

--- a/src/random.ts
+++ b/src/random.ts
@@ -244,37 +244,37 @@ export class Random {
    */
   word(): string {
     const wordMethods = [
-      'commerce.department',
-      'commerce.productName',
-      'commerce.productAdjective',
-      'commerce.productMaterial',
-      'commerce.product',
-      'commerce.color',
+      this.faker.commerce.department,
+      this.faker.commerce.productName,
+      this.faker.commerce.productAdjective,
+      this.faker.commerce.productMaterial,
+      this.faker.commerce.product,
+      this.faker.commerce.color,
 
-      'company.catchPhraseAdjective',
-      'company.catchPhraseDescriptor',
-      'company.catchPhraseNoun',
-      'company.bsAdjective',
-      'company.bsBuzz',
-      'company.bsNoun',
-      'address.streetSuffix',
-      'address.county',
-      'address.country',
-      'address.state',
+      this.faker.company.catchPhraseAdjective,
+      this.faker.company.catchPhraseDescriptor,
+      this.faker.company.catchPhraseNoun,
+      this.faker.company.bsAdjective,
+      this.faker.company.bsBuzz,
+      this.faker.company.bsNoun,
+      this.faker.address.streetSuffix,
+      this.faker.address.county,
+      this.faker.address.country,
+      this.faker.address.state,
 
-      'finance.accountName',
-      'finance.transactionType',
-      'finance.currencyName',
+      this.faker.finance.accountName,
+      this.faker.finance.transactionType,
+      this.faker.finance.currencyName,
 
-      'hacker.noun',
-      'hacker.verb',
-      'hacker.adjective',
-      'hacker.ingverb',
-      'hacker.abbreviation',
+      this.faker.hacker.noun,
+      this.faker.hacker.verb,
+      this.faker.hacker.adjective,
+      this.faker.hacker.ingverb,
+      this.faker.hacker.abbreviation,
 
-      'name.jobDescriptor',
-      'name.jobArea',
-      'name.jobType',
+      this.faker.name.jobDescriptor,
+      this.faker.name.jobArea,
+      this.faker.name.jobType,
     ];
 
     const bannedChars = [
@@ -302,11 +302,14 @@ export class Random {
       '-',
     ];
     let result: string;
+
     do {
       // randomly pick from the many faker methods that can generate words
       const randomWordMethod = this.faker.random.arrayElement(wordMethods);
-      result = this.faker.fake('{{' + randomWordMethod + '}}');
+
+      result = randomWordMethod();
     } while (bannedChars.some((char) => result.includes(char)));
+
     return this.faker.random.arrayElement(result.split(' '));
   }
 

--- a/src/system.ts
+++ b/src/system.ts
@@ -178,9 +178,7 @@ export class System {
    * faker.system.filePath() // '/usr/local/src/money.rmp.dotx'
    */
   filePath(): string {
-    return this.faker.fake(
-      '{{system.directoryPath}}/{{system.fileName}}.{{system.fileExt}}'
-    );
+    return `${this.faker.system.directoryPath()}/${this.faker.system.fileName()}.${this.faker.system.fileExt()}`;
   }
 
   /**


### PR DESCRIPTION
String templates would be faster, but also come with proper type checks and easier refactoring.