### PR TITLE
docs(address.streetPrefix): refactor JSDOC example

### DIFF
--- a/src/modules/address/index.ts
+++ b/src/modules/address/index.ts
@@ -231,7 +231,7 @@ export class Address {
    * Returns a random localized street prefix.
    *
    * @example
-   * fakerGH.address.streetPrefix() // 'Boame'
+   * faker.address.streetPrefix() // 'Boame'
    */
   streetPrefix(): string {
     return this.faker.helpers.arrayElement(


### PR DESCRIPTION
Updated a JSDOC example that was not using the default `faker` module. Could also have been a typo, IDK. 