### PR TITLE
chore: rename phone.phoneNumber() to number()

### DIFF
--- a/src/phone.ts
+++ b/src/phone.ts
@@ -20,12 +20,12 @@ export class Phone {
    * @param format Format of the phone number. Defaults to `faker.phone.phoneFormats()`.
    *
    * @example
-   * faker.phone.phoneNumber() // '961-770-7727'
-   * faker.phone.phoneNumber('501-###-###') // '501-039-841'
-   * faker.phone.phoneNumber('+48 91 ### ## ##') // '+48 91 463 61 70'
+   * faker.phone.number() // '961-770-7727'
+   * faker.phone.number('501-###-###') // '501-039-841'
+   * faker.phone.number('+48 91 ### ## ##') // '+48 91 463 61 70'
    */
   // TODO @pkuczynski 2022-02-01: simplify name to `number()`
-  phoneNumber(format?: string): string {
+    number(format?: string): string {
     return this.faker.helpers.replaceSymbolWithNumber(
       format || this.phoneFormats()
     );


### PR DESCRIPTION
- Renamed  phoneNumber() to number()
 - changed deprecation warning
 # Ref : https://github.com/faker-js/faker/issues/693