### PR TITLE
chore(lorempixel.avatar): deprecate

### DIFF
--- a/src/modules/image/providers/lorempixel.ts
+++ b/src/modules/image/providers/lorempixel.ts
@@ -1,4 +1,5 @@
 import type { Faker } from '../../..';
+import { deprecated } from '../../../internal/deprecated';
 import type { MethodsOf } from '../../../utils/types';
 
 /**
@@ -40,12 +41,21 @@ export class Lorempixel {
   /**
    * Returns a random avatar url.
    *
+   * @see faker.internet.avatar()
+   *
    * @example
    * faker.internet.avatar()
    * // 'https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/315.jpg'
+   *
+   * @deprecated
    */
-  // TODO ST-DDT 2022-03-11: Deprecate this method as it is duplicate and has nothing to do with lorempixel.
   avatar(): string {
+    deprecated({
+      deprecated: 'faker.image.lorempixel.avatar()',
+      proposed: 'faker.internet.avatar()',
+      since: 'v7.3.0',
+      until: 'v8.0.0',
+    });
     return this.faker.internet.avatar();
   }
 

--- a/src/modules/image/providers/lorempixel.ts
+++ b/src/modules/image/providers/lorempixel.ts
@@ -53,8 +53,8 @@ export class Lorempixel {
     deprecated({
       deprecated: 'faker.image.lorempixel.avatar()',
       proposed: 'faker.internet.avatar()',
-      since: 'v7.3.0',
-      until: 'v8.0.0',
+      since: '7.3',
+      until: '8.0',
     });
     return this.faker.internet.avatar();
   }

--- a/test/image.spec.ts
+++ b/test/image.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { faker } from '../src';
 
 describe('image', () => {
@@ -125,6 +125,21 @@ describe('image', () => {
               'cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar'
             )
         ).toBeTruthy();
+      });
+
+      it('should log a deprecation message', () => {
+        const consoleSpy = vi.spyOn(console, 'warn');
+
+        faker.image.lorempixel.avatar();
+
+        expect(consoleSpy).toHaveBeenCalled();
+
+        const logMessage = consoleSpy.mock.calls[0][0];
+        expect(logMessage).toContain('deprecated');
+        expect(logMessage).toContain('faker.image.lorempixel.avatar()');
+        expect(logMessage).toContain('faker.internet.avatar()');
+        expect(logMessage).toContain('v7.3.0');
+        expect(logMessage).toContain('v8.0.0');
       });
     });
 

--- a/test/image.spec.ts
+++ b/test/image.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { faker } from '../src';
 
 describe('image', () => {
@@ -125,21 +125,6 @@ describe('image', () => {
               'cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar'
             )
         ).toBeTruthy();
-      });
-
-      it('should log a deprecation message', () => {
-        const consoleSpy = vi.spyOn(console, 'warn');
-
-        faker.image.lorempixel.avatar();
-
-        expect(consoleSpy).toHaveBeenCalled();
-
-        const logMessage = consoleSpy.mock.calls[0][0];
-        expect(logMessage).toContain('deprecated');
-        expect(logMessage).toContain('faker.image.lorempixel.avatar()');
-        expect(logMessage).toContain('faker.internet.avatar()');
-        expect(logMessage).toContain('v7.3.0');
-        expect(logMessage).toContain('v8.0.0');
       });
     });
 


### PR DESCRIPTION
Listed as a todo in #1044 

Deprecates `lorempixel.avatar()` in favor of `internet.avatar()`