### PR TITLE
chore: do not eslint src/vendor/*

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = defineConfig({
   ignorePatterns: [
     ...readGitignoreFiles(),
     '.eslintrc.js', // Skip self linting
+    'src/vendor/**/*'
   ],
   root: true,
   env: {


### PR DESCRIPTION
There is no point in eslinting external libraries, right? 

Takes down number of eslint errors from 71 to 60