### PR TITLE
fix: lower target to support Webpack 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [14.6, 16, 18]
+        node_version: [14, 16, 18]
         include:
           - os: macos-latest
             node_version: 16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [14, 16, 18]
+        node_version: [14.6, 16, 18]
         include:
           - os: macos-latest
             node_version: 16

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -7,6 +7,8 @@ console.log('Building dist for node (cjs)...');
 
 // Generate entry-points for cjs compatibility
 const localeDir = 'locale';
+const target = ['ES2019', 'node14.6'];
+
 if (existsSync(localeDir)) {
   rmSync(localeDir, { recursive: true, force: true });
 }
@@ -33,7 +35,7 @@ buildSync({
   // splitting: true, // Doesn't work with cjs
   format: 'cjs',
   platform: 'node',
-  target: 'es2019',
+  target,
 });
 
 console.log('Building dist for node type=module (esm)...');
@@ -48,6 +50,6 @@ buildSync({
   minify: true,
   splitting: true,
   format: 'esm',
-  target: 'es2019',
+  target,
   outExtension: { '.js': '.mjs' },
 });

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -33,7 +33,7 @@ buildSync({
   // splitting: true, // Doesn't work with cjs
   format: 'cjs',
   platform: 'node',
-  target: 'node14',
+  target: 'es2019',
 });
 
 console.log('Building dist for node type=module (esm)...');
@@ -48,6 +48,6 @@ buildSync({
   minify: true,
   splitting: true,
   format: 'esm',
-  target: 'node14',
+  target: 'es2019',
   outExtension: { '.js': '.mjs' },
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2019",
+    "target": "ES2019",
     "moduleResolution": "Node",
     "rootDir": "src",
     "outDir": "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "es2019",
     "moduleResolution": "Node",
     "rootDir": "src",
     "outDir": "dist",


### PR DESCRIPTION
This PR  would fix #1073 and target es2019 instead of dropping support for Webpack 4 (which I don't think we should do -- a lot of users are still stuck on Webpack 4, despite how long it has been out).

We're mainly having issues because we use nullish coalescing internally. This requires a target of es2019 instead of es2020. https://esbuild.github.io/content-types/#javascript

Also would fix https://github.com/cypress-io/cypress/issues/21874