### PR TITLE
refactor(phone): rename phoneNumber to number

### DIFF
--- a/src/modules/fake/index.ts
+++ b/src/modules/fake/index.ts
@@ -37,7 +37,7 @@ export class Fake {
    * and if that isn't possible, we will fall back to string:
    *
    * ```js
-   * const message = faker.fake(`You can call me at {{phone.phoneNumber(+!# !## #### #####!)}}.')
+   * const message = faker.fake(`You can call me at {{phone.number(+!# !## #### #####!)}}.')
    * ```
    *
    * Currently it is not possible to set more than a single parameter.
@@ -53,7 +53,7 @@ export class Fake {
    * faker.fake('{{name.lastName}}, {{name.firstName}} {{name.suffix}}') // 'Durgan, Noe MD'
    * faker.fake('This is static test.') // 'This is static test.'
    * faker.fake('Good Morning {{name.firstName}}!') // 'Good Morning Estelle!'
-   * faker.fake('You can call me at {{phone.phoneNumber(!## ### #####!)}}.') // 'You can call me at 202 555 973722.'
+   * faker.fake('You can call me at {{phone.number(!## ### #####!)}}.') // 'You can call me at 202 555 973722.'
    * faker.fake('I flipped the coin an got: {{helpers.arrayElement(["heads", "tails"])}}') // 'I flipped the coin an got: tails'
    */
   fake(str: string): string {

--- a/src/modules/phone/index.ts
+++ b/src/modules/phone/index.ts
@@ -20,6 +20,8 @@ export class Phone {
    *
    * @param format Format of the phone number. Defaults to a random phone number format.
    *
+   * @see faker.phone.number
+   *
    * @example
    * faker.phone.phoneNumber() // '961-770-7727'
    * faker.phone.phoneNumber('501-###-###') // '501-039-841'
@@ -43,9 +45,9 @@ export class Phone {
    * @param format Format of the phone number. Defaults to a random phone number format.
    *
    * @example
-   * faker.phone.phoneNumber() // '961-770-7727'
-   * faker.phone.phoneNumber('501-###-###') // '501-039-841'
-   * faker.phone.phoneNumber('+48 91 ### ## ##') // '+48 91 463 61 70'
+   * faker.phone.number() // '961-770-7727'
+   * faker.phone.number('501-###-###') // '501-039-841'
+   * faker.phone.number('+48 91 ### ## ##') // '+48 91 463 61 70'
    */
   number(format?: string): string {
     format =

--- a/src/modules/phone/index.ts
+++ b/src/modules/phone/index.ts
@@ -24,15 +24,17 @@ export class Phone {
    * faker.phone.phoneNumber() // '961-770-7727'
    * faker.phone.phoneNumber('501-###-###') // '501-039-841'
    * faker.phone.phoneNumber('+48 91 ### ## ##') // '+48 91 463 61 70'
+   *
+   * @deprecated
    */
-  // TODO @pkuczynski 2022-02-01: simplify name to `number()`
   phoneNumber(format?: string): string {
-    format =
-      format ??
-      this.faker.helpers.arrayElement(
-        this.faker.definitions.phone_number.formats
-      );
-    return this.faker.helpers.replaceSymbolWithNumber(format);
+    deprecated({
+      deprecated: 'faker.phone.phoneNumber()',
+      proposed: 'faker.phone.number()',
+      since: 'v7.2.0',
+      until: 'v8.0.0',
+    });
+    return this.faker.phone.number(format);
   }
 
   /**

--- a/src/modules/phone/index.ts
+++ b/src/modules/phone/index.ts
@@ -36,6 +36,25 @@ export class Phone {
   }
 
   /**
+   * Generates a random phone number.
+   *
+   * @param format Format of the phone number. Defaults to a random phone number format.
+   *
+   * @example
+   * faker.phone.phoneNumber() // '961-770-7727'
+   * faker.phone.phoneNumber('501-###-###') // '501-039-841'
+   * faker.phone.phoneNumber('+48 91 ### ## ##') // '+48 91 463 61 70'
+   */
+  number(format?: string): string {
+    format =
+      format ??
+      this.faker.helpers.arrayElement(
+        this.faker.definitions.phone_number.formats
+      );
+    return this.faker.helpers.replaceSymbolWithNumber(format);
+  }
+
+  /**
    * Returns phone number in a format of the given index from `faker.definitions.phone_number.formats`.
    *
    * @param phoneFormatsArrayIndex Index in the `faker.definitions.phone_number.formats` array. Defaults to `0`.

--- a/src/modules/phone/index.ts
+++ b/src/modules/phone/index.ts
@@ -33,8 +33,8 @@ export class Phone {
     deprecated({
       deprecated: 'faker.phone.phoneNumber()',
       proposed: 'faker.phone.number()',
-      since: 'v7.3.0',
-      until: 'v8.0.0',
+      since: 'v7.3',
+      until: 'v8.0',
     });
     return this.faker.phone.number(format);
   }

--- a/src/modules/phone/index.ts
+++ b/src/modules/phone/index.ts
@@ -33,7 +33,7 @@ export class Phone {
     deprecated({
       deprecated: 'faker.phone.phoneNumber()',
       proposed: 'faker.phone.number()',
-      since: 'v7.2.0',
+      since: 'v7.3.0',
       until: 'v8.0.0',
     });
     return this.faker.phone.number(format);

--- a/test/fake.spec.ts
+++ b/test/fake.spec.ts
@@ -5,7 +5,7 @@ import { FakerError } from '../src/errors/faker-error';
 describe('fake', () => {
   describe('fake()', () => {
     it('replaces a token with a random value for a method with no parameters', () => {
-      const name = faker.fake('{{phone.phoneNumber}}');
+      const name = faker.fake('{{phone.number}}');
       expect(name).toMatch(/\d/);
     });
 

--- a/test/phone.spec.ts
+++ b/test/phone.spec.ts
@@ -130,7 +130,7 @@ describe('phone', () => {
           expect(logMessage).toContain('deprecated');
           expect(logMessage).toContain('faker.phone.phoneNumber()');
           expect(logMessage).toContain('faker.phone.number()');
-          expect(logMessage).toContain('v7.2.0');
+          expect(logMessage).toContain('v7.3.0');
           expect(logMessage).toContain('v8.0.0');
         });
       });

--- a/test/phone.spec.ts
+++ b/test/phone.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { faker } from '../src';
 import { luhnCheck } from '../src/modules/helpers/luhn-check';
 
@@ -118,20 +118,6 @@ describe('phone', () => {
           const phoneNumber = faker.phone.phoneNumber();
 
           expect(phoneNumber).toMatch(/\d/);
-        });
-
-        it('should log a deprecation message to the console', () => {
-          const consoleSpy = vi.spyOn(console, 'warn');
-
-          faker.phone.phoneNumber();
-
-          expect(consoleSpy).toHaveBeenCalled();
-          const logMessage = consoleSpy.mock.calls[0][0];
-          expect(logMessage).toContain('deprecated');
-          expect(logMessage).toContain('faker.phone.phoneNumber()');
-          expect(logMessage).toContain('faker.phone.number()');
-          expect(logMessage).toContain('v7.3.0');
-          expect(logMessage).toContain('v8.0.0');
         });
       });
 

--- a/test/phone.spec.ts
+++ b/test/phone.spec.ts
@@ -121,6 +121,14 @@ describe('phone', () => {
         });
       });
 
+      describe('number()', () => {
+        it('should return a random phoneNumber with a random format', () => {
+          const phoneNumber = faker.phone.number();
+
+          expect(phoneNumber).toMatch(/\d/);
+        });
+      });
+
       describe('phoneNumberFormat()', () => {
         it('should return phone number with proper US format (Array index)', () => {
           faker.locale = 'en';

--- a/test/phone.spec.ts
+++ b/test/phone.spec.ts
@@ -9,6 +9,9 @@ const seededRuns = [
       phoneNumber: {
         noArgs: '891.775.5141',
       },
+      number: {
+        noArgs: '891.775.5141',
+      },
       phoneNumberFormat: {
         noArgs: '479-377-5514',
         phoneFormatsArrayIndex: { arrayIndex: 1, expected: '(479) 377-5514' },
@@ -25,6 +28,9 @@ const seededRuns = [
     seed: 1337,
     expectations: {
       phoneNumber: {
+        noArgs: '(612) 454-0325',
+      },
+      number: {
         noArgs: '(612) 454-0325',
       },
       phoneNumberFormat: {
@@ -45,6 +51,9 @@ const seededRuns = [
       phoneNumber: {
         noArgs: '1-587-319-0616 x27431',
       },
+      number: {
+        noArgs: '1-587-319-0616 x27431',
+      },
       phoneNumberFormat: {
         noArgs: '948-821-9061',
         phoneFormatsArrayIndex: { arrayIndex: 1, expected: '(948) 821-9061' },
@@ -61,6 +70,7 @@ const seededRuns = [
 
 const functionNames = [
   'phoneNumber',
+  'number',
   'phoneNumberFormat',
   'phoneFormats',
   'imei',

--- a/test/phone.spec.ts
+++ b/test/phone.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { faker } from '../src';
 import { luhnCheck } from '../src/modules/helpers/luhn-check';
 
@@ -118,6 +118,20 @@ describe('phone', () => {
           const phoneNumber = faker.phone.phoneNumber();
 
           expect(phoneNumber).toMatch(/\d/);
+        });
+
+        it('should log a deprecation message to the console', () => {
+          const consoleSpy = vi.spyOn(console, 'warn');
+
+          faker.phone.phoneNumber();
+
+          expect(consoleSpy).toHaveBeenCalled();
+          const logMessage = consoleSpy.mock.calls[0][0];
+          expect(logMessage).toContain('deprecated');
+          expect(logMessage).toContain('faker.phone.phoneNumber()');
+          expect(logMessage).toContain('faker.phone.number()');
+          expect(logMessage).toContain('v7.2.0');
+          expect(logMessage).toContain('v8.0.0');
         });
       });
 


### PR DESCRIPTION
Listed as a todo in #1044.

This PR does the following things:
- move the implementation from `phone.phoneNumber()` into a new function called `phone.number()`
- deprecate `phone.phoneNumber()` via the internal deprecated method
- add a `@deprecated` JSDoc parameter to the `phone.phoneNumber()` signature documentation
- duplicates the test checks from `phoneNumber()` to `number()`
- add a test case for `phoneNumber()` deprecation log