### PR TITLE
test: use consistent assertion functions

### DIFF
--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -373,12 +373,12 @@ describe('address', () => {
         it('returns random zipCode - user specified format', () => {
           let zipCode = faker.address.zipCode('?#? #?#');
 
-          expect(zipCode).match(/^[A-Za-z]\d[A-Za-z]\s\d[A-Za-z]\d$/);
+          expect(zipCode).toMatch(/^[A-Za-z]\d[A-Za-z]\s\d[A-Za-z]\d$/);
 
           // try another format
           zipCode = faker.address.zipCode('###-###');
 
-          expect(zipCode).match(/^\d{3}-\d{3}$/);
+          expect(zipCode).toMatch(/^\d{3}-\d{3}$/);
         });
 
         it('returns zipCode with proper locale format', () => {
@@ -386,7 +386,7 @@ describe('address', () => {
           faker.locale = 'en_CA';
           const zipCode = faker.address.zipCode();
 
-          expect(zipCode).match(/^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/);
+          expect(zipCode).toMatch(/^[A-Za-z]\d[A-Za-z]\s?\d[A-Za-z]\d$/);
         });
       });
 
@@ -396,16 +396,16 @@ describe('address', () => {
           const states = ['IL', 'GA', 'WA'];
 
           const zipCode1 = +faker.address.zipCodeByState(states[0]);
-          expect(zipCode1).greaterThanOrEqual(60001);
-          expect(zipCode1).lessThanOrEqual(62999);
+          expect(zipCode1).toBeGreaterThanOrEqual(60001);
+          expect(zipCode1).toBeLessThanOrEqual(62999);
 
           const zipCode2 = +faker.address.zipCodeByState(states[1]);
-          expect(zipCode2).greaterThanOrEqual(30001);
-          expect(zipCode2).lessThanOrEqual(31999);
+          expect(zipCode2).toBeGreaterThanOrEqual(30001);
+          expect(zipCode2).toBeLessThanOrEqual(31999);
 
           const zipCode3 = +faker.address.zipCodeByState(states[2]);
-          expect(zipCode3).greaterThanOrEqual(98001);
-          expect(zipCode3).lessThanOrEqual(99403);
+          expect(zipCode3).toBeGreaterThanOrEqual(98001);
+          expect(zipCode3).toBeLessThanOrEqual(99403);
         });
       });
 
@@ -418,8 +418,8 @@ describe('address', () => {
 
             const latitude_float = parseFloat(latitude);
 
-            expect(latitude_float).greaterThanOrEqual(-90.0);
-            expect(latitude_float).lessThanOrEqual(90.0);
+            expect(latitude_float).toBeGreaterThanOrEqual(-90.0);
+            expect(latitude_float).toBeLessThanOrEqual(90.0);
           }
         });
 
@@ -435,8 +435,8 @@ describe('address', () => {
 
             const latitude_float = parseFloat(latitude);
 
-            expect(latitude_float).greaterThanOrEqual(-5);
-            expect(latitude_float).lessThanOrEqual(5);
+            expect(latitude_float).toBeGreaterThanOrEqual(-5);
+            expect(latitude_float).toBeLessThanOrEqual(5);
           }
         });
 
@@ -452,8 +452,8 @@ describe('address', () => {
 
             const latitude_float = parseFloat(latitude);
 
-            expect(latitude_float).greaterThanOrEqual(-180);
-            expect(latitude_float).lessThanOrEqual(180);
+            expect(latitude_float).toBeGreaterThanOrEqual(-180);
+            expect(latitude_float).toBeLessThanOrEqual(180);
           }
         });
       });
@@ -467,8 +467,8 @@ describe('address', () => {
 
             const longitude_float = parseFloat(longitude);
 
-            expect(longitude_float).greaterThanOrEqual(-180);
-            expect(longitude_float).lessThanOrEqual(180);
+            expect(longitude_float).toBeGreaterThanOrEqual(-180);
+            expect(longitude_float).toBeLessThanOrEqual(180);
           }
         });
 
@@ -484,8 +484,8 @@ describe('address', () => {
 
             const longitude_float = parseFloat(longitude);
 
-            expect(longitude_float).greaterThanOrEqual(-30);
-            expect(longitude_float).lessThanOrEqual(100);
+            expect(longitude_float).toBeGreaterThanOrEqual(-30);
+            expect(longitude_float).toBeLessThanOrEqual(100);
           }
         });
 
@@ -501,8 +501,8 @@ describe('address', () => {
 
             const longitude_float = parseFloat(longitude);
 
-            expect(longitude_float).greaterThanOrEqual(-180);
-            expect(longitude_float).lessThanOrEqual(180);
+            expect(longitude_float).toBeGreaterThanOrEqual(-180);
+            expect(longitude_float).toBeLessThanOrEqual(180);
           }
         });
       });
@@ -518,7 +518,7 @@ describe('address', () => {
             direction,
             `${prefixErrorMessage} be of type string. Current is ${typeof direction}`
           ).toBeTypeOf('string');
-          expect(lengthDirection).lessThanOrEqual(2);
+          expect(lengthDirection).toBeLessThanOrEqual(2);
         });
       });
 
@@ -534,7 +534,7 @@ describe('address', () => {
             ordinalDirection,
             `${prefixErrorMessage} be equal ${expectedType}. Current is ${typeof ordinalDirection}`
           ).toBeTypeOf(expectedType);
-          expect(ordinalDirectionLength).lessThanOrEqual(2);
+          expect(ordinalDirectionLength).toBeLessThanOrEqual(2);
         });
       });
 
@@ -550,7 +550,7 @@ describe('address', () => {
             cardinalDirection,
             `${prefixErrorMessage} be of type ${expectedType}. Current is ${typeof cardinalDirection}`
           ).toBeTypeOf(expectedType);
-          expect(cardinalDirectionLength).lessThanOrEqual(2);
+          expect(cardinalDirectionLength).toBeLessThanOrEqual(2);
         });
       });
 
@@ -598,12 +598,12 @@ describe('address', () => {
             expect(coordinate[1]).toBeTypeOf('string');
 
             const latFloat2 = parseFloat(coordinate[0]);
-            expect(latFloat2).greaterThanOrEqual(-90.0);
-            expect(latFloat2).lessThanOrEqual(90.0);
+            expect(latFloat2).toBeGreaterThanOrEqual(-90.0);
+            expect(latFloat2).toBeLessThanOrEqual(90.0);
 
             const lonFloat2 = parseFloat(coordinate[1]);
-            expect(lonFloat2).greaterThanOrEqual(-180.0);
-            expect(lonFloat2).lessThanOrEqual(180.0);
+            expect(lonFloat2).toBeGreaterThanOrEqual(-180.0);
+            expect(lonFloat2).toBeLessThanOrEqual(180.0);
 
             // Due to floating point math, and constants that are not extremely precise,
             // returned points will not be strictly within the given radius of the input
@@ -616,7 +616,7 @@ describe('address', () => {
               lonFloat2,
               isMetric
             );
-            expect(actualDistance).lessThanOrEqual(radius + error);
+            expect(actualDistance).toBeLessThanOrEqual(radius + error);
           }
         });
 
@@ -639,7 +639,7 @@ describe('address', () => {
             Math.pow(+coordinate[0] - latitude, 2) +
             Math.pow(+coordinate[1] - longitude, 2);
 
-          expect(distanceToTarget).lessThanOrEqual(
+          expect(distanceToTarget).toBeLessThanOrEqual(
             100 * 0.002 // 100 km ~= 0.9 degrees, we take 2 degrees
           );
         });
@@ -664,7 +664,7 @@ describe('address', () => {
           //   Math.pow(coordinate[1] - longitude, 2);
 
           // TODO @Shinigami92 2022-01-27: Investigate why this test sometimes fails
-          // expect(distanceToTarget).lessThanOrEqual(
+          // expect(distanceToTarget).toBeLessThanOrEqual(
           //   100 * 0.002 * 1.6093444978925633 // 100 miles to km ~= 0.9 degrees, we take 2 degrees
           // );
         });

--- a/test/commerce.spec.ts
+++ b/test/commerce.spec.ts
@@ -101,7 +101,7 @@ describe('commerce', () => {
       describe(`productName()`, () => {
         it('should return random values from product arrays', () => {
           const name = faker.commerce.productName();
-          expect(name.split(' ').length).greaterThanOrEqual(3);
+          expect(name.split(' ').length).toBeGreaterThanOrEqual(3);
 
           const parts = name.split(' ');
           expect(faker.definitions.commerce.product_name.adjective).toContain(
@@ -122,8 +122,8 @@ describe('commerce', () => {
 
           expect(price).toBeTruthy();
           expect(price).toBeTypeOf('string');
-          expect(+price).greaterThan(0);
-          expect(+price).lessThanOrEqual(1000);
+          expect(+price).toBeGreaterThan(0);
+          expect(+price).toBeLessThanOrEqual(1000);
         });
 
         it('should use the default decimal location when not passing arguments', () => {

--- a/test/company.spec.ts
+++ b/test/company.spec.ts
@@ -155,7 +155,7 @@ describe('company', () => {
 
           const parts = actual.split(' ');
 
-          expect(parts.length).greaterThanOrEqual(3);
+          expect(parts.length).toBeGreaterThanOrEqual(3);
         });
       });
 
@@ -168,7 +168,7 @@ describe('company', () => {
 
           const parts = actual.split(' ');
 
-          expect(parts.length).greaterThanOrEqual(3);
+          expect(parts.length).toBeGreaterThanOrEqual(3);
         });
       });
 

--- a/test/datatype.spec.ts
+++ b/test/datatype.spec.ts
@@ -434,8 +434,8 @@ describe('datatype', () => {
 
           const actual = faker.datatype.number(max);
 
-          expect(actual).greaterThanOrEqual(0);
-          expect(actual).lessThanOrEqual(max);
+          expect(actual).toBeGreaterThanOrEqual(0);
+          expect(actual).toBeLessThanOrEqual(max);
         });
 
         it('should return a random number given a maximum value as Object', () => {
@@ -443,8 +443,8 @@ describe('datatype', () => {
 
           const actual = faker.datatype.number(options);
 
-          expect(actual).greaterThanOrEqual(0);
-          expect(actual).lessThanOrEqual(options.max);
+          expect(actual).toBeGreaterThanOrEqual(0);
+          expect(actual).toBeLessThanOrEqual(options.max);
         });
 
         it('should return a random number given a maximum value of 0', () => {
@@ -460,16 +460,16 @@ describe('datatype', () => {
 
           const actual = faker.datatype.number(options);
 
-          expect(actual).greaterThanOrEqual(options.min);
-          expect(actual).lessThanOrEqual(options.max);
+          expect(actual).toBeGreaterThanOrEqual(options.min);
+          expect(actual).toBeLessThanOrEqual(options.max);
         });
 
         it('should return a random number between a range', () => {
           const options = { min: 22, max: 33 };
           for (let i = 0; i < 100; i++) {
             const actual = faker.datatype.number(options);
-            expect(actual).greaterThanOrEqual(options.min);
-            expect(actual).lessThanOrEqual(options.max);
+            expect(actual).toBeGreaterThanOrEqual(options.min);
+            expect(actual).toBeLessThanOrEqual(options.max);
           }
         });
 
@@ -486,8 +486,8 @@ describe('datatype', () => {
               foundNegative5 = true;
             }
 
-            expect(actual).greaterThanOrEqual(-5);
-            expect(actual).lessThanOrEqual(-4);
+            expect(actual).toBeGreaterThanOrEqual(-5);
+            expect(actual).toBeLessThanOrEqual(-4);
 
             if (foundNegative4 && foundNegative5) {
               break;
@@ -553,8 +553,10 @@ describe('datatype', () => {
 
         it('should return a random number given a maximum value as Object', () => {
           const options = { max: 10 };
-          expect(faker.datatype.float(options)).greaterThanOrEqual(0);
-          expect(faker.datatype.float(options)).lessThanOrEqual(options.max);
+          expect(faker.datatype.float(options)).toBeGreaterThanOrEqual(0);
+          expect(faker.datatype.float(options)).toBeLessThanOrEqual(
+            options.max
+          );
         });
 
         it('should return a random number given a maximum value of 0', () => {
@@ -564,16 +566,20 @@ describe('datatype', () => {
 
         it('should return a random number given a negative number minimum and maximum value of 0', () => {
           const options = { min: -100, max: 0 };
-          expect(faker.datatype.float(options)).greaterThanOrEqual(options.min);
-          expect(faker.datatype.float(options)).lessThanOrEqual(options.max);
+          expect(faker.datatype.float(options)).toBeGreaterThanOrEqual(
+            options.min
+          );
+          expect(faker.datatype.float(options)).toBeLessThanOrEqual(
+            options.max
+          );
         });
 
         it('should return a random number between a range', () => {
           const options = { min: 22, max: 33 };
           for (let i = 0; i < 5; i++) {
             const randomNumber = faker.datatype.float(options);
-            expect(randomNumber).greaterThanOrEqual(options.min);
-            expect(randomNumber).lessThanOrEqual(options.max);
+            expect(randomNumber).toBeGreaterThanOrEqual(options.min);
+            expect(randomNumber).toBeLessThanOrEqual(options.max);
           }
         });
 
@@ -654,7 +660,7 @@ describe('datatype', () => {
           const UUID = faker.datatype.uuid();
           const RFC4122 =
             /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-          expect(UUID).match(RFC4122);
+          expect(UUID).toMatch(RFC4122);
         });
       });
 
@@ -685,13 +691,13 @@ describe('datatype', () => {
       describe('hexadecimal', () => {
         it('generates single hex character when no additional argument was provided', () => {
           const hex = faker.datatype.hexadecimal();
-          expect(hex).match(/^(0x)[0-9a-f]{1}$/i);
+          expect(hex).toMatch(/^(0x)[0-9a-f]{1}$/i);
           expect(hex.substring(2)).toHaveLength(1);
         });
 
         it('generates a random hex string', () => {
           const hex = faker.datatype.hexadecimal(5);
-          expect(hex).match(/^(0x)[0-9a-f]+$/i);
+          expect(hex).toMatch(/^(0x)[0-9a-f]+$/i);
           expect(hex.substring(2)).toHaveLength(5);
         });
       });

--- a/test/fake.spec.ts
+++ b/test/fake.spec.ts
@@ -6,14 +6,14 @@ describe('fake', () => {
   describe('fake()', () => {
     it('replaces a token with a random value for a method with no parameters', () => {
       const name = faker.fake('{{phone.phoneNumber}}');
-      expect(name).match(/\d/);
+      expect(name).toMatch(/\d/);
     });
 
     it('replaces multiple tokens with random values for methods with no parameters', () => {
       const name = faker.fake(
         '{{helpers.randomize}}{{helpers.randomize}}{{helpers.randomize}}'
       );
-      expect(name).match(/[abc]{3}/);
+      expect(name).toMatch(/[abc]{3}/);
     });
 
     it('replaces a token with a random value for a methods with a simple parameter', () => {

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -208,8 +208,13 @@ describe('finance', () => {
 
           expect(amount).toBeTruthy();
           expect(amount).toBeTypeOf('string');
-          expect(+amount, 'the amount should be greater than 0').greaterThan(0);
-          expect(+amount, 'the amount should be less than 1001').lessThan(1001);
+          expect(
+            +amount,
+            'the amount should be greater than 0'
+          ).toBeGreaterThan(0);
+          expect(+amount, 'the amount should be less than 1001').toBeLessThan(
+            1001
+          );
         });
 
         it('should use the default decimal location when not passing arguments', () => {
@@ -238,10 +243,11 @@ describe('finance', () => {
 
           expect(amount).toBeTruthy();
           expect(amount).toBeTypeOf('string');
-          expect(+amount, 'the amount should be less than 0').lessThan(0);
-          expect(+amount, 'the amount should be greater than -201').greaterThan(
-            -201
-          );
+          expect(+amount, 'the amount should be less than 0').toBeLessThan(0);
+          expect(
+            +amount,
+            'the amount should be greater than -201'
+          ).toBeGreaterThan(-201);
         });
 
         it('it should handle argument dec', () => {
@@ -317,7 +323,7 @@ describe('finance', () => {
           const currencyCode = faker.finance.currencyCode();
 
           expect(currencyCode).toBeTypeOf('string');
-          expect(currencyCode).match(/^[A-Z]{3}$/);
+          expect(currencyCode).toMatch(/^[A-Z]{3}$/);
         });
       });
 
@@ -347,7 +353,7 @@ describe('finance', () => {
 
           expect(bitcoinAddress).toBeTruthy();
           expect(bitcoinAddress).toBeTypeOf('string');
-          expect(bitcoinAddress).match(/^[13][a-km-zA-HJ-NP-Z1-9]{24,33}$/);
+          expect(bitcoinAddress).toMatch(/^[13][a-km-zA-HJ-NP-Z1-9]{24,33}$/);
         });
       });
 
@@ -356,7 +362,7 @@ describe('finance', () => {
           const litecoinAddress = faker.finance.litecoinAddress();
 
           expect(litecoinAddress).toBeTypeOf('string');
-          expect(litecoinAddress).match(/^[LM3][1-9a-km-zA-HJ-NP-Z]{25,32}$/);
+          expect(litecoinAddress).toMatch(/^[LM3][1-9a-km-zA-HJ-NP-Z]{25,32}$/);
         });
       });
 
@@ -366,9 +372,9 @@ describe('finance', () => {
           number = number.replace(/\D/g, ''); // remove formatting
           console.log('version:', process.version, number, number.length);
 
-          expect(number.length).greaterThanOrEqual(13);
-          expect(number.length).lessThanOrEqual(20);
-          expect(number).match(/^\d{13,20}$/);
+          expect(number.length).toBeGreaterThanOrEqual(13);
+          expect(number.length).toBeLessThanOrEqual(20);
+          expect(number).toMatch(/^\d{13,20}$/);
           expect(luhnCheck(number)).toBeTruthy();
         });
 
@@ -403,11 +409,11 @@ describe('finance', () => {
         it('should return a correct credit card number when issuer provided', () => {
           //TODO: implement checks for each format with regexp
           const visa = faker.finance.creditCardNumber('visa');
-          expect(visa).match(/^4(([0-9]){12}|([0-9]){3}(\-([0-9]){4}){3})$/);
+          expect(visa).toMatch(/^4(([0-9]){12}|([0-9]){3}(\-([0-9]){4}){3})$/);
           expect(luhnCheck(visa)).toBeTruthy();
 
           const mastercard = faker.finance.creditCardNumber('mastercard');
-          expect(mastercard).match(/^(5[1-5]\d{2}|6771)(\-\d{4}){3}$/);
+          expect(mastercard).toMatch(/^(5[1-5]\d{2}|6771)(\-\d{4}){3}$/);
           expect(luhnCheck(mastercard)).toBeTruthy();
 
           const discover = faker.finance.creditCardNumber('discover');
@@ -435,11 +441,11 @@ describe('finance', () => {
 
         it('should return custom formatted strings', () => {
           let number = faker.finance.creditCardNumber('###-###-##L');
-          expect(number).match(/^\d{3}\-\d{3}\-\d{3}$/);
+          expect(number).toMatch(/^\d{3}\-\d{3}\-\d{3}$/);
           expect(luhnCheck(number)).toBeTruthy();
 
           number = faker.finance.creditCardNumber('234[5-9]#{999}L');
-          expect(number).match(/^234[5-9]\d{1000}$/);
+          expect(number).toMatch(/^234[5-9]\d{1000}$/);
           expect(luhnCheck(number)).toBeTruthy();
         });
       });
@@ -449,7 +455,7 @@ describe('finance', () => {
           const cvv = faker.finance.creditCardCVV();
 
           expect(cvv).toBeTypeOf('string');
-          expect(cvv).match(/\d{3}/);
+          expect(cvv).toMatch(/\d{3}/);
           expect(
             cvv,
             'The length of the cvv should be 3 characters long'
@@ -490,7 +496,7 @@ describe('finance', () => {
           const ethereumAddress = faker.finance.ethereumAddress();
 
           expect(ethereumAddress).toBeTypeOf('string');
-          expect(ethereumAddress).match(/^(0x)[0-9a-f]{40}$/);
+          expect(ethereumAddress).toMatch(/^(0x)[0-9a-f]{40}$/);
         });
       });
 
@@ -541,7 +547,7 @@ describe('finance', () => {
           );
 
           expect(bic).toBeTypeOf('string');
-          expect(bic).match(expr);
+          expect(bic).toMatch(expr);
         });
       });
 

--- a/test/finance_iban.spec.ts
+++ b/test/finance_iban.spec.ts
@@ -15,7 +15,7 @@ describe('finance_iban', () => {
       const actual = faker.finance.iban(true, country);
 
       expect(actual).toMatch(new RegExp(`^${country}`));
-      expect(actual).satisfy(validator.isIBAN);
+      expect(actual).toSatisfy(validator.isIBAN);
     });
   });
 
@@ -37,7 +37,7 @@ describe('finance_iban', () => {
 
           const iban = faker.finance.iban(false, 'GE');
 
-          expect(iban).satisfy(validator.isIBAN);
+          expect(iban).toSatisfy(validator.isIBAN);
 
           const ibanFormatted = iban.match(/.{1,4}/g).join(' ');
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -53,28 +53,28 @@ describe('finance_iban', () => {
               0,
               2
             )} must contains only characters in GE IBAN ${ibanFormatted}`
-          ).match(/^[A-Z]{2}$/);
+          ).toMatch(/^[A-Z]{2}$/);
           expect(
             iban.substring(2, 4),
             `${iban.substring(
               2,
               4
             )} must contains only digit in GE IBAN ${ibanFormatted}`
-          ).match(/^\d{2}$/);
+          ).toMatch(/^\d{2}$/);
           expect(
             iban.substring(4, 6),
             `${iban.substring(
               4,
               6
             )} must contains only characters in GE IBAN ${ibanFormatted}`
-          ).match(/^[A-Z]{2}$/);
+          ).toMatch(/^[A-Z]{2}$/);
           expect(
             iban.substring(6, 24),
             `${iban.substring(
               6,
               24
             )} must contains only characters in GE IBAN ${ibanFormatted}`
-          ).match(/^\d{16}$/);
+          ).toMatch(/^\d{16}$/);
 
           expect(
             ibanLib.mod97(ibanLib.toDigitString(bban)),
@@ -97,7 +97,7 @@ describe('finance_iban', () => {
 
           const iban = faker.finance.iban(false, 'PK');
 
-          expect(iban).satisfy(validator.isIBAN);
+          expect(iban).toSatisfy(validator.isIBAN);
 
           const ibanFormated = iban.match(/.{1,4}/g).join(' ');
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -113,28 +113,28 @@ describe('finance_iban', () => {
               0,
               2
             )} must contains only characters in PK IBAN ${ibanFormated}`
-          ).match(/^[A-Z]{2}$/);
+          ).toMatch(/^[A-Z]{2}$/);
           expect(
             iban.substring(2, 4),
             `${iban.substring(
               2,
               4
             )} must contains only digit in PK IBAN ${ibanFormated}`
-          ).match(/^\d{2}$/);
+          ).toMatch(/^\d{2}$/);
           expect(
             iban.substring(4, 8),
             `${iban.substring(
               4,
               8
             )} must contains only characters in PK IBAN ${ibanFormated}`
-          ).match(/^[A-Z]{4}$/);
+          ).toMatch(/^[A-Z]{4}$/);
           expect(
             iban.substring(8, 24),
             `${iban.substring(
               8,
               24
             )} must contains only digits in PK IBAN ${ibanFormated}`
-          ).match(/^\d{16}$/);
+          ).toMatch(/^\d{16}$/);
 
           expect(
             ibanLib.mod97(ibanLib.toDigitString(bban)),
@@ -163,7 +163,7 @@ describe('finance_iban', () => {
 
           const iban = faker.finance.iban(false, 'TR');
 
-          expect(iban).satisfy(validator.isIBAN);
+          expect(iban).toSatisfy(validator.isIBAN);
 
           const ibanFormated = iban.match(/.{1,4}/g).join(' ');
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -179,40 +179,40 @@ describe('finance_iban', () => {
               0,
               2
             )} must contains only characters in PK IBAN ${ibanFormated}`
-          ).match(/^[A-Z]{2}$/);
+          ).toMatch(/^[A-Z]{2}$/);
           expect(
             iban.substring(2, 4),
             `Control key:${iban.substring(
               2,
               4
             )} must contains only digit in PK IBAN ${ibanFormated}`
-          ).match(/^\d{2}$/);
+          ).toMatch(/^\d{2}$/);
           expect(
             iban.substring(4, 9),
             `Swift Bank Code:${iban.substring(
               4,
               9
             )} must contains only digits in PK IBAN ${ibanFormated}`
-          ).match(/^\d{5}$/);
+          ).toMatch(/^\d{5}$/);
           expect(
             iban.substring(9, 10),
             `National Digit:${iban.substring(
               9,
               10
             )} must contains only digits in PK IBAN ${ibanFormated}`
-          ).match(/^\d{1}$/);
+          ).toMatch(/^\d{1}$/);
           expect(
             iban.substring(10, 26),
             `Account Code:${iban.substring(
               10,
               26
             )} must contains only digits in PK IBAN ${ibanFormated}`
-          ).match(/^\d{16}$/);
+          ).toMatch(/^\d{16}$/);
 
           expect(
             iban.substring(2, 26),
             `No character after TR ${ibanFormated}`
-          ).match(/^\d{24}$/);
+          ).toMatch(/^\d{24}$/);
 
           expect(
             ibanLib.mod97(ibanLib.toDigitString(bban)),
@@ -233,7 +233,7 @@ describe('finance_iban', () => {
 
           const iban = faker.finance.iban(false, 'AZ');
 
-          expect(iban).satisfy(validator.isIBAN);
+          expect(iban).toSatisfy(validator.isIBAN);
 
           const ibanFormated = iban.match(/.{1,4}/g).join(' ');
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -249,28 +249,28 @@ describe('finance_iban', () => {
               0,
               2
             )} must contains only characters in AZ IBAN ${ibanFormated}`
-          ).match(/^[A-Z]{2}$/);
+          ).toMatch(/^[A-Z]{2}$/);
           expect(
             iban.substring(2, 4),
             `${iban.substring(
               2,
               4
             )} must contains only digit in AZ IBAN ${ibanFormated}`
-          ).match(/^\d{2}$/);
+          ).toMatch(/^\d{2}$/);
           expect(
             iban.substring(4, 8),
             `${iban.substring(
               4,
               8
             )} must contains only characters in AZ IBAN ${ibanFormated}`
-          ).match(/^[A-Z]{4}$/);
+          ).toMatch(/^[A-Z]{4}$/);
           expect(
             iban.substring(8, 28),
             `${iban.substring(
               8,
               28
             )} must contains 20 characters in AZ IBAN ${ibanFormated}`
-          ).match(/^\d{20}$/);
+          ).toMatch(/^\d{20}$/);
 
           expect(
             ibanLib.mod97(ibanLib.toDigitString(bban)),
@@ -292,7 +292,7 @@ describe('finance_iban', () => {
 
           const iban = faker.finance.iban(false, 'CR');
 
-          expect(iban).satisfy(validator.isIBAN);
+          expect(iban).toSatisfy(validator.isIBAN);
 
           const ibanFormated = iban.match(/.{1,4}/g).join(' ');
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -316,7 +316,7 @@ describe('finance_iban', () => {
               2,
               22
             )} must contains only digit in AZ IBAN ${ibanFormated}`
-          ).match(/^\d{20}$/);
+          ).toMatch(/^\d{20}$/);
 
           expect(
             ibanLib.mod97(ibanLib.toDigitString(bban)),
@@ -341,7 +341,7 @@ describe('finance_iban', () => {
           const iban = faker.finance.iban(false, 'AL');
           const ibanFormated = iban.match(/.{1,4}/g).join(' ');
 
-          expect(iban).satisfy(validator.isIBAN);
+          expect(iban).toSatisfy(validator.isIBAN);
 
           expect(
             28,

--- a/test/git.spec.ts
+++ b/test/git.spec.ts
@@ -111,7 +111,7 @@ describe('git', () => {
 
           expect(branch).toBeTruthy();
           expect(branch).toBeTypeOf('string');
-          expect(branch).satisfy(validator.isSlug);
+          expect(branch).toSatisfy(validator.isSlug);
         });
       });
 
@@ -124,21 +124,21 @@ describe('git', () => {
 
           const parts = commitEntry.split(/\r?\n/);
 
-          expect(parts.length).greaterThanOrEqual(6);
-          expect(parts.length).lessThanOrEqual(7);
+          expect(parts.length).toBeGreaterThanOrEqual(6);
+          expect(parts.length).toBeLessThanOrEqual(7);
 
-          expect(parts[0]).match(/^commit [a-f0-9]+$/);
+          expect(parts[0]).toMatch(/^commit [a-f0-9]+$/);
           if (parts.length === 7) {
-            expect(parts[1]).match(/^Merge: [a-f0-9]+ [a-f0-9]+$/);
-            expect(parts[2]).match(/^Author: \w+ \w+ \<[\w\.]+@[\w\.]+\>$/);
-            expect(parts[3]).match(/^Date: .+$/);
+            expect(parts[1]).toMatch(/^Merge: [a-f0-9]+ [a-f0-9]+$/);
+            expect(parts[2]).toMatch(/^Author: \w+ \w+ \<[\w\.]+@[\w\.]+\>$/);
+            expect(parts[3]).toMatch(/^Date: .+$/);
             expect(parts[4]).toBe('');
-            expect(parts[5]).match(/^\s{4}.+$/);
+            expect(parts[5]).toMatch(/^\s{4}.+$/);
           } else {
-            expect(parts[1]).match(/^Author: \w+ \w+ \<[\w\.]+@[\w\.]+\>$/);
-            expect(parts[2]).match(/^Date: .+$/);
+            expect(parts[1]).toMatch(/^Author: \w+ \w+ \<[\w\.]+@[\w\.]+\>$/);
+            expect(parts[2]).toMatch(/^Date: .+$/);
             expect(parts[3]).toBe('');
-            expect(parts[4]).match(/^\s{4}.+$/);
+            expect(parts[4]).toMatch(/^\s{4}.+$/);
           }
         });
       });
@@ -151,7 +151,7 @@ describe('git', () => {
           expect(commitMessage).toBeTypeOf('string');
 
           const parts = commitMessage.split(' ');
-          expect(parts.length).greaterThanOrEqual(3);
+          expect(parts.length).toBeGreaterThanOrEqual(3);
         });
       });
 
@@ -161,7 +161,7 @@ describe('git', () => {
 
           expect(commitSha).toBeTruthy();
           expect(commitSha).toBeTypeOf('string');
-          expect(commitSha).satisfy(validator.isHexadecimal);
+          expect(commitSha).toSatisfy(validator.isHexadecimal);
           expect(commitSha).toHaveLength(40);
         });
       });
@@ -172,7 +172,7 @@ describe('git', () => {
 
           expect(shortSha).toBeTruthy();
           expect(shortSha).toBeTypeOf('string');
-          expect(shortSha).satisfy(validator.isHexadecimal);
+          expect(shortSha).toSatisfy(validator.isHexadecimal);
           expect(shortSha).toHaveLength(7);
         });
       });

--- a/test/hacker.spec.ts
+++ b/test/hacker.spec.ts
@@ -121,7 +121,7 @@ describe('name', () => {
           const abbreviation = faker.hacker.abbreviation();
 
           expect(abbreviation).toBeTypeOf('string');
-          expect(abbreviation.length).greaterThan(0);
+          expect(abbreviation.length).toBeGreaterThan(0);
           expect(faker.definitions.hacker.abbreviation).toContain(abbreviation);
         });
       });
@@ -135,7 +135,7 @@ describe('name', () => {
           const adjective = faker.hacker.adjective();
 
           expect(adjective).toBeTypeOf('string');
-          expect(adjective.length).greaterThan(0);
+          expect(adjective.length).toBeGreaterThan(0);
           expect(faker.definitions.hacker.adjective).toContain(adjective);
         });
       });
@@ -149,7 +149,7 @@ describe('name', () => {
           const noun = faker.hacker.noun();
 
           expect(noun).toBeTypeOf('string');
-          expect(noun.length).greaterThan(0);
+          expect(noun.length).toBeGreaterThan(0);
           expect(faker.definitions.hacker.noun).toContain(noun);
         });
       });
@@ -163,7 +163,7 @@ describe('name', () => {
           const verb = faker.hacker.verb();
 
           expect(verb).toBeTypeOf('string');
-          expect(verb.length).greaterThan(0);
+          expect(verb.length).toBeGreaterThan(0);
           expect(faker.definitions.hacker.verb).toContain(verb);
         });
       });
@@ -177,7 +177,7 @@ describe('name', () => {
           const ingverb = faker.hacker.ingverb();
 
           expect(ingverb).toBeTypeOf('string');
-          expect(ingverb.length).greaterThan(0);
+          expect(ingverb.length).toBeGreaterThan(0);
           expect(faker.definitions.hacker.ingverb).toContain(ingverb);
         });
       });
@@ -191,7 +191,7 @@ describe('name', () => {
           const phrase = faker.hacker.phrase();
 
           expect(phrase).toBeTypeOf('string');
-          expect(phrase.length).greaterThan(0);
+          expect(phrase.length).toBeGreaterThan(0);
         });
       });
     }

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -519,14 +519,14 @@ describe('helpers', () => {
         describe('when no symbol passed in', () => {
           it("uses '#' by default", () => {
             const num = faker.helpers.replaceSymbolWithNumber('#AB');
-            expect(num).match(/\dAB/);
+            expect(num).toMatch(/\dAB/);
           });
         });
 
         describe('when symbol passed in', () => {
           it('replaces that symbol with integers', () => {
             const num = faker.helpers.replaceSymbolWithNumber('#AB', 'A');
-            expect(num).match(/#\dB/);
+            expect(num).toMatch(/#\dB/);
           });
         });
       });
@@ -539,7 +539,7 @@ describe('helpers', () => {
         describe("when '*' passed", () => {
           it('replaces it with alphanumeric', () => {
             const num = faker.helpers.replaceSymbols('*AB');
-            expect(num).match(/\wAB/);
+            expect(num).toMatch(/\wAB/);
           });
         });
       });
@@ -549,7 +549,7 @@ describe('helpers', () => {
           const number = faker.helpers.replaceCreditCardSymbols(
             '6453-####-####-####-###L'
           );
-          expect(number).match(
+          expect(number).toMatch(
             /^6453\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}$/
           );
           expect(luhnCheck(number)).toBeTruthy();
@@ -560,7 +560,7 @@ describe('helpers', () => {
             '6453-****-****-****-***L',
             '*'
           );
-          expect(number).match(
+          expect(number).toMatch(
             /^6453\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}$/
           );
           expect(luhnCheck(number)).toBeTruthy();
@@ -571,14 +571,14 @@ describe('helpers', () => {
             '6453-*{4}-*{4}-*{4}-*{3}L',
             '*'
           );
-          expect(number).match(
+          expect(number).toMatch(
             /^6453\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}$/
           );
           expect(luhnCheck(number)).toBeTruthy();
           number = faker.helpers.replaceCreditCardSymbols(
             '645[5-9]-#{4,6}-#{1,2}-#{4,6}-#{3}L'
           );
-          expect(number).match(
+          expect(number).toMatch(
             /^645[5-9]\-([0-9]){4,6}\-([0-9]){1,2}\-([0-9]){4,6}\-([0-9]){4}$/
           );
           expect(luhnCheck(number)).toBeTruthy();
@@ -598,16 +598,16 @@ describe('helpers', () => {
 
         it('deals with range repeat', () => {
           const string = faker.helpers.regexpStyleStringParse('#{5,10}');
-          expect(string.length).lessThanOrEqual(10);
-          expect(string.length).greaterThanOrEqual(5);
-          expect(string).match(/^\#{5,10}$/);
+          expect(string.length).toBeLessThanOrEqual(10);
+          expect(string.length).toBeGreaterThanOrEqual(5);
+          expect(string).toMatch(/^\#{5,10}$/);
         });
 
         it('flips the range when min > max', () => {
           const string = faker.helpers.regexpStyleStringParse('#{10,5}');
-          expect(string.length).lessThanOrEqual(10);
-          expect(string.length).greaterThanOrEqual(5);
-          expect(string).match(/^\#{5,10}$/);
+          expect(string.length).toBeLessThanOrEqual(10);
+          expect(string.length).toBeGreaterThanOrEqual(5);
+          expect(string).toMatch(/^\#{5,10}$/);
         });
 
         it('repeats string {n} number of times', () => {
@@ -624,14 +624,16 @@ describe('helpers', () => {
 
         it('creates a numerical range', () => {
           const string = faker.helpers.regexpStyleStringParse('Hello[0-9]');
-          expect(string).match(/^Hello[0-9]$/);
+          expect(string).toMatch(/^Hello[0-9]$/);
         });
 
         it('deals with multiple tokens in one string', () => {
           const string = faker.helpers.regexpStyleStringParse(
             'Test#{5}%{2,5}Testing**[1-5]**{10}END'
           );
-          expect(string).match(/^Test\#{5}%{2,5}Testing\*\*[1-5]\*\*{10}END$/);
+          expect(string).toMatch(
+            /^Test\#{5}%{2,5}Testing\*\*[1-5]\*\*{10}END$/
+          );
         });
       });
 

--- a/test/internet.spec.ts
+++ b/test/internet.spec.ts
@@ -136,8 +136,8 @@ describe('internet', () => {
 
           expect(avatar).toBeTruthy();
           expect(avatar).toBeTypeOf('string');
-          expect(avatar).satisfy(validator.isURL);
-          expect(avatar).match(
+          expect(avatar).toSatisfy(validator.isURL);
+          expect(avatar).toMatch(
             /^https:\/\/cloudflare-ipfs.com\/ipfs\/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye\/avatar\/\d+.jpg$/
           );
         });
@@ -149,7 +149,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [, suffix] = email.split('@');
           expect(faker.definitions.internet.free_email).toContain(suffix);
@@ -162,11 +162,11 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
 
-          expect(prefix).match(/^Aiden.Harann55/);
+          expect(prefix).toMatch(/^Aiden.Harann55/);
           expect(faker.definitions.internet.free_email).toContain(suffix);
         });
 
@@ -175,11 +175,11 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
 
-          expect(prefix).match(/^Aiden([._]Harann)?\d*/);
+          expect(prefix).toMatch(/^Aiden([._]Harann)?\d*/);
           expect(faker.definitions.internet.free_email).toContain(suffix);
         });
 
@@ -188,11 +188,11 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
 
-          expect(prefix).match(/^思源_唐3/);
+          expect(prefix).toMatch(/^思源_唐3/);
           expect(faker.definitions.internet.free_email).toContain(suffix);
         });
 
@@ -203,11 +203,11 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
 
-          expect(prefix).match(/^Mike([.!#$%&'*+-/=?^_`{|}~]Smith)?\d*/);
+          expect(prefix).toMatch(/^Mike([.!#$%&'*+-/=?^_`{|}~]Smith)?\d*/);
           expect(faker.definitions.internet.free_email).toContain(suffix);
         });
       });
@@ -218,11 +218,11 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const suffix = email.split('@')[1];
 
-          expect(suffix).match(/^example\.(com|net|org)$/);
+          expect(suffix).toMatch(/^example\.(com|net|org)$/);
           expect(faker.definitions.internet.example_email).toContain(suffix);
         });
 
@@ -231,13 +231,13 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
 
-          expect(suffix).match(/^example\.(com|net|org)$/);
+          expect(suffix).toMatch(/^example\.(com|net|org)$/);
           expect(faker.definitions.internet.example_email).toContain(suffix);
-          expect(prefix).match(/^Aiden.Harann55/);
+          expect(prefix).toMatch(/^Aiden.Harann55/);
         });
 
         it('should return an email with the example suffix and given firstName and lastName', () => {
@@ -245,13 +245,13 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
 
-          expect(suffix).match(/^example\.(com|net|org)$/);
+          expect(suffix).toMatch(/^example\.(com|net|org)$/);
           expect(faker.definitions.internet.example_email).toContain(suffix);
-          expect(prefix).match(/^Aiden([._]Harann)?\d*/);
+          expect(prefix).toMatch(/^Aiden([._]Harann)?\d*/);
         });
 
         it('should return an email with the example suffix and japanese characters', () => {
@@ -259,13 +259,13 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
 
-          expect(suffix).match(/^example\.(com|net|org)$/);
+          expect(suffix).toMatch(/^example\.(com|net|org)$/);
           expect(faker.definitions.internet.example_email).toContain(suffix);
-          expect(prefix).match(/^思源_唐3/);
+          expect(prefix).toMatch(/^思源_唐3/);
         });
 
         it('should return an email with special characters', () => {
@@ -275,13 +275,13 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).satisfy(validator.isEmail);
+          expect(email).toSatisfy(validator.isEmail);
 
           const [prefix, suffix] = email.split('@');
 
-          expect(suffix).match(/^example\.(com|net|org)$/);
+          expect(suffix).toMatch(/^example\.(com|net|org)$/);
           expect(faker.definitions.internet.example_email).toContain(suffix);
-          expect(prefix).match(/^Mike([.!#$%&'*+-/=?^_`{|}~]Smith)?\d*/);
+          expect(prefix).toMatch(/^Mike([.!#$%&'*+-/=?^_`{|}~]Smith)?\d*/);
         });
       });
 
@@ -291,7 +291,7 @@ describe('internet', () => {
 
           expect(username).toBeTruthy();
           expect(username).toBeTypeOf('string');
-          expect(username).match(/\w/);
+          expect(username).toMatch(/\w/);
         });
 
         it('should return a random username with given firstName', () => {
@@ -299,7 +299,7 @@ describe('internet', () => {
 
           expect(username).toBeTruthy();
           expect(username).toBeTypeOf('string');
-          expect(username).match(/\w/);
+          expect(username).toMatch(/\w/);
           expect(username).includes('Aiden');
         });
 
@@ -308,7 +308,7 @@ describe('internet', () => {
 
           expect(username).toBeTruthy();
           expect(username).toBeTypeOf('string');
-          expect(username).match(/\w/);
+          expect(username).toMatch(/\w/);
           expect(username).includes('Aiden');
           // FIXME christopher 2022-02-11: The lastName is sometimes not taken
         });
@@ -349,7 +349,7 @@ describe('internet', () => {
 
           expect(url).toBeTruthy();
           expect(url).toBeTypeOf('string');
-          expect(url).satisfy(validator.isURL);
+          expect(url).toSatisfy(validator.isURL);
         });
       });
 
@@ -359,11 +359,11 @@ describe('internet', () => {
 
           expect(domainName).toBeTruthy();
           expect(domainName).toBeTypeOf('string');
-          expect(domainName).satisfy(validator.isFQDN);
+          expect(domainName).toSatisfy(validator.isFQDN);
 
           const [prefix, suffix] = domainName.split('.');
 
-          expect(prefix).satisfy(validator.isSlug);
+          expect(prefix).toSatisfy(validator.isSlug);
           expect(faker.definitions.internet.domain_suffix).toContain(suffix);
         });
       });
@@ -386,8 +386,8 @@ describe('internet', () => {
 
           expect(domainWord).toBeTruthy();
           expect(domainWord).toBeTypeOf('string');
-          expect(domainWord).satisfy(validator.isSlug);
-          expect(domainWord).satisfy((value: string) =>
+          expect(domainWord).toSatisfy(validator.isSlug);
+          expect(domainWord).toSatisfy((value: string) =>
             validator.isFQDN(value, { require_tld: false })
           );
         });
@@ -399,7 +399,7 @@ describe('internet', () => {
 
           expect(ip).toBeTruthy();
           expect(ip).toBeTypeOf('string');
-          expect(ip).satisfy((value: string) => validator.isIP(value, 4));
+          expect(ip).toSatisfy((value: string) => validator.isIP(value, 4));
 
           const parts = ip.split('.');
 
@@ -407,8 +407,8 @@ describe('internet', () => {
 
           for (const part of parts) {
             expect(part).toMatch(/^\d+$/);
-            expect(+part).greaterThanOrEqual(0);
-            expect(+part).lessThanOrEqual(255);
+            expect(+part).toBeGreaterThanOrEqual(0);
+            expect(+part).toBeLessThanOrEqual(255);
           }
         });
       });
@@ -419,7 +419,7 @@ describe('internet', () => {
 
           expect(ipv6).toBeTruthy();
           expect(ipv6).toBeTypeOf('string');
-          expect(ipv6).satisfy((value: string) => validator.isIP(value, 6));
+          expect(ipv6).toSatisfy((value: string) => validator.isIP(value, 6));
 
           const parts = ipv6.split(':');
 
@@ -432,9 +432,9 @@ describe('internet', () => {
           const port = faker.internet.port();
 
           expect(port).toBeTypeOf('number');
-          expect(port).greaterThanOrEqual(0);
-          expect(port).lessThanOrEqual(65535);
-          expect(String(port)).satisfy(validator.isPort);
+          expect(port).toBeGreaterThanOrEqual(0);
+          expect(port).toBeLessThanOrEqual(65535);
+          expect(String(port)).toSatisfy(validator.isPort);
         });
       });
 
@@ -454,7 +454,7 @@ describe('internet', () => {
 
           expect(color).toBeTruthy();
           expect(color).toBeTypeOf('string');
-          expect(color).satisfy(validator.isHexColor);
+          expect(color).toSatisfy(validator.isHexColor);
         });
 
         it('should return a random hex value with given values', () => {
@@ -463,7 +463,7 @@ describe('internet', () => {
 
           expect(color).toBeTruthy();
           expect(color).toBeTypeOf('string');
-          expect(color).satisfy(validator.isHexColor);
+          expect(color).toSatisfy(validator.isHexColor);
         });
       });
 
@@ -474,8 +474,8 @@ describe('internet', () => {
           expect(mac).toBeTruthy();
           expect(mac).toBeTypeOf('string');
           expect(mac).toHaveLength(17);
-          expect(mac).match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/);
-          expect(mac).satisfy(validator.isMACAddress);
+          expect(mac).toMatch(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/);
+          expect(mac).toSatisfy(validator.isMACAddress);
         });
 
         it('should return a random MAC address with 6 hexadecimal digits and given separator', () => {
@@ -484,8 +484,8 @@ describe('internet', () => {
           expect(mac).toBeTruthy();
           expect(mac).toBeTypeOf('string');
           expect(mac).toHaveLength(17);
-          expect(mac).match(/^([a-f0-9]{2}-){5}[a-f0-9]{2}$/);
-          expect(mac).satisfy(validator.isMACAddress);
+          expect(mac).toMatch(/^([a-f0-9]{2}-){5}[a-f0-9]{2}$/);
+          expect(mac).toSatisfy(validator.isMACAddress);
         });
 
         it('should return a random MAC address with 6 hexadecimal digits and empty separator', () => {
@@ -493,7 +493,7 @@ describe('internet', () => {
 
           expect(mac).toBeTruthy();
           expect(mac).toBeTypeOf('string');
-          expect(mac).satisfy(validator.isHexadecimal);
+          expect(mac).toSatisfy(validator.isHexadecimal);
           expect(mac).toHaveLength(12);
           // It's not a valid MAC address
         });
@@ -506,8 +506,8 @@ describe('internet', () => {
             expect(mac).toBeTruthy();
             expect(mac).toBeTypeOf('string');
             expect(mac).toHaveLength(17);
-            expect(mac).match(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/);
-            expect(mac).satisfy(validator.isMACAddress);
+            expect(mac).toMatch(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/);
+            expect(mac).toSatisfy(validator.isMACAddress);
           }
         );
       });
@@ -519,7 +519,7 @@ describe('internet', () => {
           expect(password).toBeTruthy();
           expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(15);
-          expect(password).match(/^\w{15}$/);
+          expect(password).toMatch(/^\w{15}$/);
         });
 
         it.each(times(32))(
@@ -530,7 +530,7 @@ describe('internet', () => {
             expect(password).toBeTruthy();
             expect(password).toBeTypeOf('string');
             expect(password).toHaveLength(length);
-            expect(password).match(/^\w+$/);
+            expect(password).toMatch(/^\w+$/);
           }
         );
 
@@ -540,7 +540,7 @@ describe('internet', () => {
           expect(password).toBeTruthy();
           expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(12);
-          expect(password).match(/^\w{12}$/);
+          expect(password).toMatch(/^\w{12}$/);
         });
 
         it('should return non memorable password', () => {
@@ -549,9 +549,9 @@ describe('internet', () => {
           expect(password).toBeTruthy();
           expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(12);
-          expect(password).match(/^\w{12}$/);
+          expect(password).toMatch(/^\w{12}$/);
           // TODO @Shinigami92 2022-02-11: I would say a non memorable password should satisfy `validator.isStrongPassword`, but it does not currently
-          //expect(password).satisfy(validator.isStrongPassword);
+          //expect(password).toSatisfy(validator.isStrongPassword);
         });
 
         it('should return non memorable strong password with length 32', () => {
@@ -565,7 +565,7 @@ describe('internet', () => {
           expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(32);
           // TODO @Shinigami92 2022-02-11: This should definitely be a strong password, but it doesn't :(
-          //expect(password).satisfy(validator.isStrongPassword);
+          //expect(password).toSatisfy(validator.isStrongPassword);
         });
 
         it('should return non memorable strong password with length 32 and given prefix', () => {
@@ -579,8 +579,8 @@ describe('internet', () => {
           expect(password).toBeTruthy();
           expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(32);
-          expect(password).match(/^a!G6/);
-          expect(password).satisfy(validator.isStrongPassword);
+          expect(password).toMatch(/^a!G6/);
+          expect(password).toSatisfy(validator.isStrongPassword);
         });
       });
 

--- a/test/lorem.spec.ts
+++ b/test/lorem.spec.ts
@@ -214,7 +214,7 @@ describe('lorem', () => {
 
           expect(actual).toBeTruthy();
           expect(actual).toBeTypeOf('string');
-          expect(actual).satisfy(validator.isSlug);
+          expect(actual).toSatisfy(validator.isSlug);
         });
 
         it.each(times(25))(
@@ -230,7 +230,7 @@ describe('lorem', () => {
             expect(words).toHaveLength(wordCount);
 
             if (wordCount > 1) {
-              expect(actual).satisfy(validator.isSlug);
+              expect(actual).toSatisfy(validator.isSlug);
             }
           }
         );
@@ -298,8 +298,8 @@ describe('lorem', () => {
 
             const sentences = actual.split('. ');
 
-            expect(sentences.length).greaterThanOrEqual(sentenceCount);
-            expect(sentences.length).lessThanOrEqual(sentenceCount + 3);
+            expect(sentences.length).toBeGreaterThanOrEqual(sentenceCount);
+            expect(sentences.length).toBeLessThanOrEqual(sentenceCount + 3);
           }
         );
       });

--- a/test/name.spec.ts
+++ b/test/name.spec.ts
@@ -180,7 +180,7 @@ describe('name', () => {
           const first_name = faker.name.firstName();
 
           expect(first_name).toBeTypeOf('string');
-          expect(first_name.length).greaterThan(0);
+          expect(first_name.length).toBeGreaterThan(0);
         });
 
         it('should return a gender-specific first name when passed a number', () => {
@@ -231,7 +231,7 @@ describe('name', () => {
           const last_name = faker.name.lastName();
 
           expect(last_name).toBeTypeOf('string');
-          expect(last_name.length).greaterThan(0);
+          expect(last_name.length).toBeGreaterThan(0);
         });
 
         it('should return a gender-specific last name when passed a number', () => {
@@ -275,7 +275,7 @@ describe('name', () => {
           const middle_name = faker.name.middleName();
 
           expect(middle_name).toBeTypeOf('string');
-          expect(middle_name.length).greaterThan(0);
+          expect(middle_name.length).toBeGreaterThan(0);
         });
 
         it('should return a middle name when passed en locale', () => {

--- a/test/phone.spec.ts
+++ b/test/phone.spec.ts
@@ -110,7 +110,7 @@ describe('phone', () => {
         it('should return a random phoneNumber with a random format', () => {
           const phoneNumber = faker.phone.phoneNumber();
 
-          expect(phoneNumber).match(/\d/);
+          expect(phoneNumber).toMatch(/\d/);
         });
       });
 
@@ -118,19 +118,19 @@ describe('phone', () => {
         it('should return phone number with proper US format (Array index)', () => {
           faker.locale = 'en';
           const phoneNumber = faker.phone.phoneNumberFormat(1);
-          expect(phoneNumber).match(/\([2-9]\d\d\) [2-9]\d\d-\d\d\d\d/);
+          expect(phoneNumber).toMatch(/\([2-9]\d\d\) [2-9]\d\d-\d\d\d\d/);
         });
 
         it('should return phone number with proper CA format (Array index)', () => {
           faker.locale = 'en_CA';
           const phoneNumber = faker.phone.phoneNumberFormat(1);
-          expect(phoneNumber).match(/\([2-9]\d\d\)[2-9]\d\d-\d\d\d\d/);
+          expect(phoneNumber).toMatch(/\([2-9]\d\d\)[2-9]\d\d-\d\d\d\d/);
         });
 
         it('should return phone number with proper PL format (Array index)', () => {
           faker.locale = 'pl';
           const phoneNumber = faker.phone.phoneNumberFormat(1);
-          expect(phoneNumber).match(/13-\d{3}-\d{2}-\d{2}/);
+          expect(phoneNumber).toMatch(/13-\d{3}-\d{2}-\d{2}/);
         });
       });
 
@@ -154,7 +154,7 @@ describe('phone', () => {
 
         it('should be Luhn-valid', () => {
           const imei = faker.phone.imei();
-          expect(imei).satisfy(luhnCheck);
+          expect(imei).toSatisfy(luhnCheck);
         });
       });
     }

--- a/test/random.spec.ts
+++ b/test/random.spec.ts
@@ -25,8 +25,8 @@ describe('random', () => {
       const subset = faker.random.arrayElements(testArray);
 
       // Check length
-      expect(subset.length).greaterThanOrEqual(1);
-      expect(subset.length).lessThanOrEqual(testArray.length);
+      expect(subset.length).toBeGreaterThanOrEqual(1);
+      expect(subset.length).toBeLessThanOrEqual(testArray.length);
 
       // Check elements
       subset.forEach((element) => {
@@ -152,8 +152,8 @@ describe('random', () => {
       expect(actual).toBeTypeOf('string');
 
       const words = actual.split(' ');
-      expect(words.length).greaterThanOrEqual(1);
-      expect(words.length).lessThanOrEqual(3);
+      expect(words.length).toBeGreaterThanOrEqual(1);
+      expect(words.length).toBeLessThanOrEqual(3);
     });
 
     it('should return random words', () => {
@@ -187,12 +187,12 @@ describe('random', () => {
     it('should return lowercase letter when no upcase option provided', () => {
       const actual = faker.random.alpha();
 
-      expect(actual).match(/^[a-z]$/);
+      expect(actual).toMatch(/^[a-z]$/);
     });
 
     it('should return uppercase when upcase option is true', () => {
       const actual = faker.random.alpha({ upcase: true });
-      expect(actual).match(/^[A-Z]$/);
+      expect(actual).toMatch(/^[A-Z]$/);
     });
 
     it('should generate many random letters', () => {
@@ -208,7 +208,7 @@ describe('random', () => {
       });
 
       expect(actual).toHaveLength(5);
-      expect(actual).match(/^[b-oq-z]{5}$/);
+      expect(actual).toMatch(/^[b-oq-z]{5}$/);
     });
 
     it('should be able handle mistake in banned characters array', () => {
@@ -218,7 +218,7 @@ describe('random', () => {
       });
 
       expect(alphaText).toHaveLength(5);
-      expect(alphaText).match(/^[b-oq-z]{5}$/);
+      expect(alphaText).toMatch(/^[b-oq-z]{5}$/);
     });
 
     it('should not mutate the input object', () => {
@@ -280,7 +280,7 @@ describe('random', () => {
       });
 
       expect(alphaText).toHaveLength(5);
-      expect(alphaText).match(/^[0-9b-oq-z]{5}$/);
+      expect(alphaText).toMatch(/^[0-9b-oq-z]{5}$/);
     });
 
     it('should throw if all possible characters being banned', () => {

--- a/test/system.spec.ts
+++ b/test/system.spec.ts
@@ -254,7 +254,7 @@ describe('system', () => {
           expect(
             mimeType,
             `generated mime types should be valid mime types.`
-          ).satisfy(validator.isMimeType);
+          ).toSatisfy(validator.isMimeType);
         });
       });
 
@@ -263,7 +263,7 @@ describe('system', () => {
           expect(
             faker.system.semver(),
             `generated semver, first number should be between 0 and 9.`
-          ).satisfy(validator.isSemVer);
+          ).toSatisfy(validator.isSemVer);
         });
       });
     }

--- a/test/vehicle.spec.ts
+++ b/test/vehicle.spec.ts
@@ -152,7 +152,7 @@ describe('vehicle', () => {
 
           expect(vin).toBeTruthy();
           expect(vin).toBeTypeOf('string');
-          expect(vin).match(
+          expect(vin).toMatch(
             /^([A-HJ-NPR-Z0-9]{10}[A-HJ-NPR-Z0-9]{1}[A-HJ-NPR-Z0-9]{1}\d{5})$/
           );
         });
@@ -174,7 +174,7 @@ describe('vehicle', () => {
 
           expect(vrm).toBeTruthy();
           expect(vrm).toBeTypeOf('string');
-          expect(vrm).match(/^[A-Z]{2}[0-9]{2}[A-Z]{3}$/);
+          expect(vrm).toMatch(/^[A-Z]{2}[0-9]{2}[A-Z]{3}$/);
         });
       });
 


### PR DESCRIPTION
Waiting on https://github.com/vitest-dev/vitest/pull/1172

Theoretically we would also need that `greaterThanOrEquals` behave the same as `toBeGreaterThanOrEquals`
The one use `number | bigint` and the other uses `number | Date`