### PR TITLE
fix(typescript): support module Node16/NodeNext

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "require": "./dist/cjs/index.js",
       "import": "./dist/esm/index.mjs"
     },
     "./locale/*": {
+      "types": "./dist/types/locale/*.d.ts",
       "require": "./dist/cjs/locale/*.js",
       "import": "./dist/esm/locale/*.mjs"
     },


### PR DESCRIPTION
Fix #1004

Recreating https://github.com/faker-js/faker/pull/979 (without changing the base `"types"` field)