### PR TITLE
chore: remove useless fallback to undefined

### DIFF
--- a/src/faker.ts
+++ b/src/faker.ts
@@ -96,8 +96,8 @@ export class Faker {
     }
 
     this.locales = opts.locales;
-    this.locale = this.locale || opts.locale || 'en';
-    this.localeFallback = this.localeFallback || opts.localeFallback || 'en';
+    this.locale = opts.locale || 'en';
+    this.localeFallback = opts.localeFallback || 'en';
 
     this.loadDefinitions();
   }


### PR DESCRIPTION
Before we set `this.locale` it is undefined, so there is no need to use it as a fallback.