### PR TITLE
build!: remove node v12 support

### DIFF
--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -33,7 +33,7 @@ buildSync({
   // splitting: true, // Doesn't work with cjs
   format: 'cjs',
   platform: 'node',
-  target: 'node12',
+  target: 'node14',
 });
 
 console.log('Building dist for node type=module (esm)...');
@@ -48,6 +48,6 @@ buildSync({
   minify: true,
   splitting: true,
   format: 'esm',
-  target: 'node12.20',
+  target: 'node14',
   outExtension: { '.js': '.mjs' },
 });


### PR DESCRIPTION
Fully remove support for node v12

For upgrade to node v18 see #847 