### PR TITLE
feat: add creditCardIssuer

### DIFF
--- a/src/definitions/finance.ts
+++ b/src/definitions/finance.ts
@@ -9,12 +9,12 @@ export interface FinanceDefinitions {
    */
   account_type: string[];
   /**
-   * The pattern by (lowercase) provider name used to generate credit card codes.
+   * The pattern by (lowercase) issuer name used to generate credit card codes.
    * `L` will be replaced by the check bit.
    *
    * @see Helpers.replaceCreditCardSymbols()
    */
-  credit_card: { [provider: string]: string[] };
+  credit_card: { [issuer: string]: string[] };
   /**
    * Currencies by their full name and their symbols (e.g. `US Dollar` -> `USD` / `$`).
    */

--- a/src/finance.ts
+++ b/src/finance.ts
@@ -287,12 +287,12 @@ export class Finance {
   }
 
   /**
-   * Returns a random credit card provider.
+   * Returns a random credit card issuer.
    *
    * @example
-   * faker.finance.creditCardProvider() // 'discover'
+   * faker.finance.creditCardIssuer() // 'discover'
    */
-  creditCardProvider(): string {
+  creditCardIssuer(): string {
     return this.faker.random.objectElement(
       this.faker.definitions.finance.credit_card,
       'key'

--- a/src/finance.ts
+++ b/src/finance.ts
@@ -287,7 +287,7 @@ export class Finance {
   }
 
   /**
-   * Returns a random credit card provider
+   * Returns a random credit card provider.
    *
    * @example
    * faker.finance.creditCardProvider() // 'discover'

--- a/src/finance.ts
+++ b/src/finance.ts
@@ -246,24 +246,24 @@ export class Finance {
   /**
    * Generates a random credit card number.
    *
-   * @param provider The name of the provider (case insensitive) or the format used to generate one.
+   * @param issuer The name of the issuer (case insensitive) or the format used to generate one.
    *
    * @example
    * faker.finance.creditCardNumber() // '4427163488668'
    * faker.finance.creditCardNumber('visa') // '4882664999003'
    * faker.finance.creditCardNumber('63[7-9]#-####-####-###L') // '6375-3265-4676-6644'
    */
-  creditCardNumber(provider = ''): string {
+  creditCardNumber(issuer = ''): string {
     let format: string;
     const localeFormat = this.faker.definitions.finance.credit_card;
-    const normalizedProvider = provider.toLowerCase();
-    if (normalizedProvider in localeFormat) {
-      format = this.faker.random.arrayElement(localeFormat[normalizedProvider]);
-    } else if (provider.match(/#/)) {
+    const normalizedIssuer = issuer.toLowerCase();
+    if (normalizedIssuer in localeFormat) {
+      format = this.faker.random.arrayElement(localeFormat[normalizedIssuer]);
+    } else if (issuer.match(/#/)) {
       // The user chose an optional scheme
-      format = provider;
+      format = issuer;
     } else {
-      // Choose a random provider
+      // Choose a random issuer
       // Credit cards are in an object structure
       const formats = this.faker.random.objectElement(localeFormat, 'value'); // There could be multiple formats
       format = this.faker.random.arrayElement(formats);

--- a/src/finance.ts
+++ b/src/finance.ts
@@ -287,6 +287,19 @@ export class Finance {
   }
 
   /**
+   * Returns a random credit card provider
+   *
+   * @example
+   * faker.finance.creditCardProvider() // 'discover'
+   */
+  creditCardProvider(): string {
+    return this.faker.random.objectElement(
+      this.faker.definitions.finance.credit_card,
+      'key'
+    );
+  }
+
+  /**
    * Generates a random PIN number.
    *
    * @param length The length of the PIN to generate. Defaults to `4`.

--- a/src/finance.ts
+++ b/src/finance.ts
@@ -292,10 +292,9 @@ export class Finance {
    * faker.finance.creditCardIssuer() // 'discover'
    */
   creditCardIssuer(): string {
-    return this.faker.random.objectElement(
-      this.faker.definitions.finance.credit_card,
-      'key'
-    );
+    return this.faker.helpers.objectKey(
+      this.faker.definitions.finance.credit_card
+    ) as string;
   }
 
   /**

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -450,7 +450,7 @@ describe('finance', () => {
         });
       });
 
-      describe('cardCardIssuer()', () => {
+      describe('creditCardIssuer()', () => {
         it('should return a string', () => {
           const issuer = faker.finance.creditCardIssuer();
           expect(issuer).toBeTypeOf('string');

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -394,7 +394,7 @@ describe('finance', () => {
           expect(luhnCheck(faker.finance.creditCardNumber())).toBeTruthy();
         });
 
-        it('should ignore case for provider', () => {
+        it('should ignore case for issuer', () => {
           const seed = faker.seedValue;
 
           faker.seed(seed);

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -450,12 +450,12 @@ describe('finance', () => {
         });
       });
 
-      describe('cardCardProvider()', () => {
+      describe('cardCardIssuer()', () => {
         it('should return a string', () => {
-          const provider = faker.finance.creditCardIssuer();
-          expect(provider).toBeTypeOf('string');
+          const issuer = faker.finance.creditCardIssuer();
+          expect(issuer).toBeTypeOf('string');
           expect(Object.keys(faker.definitions.finance.credit_card)).toContain(
-            provider
+            issuer
           );
         });
       });

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -452,7 +452,7 @@ describe('finance', () => {
 
       describe('cardCardProvider()', () => {
         it('should return a string', () => {
-          const provider = faker.finance.creditCardProvider();
+          const provider = faker.finance.creditCardIssuer();
           expect(provider).toBeTypeOf('string');
           expect(Object.keys(faker.definitions.finance.credit_card)).toContain(
             provider

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -450,6 +450,16 @@ describe('finance', () => {
         });
       });
 
+      describe('cardCardProvider()', () => {
+        it('should return a string', () => {
+          const provider = faker.finance.creditCardProvider();
+          expect(provider).toBeTypeOf('string');
+          expect(Object.keys(faker.definitions.finance.credit_card)).toContain(
+            provider
+          );
+        });
+      });
+
       describe('creditCardCVV()', () => {
         it('should return a valid credit card CVV', () => {
           const cvv = faker.finance.creditCardCVV();


### PR DESCRIPTION
Adds method for randomly selecting a credit card provider from the keys of `faker.definitions.finance.credit_card`

    > faker.finance.creditCardProvider()
    'visa'
    > faker.finance.creditCardProvider()
    'diners_club'

For pull request #882 