### PR TITLE
docs: fix mersenne rand min max confusion

### DIFF
--- a/src/modules/mersenne/index.ts
+++ b/src/modules/mersenne/index.ts
@@ -20,14 +20,14 @@ export class Mersenne {
   }
 
   /**
-   * Generates a random number between `[min, max)`.
+   * Generates a random number between `[max, min)`.
    *
    * @param max The maximum number. Defaults to `0`.
    * @param min The minimum number. Defaults to `32768`.
    *
    * @example
    * faker.mersenne.rand() // 15515
-   * faker.mersenne.rand(500, 1000) // 578
+   * faker.mersenne.rand(1000, 500) // 578
    */
   rand(max = 32768, min = 0): number {
     if (min > max) {

--- a/src/modules/mersenne/index.ts
+++ b/src/modules/mersenne/index.ts
@@ -20,10 +20,10 @@ export class Mersenne {
   }
 
   /**
-   * Generates a random number between `[max, min)`.
+   * Generates a random number between `[min, max)`.
    *
-   * @param max The maximum number. Defaults to `0`.
-   * @param min The minimum number. Defaults to `32768`.
+   * @param max The maximum number. Defaults to `32768`.
+   * @param min The minimum number. Defaults to `0`.
    *
    * @example
    * faker.mersenne.rand() // 15515


### PR DESCRIPTION
although mersenne automatically swap the value if min is bigger than max, but it's a good practice to clear out the confusion.

Fix #775