### PR TITLE
fix: remove prohibited char `i` in bitcoinAddress generation

### DIFF
--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -217,7 +217,7 @@ export class Finance {
 
     for (let i = 0; i < addressLength - 1; i++)
       address += this.faker.helpers.arrayElement(
-        '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'.split('')
+        '123456789abcdefghjkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'.split('')
       );
 
     return address;

--- a/test/__snapshots__/finance.spec.ts.snap
+++ b/test/__snapshots__/finance.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`finance > 42 > amount > with min and max and dec and symbol 1`] = `"$24
 
 exports[`finance > 42 > bic 1`] = `"UYEOSCP1514"`;
 
-exports[`finance > 42 > bitcoinAddress 1`] = `"3XbJMAAara64sSkA9HD24YHQWd1b"`;
+exports[`finance > 42 > bitcoinAddress 1`] = `"3XbJMBB9s964tSmB9HE24YJQWd1b"`;
 
 exports[`finance > 42 > creditCardCVV 1`] = `"379"`;
 
@@ -82,7 +82,7 @@ exports[`finance > 1211 > amount > with min and max and dec and symbol 1`] = `"$
 
 exports[`finance > 1211 > bic 1`] = `"LXUEBTZ1"`;
 
-exports[`finance > 1211 > bitcoinAddress 1`] = `"1TMe8Z3EaFdLqmaGKP1LEEJQVriSZRZdsA"`;
+exports[`finance > 1211 > bitcoinAddress 1`] = `"1TMd8Z3FaGdLqnaGKP1LEEJQVrjSZRZdsA"`;
 
 exports[`finance > 1211 > creditCardCVV 1`] = `"948"`;
 
@@ -146,7 +146,7 @@ exports[`finance > 1337 > amount > with min and max and dec and symbol 1`] = `"$
 
 exports[`finance > 1337 > bic 1`] = `"OEFELYL1032"`;
 
-exports[`finance > 1337 > bitcoinAddress 1`] = `"3adhxs2jewAgkYgJi7No6Cn8JZa"`;
+exports[`finance > 1337 > bitcoinAddress 1`] = `"3adgxt2kewAfmYgJj7Np6Cn8KZa"`;
 
 exports[`finance > 1337 > creditCardCVV 1`] = `"251"`;
 


### PR DESCRIPTION
According to [the Bitcoin wiki](https://en.bitcoinwiki.org/wiki/Bitcoin_address), Bitcoin addresses "consist of random digits and uppercase and lowercase letters, with the exception that the uppercase letter "O", uppercase letter "I", lowercase letter "i", and the number "0" are never used to prevent visual ambiguity."

I noticed that when generating bitcoin addresses, `finance.bitcoinAddress()` excludes the characters `O`, `I`, and `0` successfully, but it does not exclude the lowercase character `i`.
https://github.com/faker-js/faker/blob/895799b23e8224eb1b623ef1d0ffd508f101389f/src/modules/finance/index.ts#L218-L221

I deleted the character `i` from the generation so that it doesn't show up in our bitcoin addresses.