### PR TITLE
fix(lorem.word): return word with maximum possible length when expected length is too large

### DIFF
--- a/src/modules/lorem/index.ts
+++ b/src/modules/lorem/index.ts
@@ -18,20 +18,36 @@ export class Lorem {
    * Generates a word of a specified length.
    *
    * @param length length of the word that should be returned. Defaults to a random length.
+   * If a word with the specified length does not exist return a word with maximum possible length.
    *
    * @example
    * faker.lorem.word() // 'temporibus'
    * faker.lorem.word(5) // 'velit'
+   * faker.lorem.word(9999) // 'necessitatibus'
    */
   word(length?: number): string {
-    const hasRightLength = (word: string) => word.length === length;
     let properLengthWords: readonly string[];
+
     if (length == null) {
       properLengthWords = this.faker.definitions.lorem.words;
     } else {
-      properLengthWords =
-        this.faker.definitions.lorem.words.filter(hasRightLength);
+      let maxLength = 0;
+
+      properLengthWords = this.faker.definitions.lorem.words.filter((word) => {
+        if (word.length > maxLength) {
+          maxLength = word.length;
+        }
+
+        return word.length === length;
+      });
+
+      if (properLengthWords.length === 0) {
+        properLengthWords = this.faker.definitions.lorem.words.filter(
+          (word) => word.length === maxLength
+        );
+      }
     }
+
     return this.faker.helpers.arrayElement(properLengthWords);
   }
 

--- a/test/lorem.spec.ts
+++ b/test/lorem.spec.ts
@@ -38,8 +38,15 @@ describe('lorem', () => {
           expect(faker.definitions.lorem.words).toContain(actual);
         });
 
-        // INFO @Shinigami92 2022-02-11: Seems there are only words with a max length of 14 characters
-        it.each(times(14))(
+        const maxLength = faker.definitions.lorem.words.reduce((len, word) => {
+          if (word.length > len) {
+            len = word.length;
+          }
+
+          return len;
+        }, 0);
+
+        it.each(times(maxLength))(
           'should return random value from word array with a max length of %i characters',
           (length) => {
             const actual = faker.lorem.word(length);
@@ -50,6 +57,15 @@ describe('lorem', () => {
             expect(actual).toHaveLength(length);
           }
         );
+
+        it('should return random value from word array with maximum length', () => {
+          const actual = faker.lorem.word(maxLength + 99);
+
+          expect(actual).toBeTruthy();
+          expect(actual).toBeTypeOf('string');
+          expect(faker.definitions.lorem.words).toContain(actual);
+          expect(actual).toHaveLength(maxLength);
+        });
       });
 
       describe('words()', () => {


### PR DESCRIPTION
Fixes #1131