### PR TITLE
fix: use `\n` as default separator for lorem.paragraphs()

### DIFF
--- a/src/lorem.ts
+++ b/src/lorem.ts
@@ -134,7 +134,7 @@ export class Lorem {
    * Generates the given number of paragraphs.
    *
    * @param paragraphCount The number of paragraphs to generate. Defaults to `3`.
-   * @param separator The separator to use. Defaults to `'\r\n'`.
+   * @param separator The separator to use. Defaults to `'\n'`.
    *
    * @example
    * faker.lorem.paragraphs()
@@ -153,7 +153,7 @@ export class Lorem {
    * // 'Eos magnam aut qui accusamus. Sapiente quas culpa totam excepturi. Blanditiis totam distinctio occaecati dignissimos cumque atque qui officiis.<br/>
    * // Nihil quis vel consequatur. Blanditiis commodi deserunt sunt animi dolorum. A optio porro hic dolorum fugit aut et sint voluptas. Minima ad sed ipsa est non dolores.'
    */
-  paragraphs(paragraphCount: number = 3, separator: string = '\r\n'): string {
+  paragraphs(paragraphCount: number = 3, separator: string = '\n'): string {
     const paragraphs: string[] = [];
     for (paragraphCount; paragraphCount > 0; paragraphCount--) {
       paragraphs.push(this.faker.lorem.paragraph());

--- a/src/lorem.ts
+++ b/src/lorem.ts
@@ -134,7 +134,7 @@ export class Lorem {
    * Generates the given number of paragraphs.
    *
    * @param paragraphCount The number of paragraphs to generate. Defaults to `3`.
-   * @param separator The separator to use. Defaults to `'\n \r'`.
+   * @param separator The separator to use. Defaults to `'\r\n'`.
    *
    * @example
    * faker.lorem.paragraphs()
@@ -153,8 +153,7 @@ export class Lorem {
    * // 'Eos magnam aut qui accusamus. Sapiente quas culpa totam excepturi. Blanditiis totam distinctio occaecati dignissimos cumque atque qui officiis.<br/>
    * // Nihil quis vel consequatur. Blanditiis commodi deserunt sunt animi dolorum. A optio porro hic dolorum fugit aut et sint voluptas. Minima ad sed ipsa est non dolores.'
    */
-  // TODO ST-DDT 2022-02-09: The separator looks odd.
-  paragraphs(paragraphCount: number = 3, separator: string = '\n \r'): string {
+  paragraphs(paragraphCount: number = 3, separator: string = '\r\n'): string {
     const paragraphs: string[] = [];
     for (paragraphCount; paragraphCount > 0; paragraphCount--) {
       paragraphs.push(this.faker.lorem.paragraph());

--- a/test/lorem.spec.ts
+++ b/test/lorem.spec.ts
@@ -19,7 +19,7 @@ const seededRuns = [
         'Hic sit minus dolor animi mollitia sequi ducimus sequi. Inventore praesentium et. Animi qui impedit et voluptatem. Ut quisquam fugiat.',
         'Alias sit asperiores sit. Corporis laborum cupiditate consequatur et voluptatem nostrum. Laborum in eos quae nostrum aut consequatur. Blanditiis sunt repellendus et. Eum sint voluptatibus deserunt. Quae eos est soluta ipsum qui.',
         'Hic earum delectus. Consequatur eum corporis perferendis aspernatur incidunt nobis. Odio nobis quia est.',
-      ].join('\n \r'),
+      ].join('\n'),
       text: 'Hic sit minus dolor animi mollitia sequi ducimus sequi.',
       lines: [
         'Hic sit minus dolor animi mollitia sequi ducimus sequi.',
@@ -42,7 +42,7 @@ const seededRuns = [
         'Nesciunt non minima perspiciatis praesentium aperiam voluptatem. Occaecati deserunt voluptatem suscipit. Enim minus nemo fugit et iure explicabo et commodi consequuntur. Voluptatibus nesciunt dignissimos eos temporibus temporibus autem consequatur.',
         'Esse vel qui occaecati omnis quis. Voluptatum quis et libero. Et odio dolor qui velit qui. Eveniet provident non fugiat.',
         'A a aut nihil. Quas eligendi excepturi eligendi perferendis quo minus et asperiores. Neque blanditiis consequuntur esse autem harum eligendi aut. Cum consequatur pariatur. Omnis temporibus sapiente.',
-      ].join('\n \r'),
+      ].join('\n'),
       text: 'natus nesciunt non',
       lines: [
         'Nesciunt non minima perspiciatis praesentium aperiam voluptatem.',
@@ -66,7 +66,7 @@ const seededRuns = [
         'Saepe omnis tempora magni repellat eaque. Nesciunt nobis non voluptas quam ex neque eligendi. Vel perferendis assumenda nam expedita est eum molestiae. Ullam et maiores vero doloribus eius. Officia et velit voluptatem quis dolorum. Dignissimos voluptas aut qui corporis itaque sit provident quam aut.',
         'In ullam quia impedit. Occaecati repudiandae ut maiores pariatur enim. Deserunt voluptatem in enim in quia.',
         'Ut eligendi tempora eos ipsa cumque nulla. Quidem et sed voluptate et quia. Nulla esse in similique deleniti beatae eaque.',
-      ].join('\n \r'),
+      ].join('\n'),
       text: [
         'Omnis tempora magni repellat eaque tempore nesciunt nobis non voluptas.',
         'Ex neque eligendi placeat vel perferendis.',
@@ -320,7 +320,7 @@ describe('lorem', () => {
           expect(actual).toBeTypeOf('string');
           expect(actual[actual.length - 1]).toBe('.');
 
-          const paragraphs = actual.split('\n \r');
+          const paragraphs = actual.split('\n');
 
           expect(paragraphs).toHaveLength(paragraphCount);
         });


### PR DESCRIPTION
As an alternative, we could use the current system `EOL` (or just `\n`).

Ref: #541