### PR TITLE
refactor: Allow coordinate parameter to be [string, string]

### DIFF
--- a/src/modules/address/index.ts
+++ b/src/modules/address/index.ts
@@ -441,11 +441,11 @@ export class Address {
    * @example
    * faker.address.nearbyGPSCoordinate() // [ '33.8475', '-170.5953' ]
    * faker.address.nearbyGPSCoordinate([33, -170]) // [ '33.0165', '-170.0636' ]
+   * faker.address.nearbyGPSCoordinate([33, '-170']) // [ '33.0165', '-170.0636' ]
    * faker.address.nearbyGPSCoordinate([33, -170], 1000, true) // [ '37.9163', '-179.2408' ]
    */
-  // TODO ST-DDT 2022-02-10: Allow coordinate parameter to be [string, string].
   nearbyGPSCoordinate(
-    coordinate?: [latitude: number, longitude: number],
+    coordinate?: [latitude: number | string, longitude: number | string],
     radius: number = 10,
     isMetric: boolean = false
   ): [latitude: string, longitude: string] {
@@ -478,8 +478,8 @@ export class Address {
     const distanceInDegree = distanceInKm / kmPerDegree; // in °
 
     const newCoordinate: [latitude: number, longitude: number] = [
-      coordinate[0] + Math.sin(angleRadians) * distanceInDegree,
-      coordinate[1] + Math.cos(angleRadians) * distanceInDegree,
+      +coordinate[0] + Math.sin(angleRadians) * distanceInDegree,
+      +coordinate[1] + Math.cos(angleRadians) * distanceInDegree,
     ];
 
     // Box latitude [-90°, 90°]

--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -485,44 +485,51 @@ describe('address', () => {
       });
 
       describe('nearbyGPSCoordinate()', () => {
-        for (const isMetric of [true, false]) {
-          for (const radius of times(100)) {
-            it.each(times(5))(
-              `should return random gps coordinate within a distance of another one (${JSON.stringify(
-                { isMetric, radius }
-              )}) (iter: %s)`,
-              () => {
-                const latitude1 = faker.address.latitude();
-                const longitude1 = faker.address.longitude();
+        // all coordinate type combinations
+        const coordinates: [string | number, string | number][] = [
+          [faker.address.latitude(), faker.address.longitude()],
+          [+faker.address.latitude(), +faker.address.longitude()],
+          [+faker.address.latitude(), faker.address.longitude()],
+          [faker.address.latitude(), +faker.address.longitude()],
+        ];
 
-                const coordinate = faker.address.nearbyGPSCoordinate(
-                  [latitude1, longitude1],
-                  radius,
-                  isMetric
-                );
+        for (const [latitude, longitude] of coordinates) {
+          for (const isMetric of [true, false]) {
+            for (const radius of times(100)) {
+              it.each(times(5))(
+                `should return random gps coordinate within a distance of another one ([${typeof latitude}, ${typeof longitude}]) (${JSON.stringify(
+                  { isMetric, radius }
+                )}) (iter: %s)`,
+                () => {
+                  const coordinate = faker.address.nearbyGPSCoordinate(
+                    [latitude, longitude],
+                    radius,
+                    isMetric
+                  );
 
-                expect(coordinate.length).toBe(2);
-                expect(coordinate[0]).toBeTypeOf('string');
-                expect(coordinate[1]).toBeTypeOf('string');
+                  expect(coordinate.length).toBe(2);
+                  expect(coordinate[0]).toBeTypeOf('string');
+                  expect(coordinate[1]).toBeTypeOf('string');
 
-                const latitude2 = +coordinate[0];
-                expect(latitude2).toBeGreaterThanOrEqual(-90.0);
-                expect(latitude2).toBeLessThanOrEqual(90.0);
+                  const latitude2 = +coordinate[0];
+                  expect(latitude2).toBeGreaterThanOrEqual(-90.0);
+                  expect(latitude2).toBeLessThanOrEqual(90.0);
 
-                const longitude2 = +coordinate[1];
-                expect(longitude2).toBeGreaterThanOrEqual(-180.0);
-                expect(longitude2).toBeLessThanOrEqual(180.0);
+                  const longitude2 = +coordinate[1];
+                  expect(longitude2).toBeGreaterThanOrEqual(-180.0);
+                  expect(longitude2).toBeLessThanOrEqual(180.0);
 
-                const actualDistance = haversine(
-                  +latitude1,
-                  +longitude1,
-                  latitude2,
-                  longitude2,
-                  isMetric
-                );
-                expect(actualDistance).toBeLessThanOrEqual(radius);
-              }
-            );
+                  const actualDistance = haversine(
+                    +latitude,
+                    +longitude,
+                    latitude2,
+                    longitude2,
+                    isMetric
+                  );
+                  expect(actualDistance).toBeLessThanOrEqual(radius);
+                }
+              );
+            }
           }
         }
       });

--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -492,8 +492,8 @@ describe('address', () => {
                 { isMetric, radius }
               )}) (iter: %s)`,
               () => {
-                const latitude1 = +faker.address.latitude();
-                const longitude1 = +faker.address.longitude();
+                const latitude1 = faker.address.latitude();
+                const longitude1 = faker.address.longitude();
 
                 const coordinate = faker.address.nearbyGPSCoordinate(
                   [latitude1, longitude1],
@@ -514,8 +514,8 @@ describe('address', () => {
                 expect(longitude2).toBeLessThanOrEqual(180.0);
 
                 const actualDistance = haversine(
-                  latitude1,
-                  longitude1,
+                  +latitude1,
+                  +longitude1,
                   latitude2,
                   longitude2,
                   isMetric


### PR DESCRIPTION
Hello! This is my first contribution to this great repo 🙏. Hope it helps!

Opted for :
`coordinate?: [longitude: number | string, latitude: number | string]`
instead of this:
`coordinate?: [longitude: number, latitude: number] | [longitude: string, latitude: string]`

Made sense to me given my approach coerces both into numbers either way. Hopefully this is what you were looking for.

Thank you!