### PR TITLE
chore(linter): set 'jsdoc/sort-tags' rule to 'error'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,9 +72,7 @@ module.exports = defineConfig({
         'jsdoc/require-returns-type': 'off',
         'jsdoc/require-returns': 'off',
         'jsdoc/tag-lines': 'off',
-
-        // We want to explicitly set this rule to error in the future
-        'jsdoc/sort-tags': 'warn',
+        'jsdoc/sort-tags': 'error',
       },
       settings: {
         jsdoc: {


### PR DESCRIPTION
Since we have no warnings for the `jsdoc/sort-tags` eslint rule anymore I promoted its mode from `'warning'` to `'error'` as stated in the comment above.