### PR TITLE
chore: lint switch case blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,14 +26,31 @@ module.exports = defineConfig({
   },
   plugins: ['@typescript-eslint', 'prettier'],
   rules: {
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
     // We may want to use this in the future
     'no-useless-escape': 'off',
-    eqeqeq: ['error', 'always', { null: 'ignore' }],
+    'padding-line-between-statements': [
+      'error',
+      {
+        blankLine: 'never',
+        prev: ['case', 'default'],
+        next: '*',
+      },
+    ],
     'prefer-template': 'error',
 
     '@typescript-eslint/ban-ts-comment': 'warn',
     '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        format: ['PascalCase'],
+        selector: ['class', 'interface', 'typeAlias', 'enumMember'],
+        leadingUnderscore: 'forbid',
+        trailingUnderscore: 'forbid',
+      },
+    ],
     '@typescript-eslint/no-inferrable-types': [
       'error',
       { ignoreParameters: true },
@@ -50,16 +67,8 @@ module.exports = defineConfig({
         allowBoolean: true,
       },
     ],
+    '@typescript-eslint/switch-exhaustiveness-check': 'warn',
     '@typescript-eslint/unbound-method': 'off',
-    '@typescript-eslint/naming-convention': [
-      'error',
-      {
-        format: ['PascalCase'],
-        selector: ['class', 'interface', 'typeAlias', 'enumMember'],
-        leadingUnderscore: 'forbid',
-        trailingUnderscore: 'forbid',
-      },
-    ],
   },
   overrides: [
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,7 +67,7 @@ module.exports = defineConfig({
         allowBoolean: true,
       },
     ],
-    '@typescript-eslint/switch-exhaustiveness-check': 'warn',
+    '@typescript-eslint/switch-exhaustiveness-check': 'error',
     '@typescript-eslint/unbound-method': 'off',
   },
   overrides: [

--- a/scripts/apidoc/signature.ts
+++ b/scripts/apidoc/signature.ts
@@ -267,10 +267,8 @@ function declarationTypeToText(
   switch (declaration.kind) {
     case ReflectionKind.Method:
       return signatureTypeToText(declaration.signatures?.[0]);
-
     case ReflectionKind.Property:
       return typeToText(declaration.type);
-
     case ReflectionKind.TypeLiteral:
       if (declaration.children?.length) {
         if (short) {
@@ -288,7 +286,6 @@ function declarationTypeToText(
       } else {
         return declaration.toString();
       }
-
     default:
       return declaration.toString();
   }

--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -57,6 +57,9 @@ function formatHexColor(
     case 'lower':
       hexColor = hexColor.toLowerCase();
       break;
+    case 'mixed':
+      // do nothing
+      break;
   }
   if (options?.prefix) {
     hexColor = options.prefix + hexColor;

--- a/test/color.spec.ts
+++ b/test/color.spec.ts
@@ -80,22 +80,29 @@ describe('color', () => {
         });
       });
 
+      describe(`rgb({ casing: 'mixed' })`, () => {
+        it('should return a random rgb hex color with mixed casing', () => {
+          const color = faker.color.rgb({ casing: 'mixed' });
+          expect(color).match(/^(#[A-Fa-f0-9]{6})$/);
+        });
+      });
+
       describe(`rgb({ prefix: '0x' })`, () => {
-        it('should return a random rgb hex color with # prefix', () => {
+        it('should return a random rgb hex color with 0x prefix', () => {
           const color = faker.color.rgb({ prefix: '0x' });
           expect(color).match(/^(0x[a-f0-9]{6})$/);
         });
       });
 
       describe(`rgbHex({ prefix: '0x', case: 'lower' })`, () => {
-        it('should return a random rgb hex color with # prefix and lower case only', () => {
+        it('should return a random rgb hex color with 0x prefix and lower case only', () => {
           const color = faker.color.rgb({ prefix: '0x', casing: 'lower' });
           expect(color).match(/^(0x[a-f0-9]{6})$/);
         });
       });
 
       describe(`rgb({ prefix: '0x', case: 'upper' })`, () => {
-        it('should return a random rgb hex color with # prefix and upper case only', () => {
+        it('should return a random rgb hex color with 0x prefix and upper case only', () => {
           const color = faker.color.rgb({ prefix: '0x', casing: 'upper' });
           expect(color).match(/^(0x[A-F0-9]{6})$/);
         });


### PR DESCRIPTION
This PR introduces the eslint rule [padding-line-between-statements](https://eslint.org/docs/latest/rules/padding-line-between-statements). This rule should apply to each case of a switch statement for now. 