### PR TITLE
chore: add examples and improve jsdocs for datatype.datetime

### DIFF
--- a/src/datatype.ts
+++ b/src/datatype.ts
@@ -100,19 +100,24 @@ export class Datatype {
    * Returns a Date object using a random number of milliseconds since
    * the [Unix Epoch](https://en.wikipedia.org/wiki/Unix_time) (1 January 1970 UTC).
    *
-   * @param options Max number of milliseconds since unix epoch or options object
+   * @param options Max number of milliseconds since unix epoch or options object.
    * @param options.min Lower bound for milliseconds since base date.
    *    When not provided or smaller than `-8640000000000000`, `1990-01-01` is considered
-   *    as minimum generated date. Defaults to `633880849813`.
+   *    as minimum generated date. Defaults to `631152000000`.
    * @param options.max Upper bound for milliseconds since base date.
    *    When not provided or larger than `8640000000000000`, `2100-01-01` is considered
-   *    as maximum generated date.
+   *    as maximum generated date. Defaults to `4102444800000`.
+   *
+   * @example
+   * faker.datatype.datetime() // '2089-04-17T18:03:24.956Z'
+   * faker.datatype.datetime(1893456000000) // '2022-03-28T07:00:56.876Z'
+   * faker.datatype.datetime({ min: 1577836800000, max: 1893456000000 }) // '2021-09-12T07:13:00.255Z'
    */
-  datetime(options?: number | { min?: number; max?: number }): Date {
+  datetime(options: number | { min?: number; max?: number } = {}): Date {
     const minMax = 8640000000000000;
 
-    let min = typeof options === 'number' ? undefined : options?.min;
-    let max = typeof options === 'number' ? options : options?.max;
+    let min = typeof options === 'number' ? undefined : options.min;
+    let max = typeof options === 'number' ? options : options.max;
 
     if (min == null || min < minMax * -1) {
       min = Date.UTC(1990, 0);


### PR DESCRIPTION
Discovered in #908

<details>
<summary><strong>Preview (Click to expand)</strong></summary>

![grafik](https://user-images.githubusercontent.com/1579362/166343557-1e2c26c9-b7b0-4959-8058-0281352267bb.png)

</details>