### PR TITLE
feat: ```greekLetter()```

### DIFF
--- a/src/random.ts
+++ b/src/random.ts
@@ -630,5 +630,6 @@ export class Random {
     } else if (options.format === 'long') {
       return this.faker.random.arrayElement(longGreekLetters);
     }
+    return this.faker.random.arrayElement(shortGreekLetters);
   }
 }

--- a/src/random.ts
+++ b/src/random.ts
@@ -557,4 +557,78 @@ export class Random {
     });
     return this.faker.datatype.hexaDecimal(count);
   }
+
+  /**
+   * Returns a Greek letter.
+   *
+   * @param options The options to use. Defaults to `{ format: 'short' }`.
+   * @param options.format The format of the letter. Defaults to `'short'`.
+   *
+   * @example
+   * faker.random.greekLetter() // 'θ'
+   * faker.random.greekLetter({ format: 'short' }) // 'ε'
+   * faker.random.greekLetter({ format: 'long' }) // 'lambda'
+   *
+   */
+  greekLetter(options?: { format: 'long' | 'short' }): string {
+    options.format = options.format || 'short';
+    const shortGreekLetters = [
+      'α',
+      'β',
+      'γ',
+      'δ',
+      'ε',
+      'ζ',
+      'η',
+      'θ',
+      'ι',
+      'κ',
+      'λ',
+      'μ',
+      'ν',
+      'ξ',
+      'ο',
+      'π',
+      'ρ',
+      'σ',
+      'τ',
+      'υ',
+      'φ',
+      'χ',
+      'ψ',
+      'ω',
+    ];
+    const longGreekLetters = [
+      'alpha',
+      'beta',
+      'gamma',
+      'delta',
+      'epsilon',
+      'zeta',
+      'eta',
+      'theta',
+      'iota',
+      'kappa',
+      'lambda',
+      'mu',
+      'nu',
+      'xi',
+      'omicron',
+      'pi',
+      'rho',
+      'sigma',
+      'tau',
+      'upsilon',
+      'phi',
+      'chi',
+      'psi',
+      'omega',
+    ];
+
+    if (options.format === 'short') {
+      return this.faker.random.arrayElement(shortGreekLetters);
+    } else if (options.format === 'long') {
+      return this.faker.random.arrayElement(longGreekLetters);
+    }
+  }
 }

--- a/test/random.spec.ts
+++ b/test/random.spec.ts
@@ -278,6 +278,17 @@ describe('random', () => {
     });
   });
 
+  describe('greekLetter', () => {
+    it('should return a single letter', () => {
+      const greekLetter = faker.random.greekLetter();
+      // if greekLetter does not start with an English alphabet letter,
+      // check if greekLetter has only one character (Greek letters are only one character)
+      if (!/[a-zA-Z]/.test(greekLetter)) {
+        expect(greekLetter).toHaveLength(1);
+      }
+    });
+  });
+
   describe('deprecation warnings', () => {
     it.each([
       ['number', 'datatype.number'],


### PR DESCRIPTION
fixes #558

How would I write tests for this? I was planning on using Vitest's ```toContain``` method, but according to the Vitest docs, toContain only accepts a string parameter, and I was planning on feeding an array of Greek letters to it. My current method is a somewhat workaround, but it's super janky. Any ideas?