### PR TITLE
chore: deprecate name.title() in favor of name.jobTitle()

### DIFF
--- a/src/name.ts
+++ b/src/name.ts
@@ -284,23 +284,22 @@ export class Name {
   }
 
   /**
-   * Generates a random title.
+   * Generates a random job title.
    *
    * @example
    * faker.name.title() // 'International Integration Manager'
+   *
+   * @deprecated
    */
   title(): string {
-    const descriptor = this.faker.random.arrayElement(
-      this.faker.definitions.name.title.descriptor
-    );
-    const level = this.faker.random.arrayElement(
-      this.faker.definitions.name.title.level
-    );
-    const job = this.faker.random.arrayElement(
-      this.faker.definitions.name.title.job
-    );
+    deprecated({
+      deprecated: 'faker.name.title()',
+      proposed: 'faker.name.jobTitle()',
+      since: 'v6.1.2',
+      until: 'v7.0.0',
+    });
 
-    return descriptor + ' ' + level + ' ' + job;
+    return this.jobTitle();
   }
 
   /**
@@ -310,13 +309,7 @@ export class Name {
    * faker.name.jobTitle() // 'Global Accounts Engineer'
    */
   jobTitle(): string {
-    return (
-      this.faker.name.jobDescriptor() +
-      ' ' +
-      this.faker.name.jobArea() +
-      ' ' +
-      this.faker.name.jobType()
-    );
+    return this.jobDescriptor() + ' ' + this.jobArea() + ' ' + this.jobType();
   }
 
   /**

--- a/test/name.spec.ts
+++ b/test/name.spec.ts
@@ -519,6 +519,28 @@ describe('name', () => {
           faker.localeFallback = 'en';
         });
 
+        it('should display deprecated message', () => {
+          const spy = vi.spyOn(console, 'warn');
+
+          faker.name.title();
+
+          expect(spy).toHaveBeenCalledWith(
+            '[@faker-js/faker]: faker.name.title() is deprecated since v6.1.2 and will be removed in v7.0.0. Please use faker.name.jobTitle() instead.'
+          );
+
+          spy.mockRestore();
+        });
+
+        it('should call jobTitle()', () => {
+          const spy = vi.spyOn(faker.name, 'jobTitle');
+
+          faker.name.title();
+
+          expect(spy).toHaveBeenCalledWith();
+
+          spy.mockRestore();
+        });
+
         it('should return a title consisting of a descriptor, area, and type', () => {
           const title = faker.name.title();
 
@@ -526,7 +548,6 @@ describe('name', () => {
 
           const [descriptor, level, job] = title.split(' ');
 
-          // TODO @Shinigami92 2022-01-31: jobTitle and title are the same
           expect(faker.definitions.name.title.descriptor).toContain(descriptor);
           expect(faker.definitions.name.title.level).toContain(level);
           expect(faker.definitions.name.title.job).toContain(job);


### PR DESCRIPTION
Ref: #541 