### PR TITLE
test: validate @see contents

### DIFF
--- a/test/scripts/apidoc/examplesAndDeprecations.spec.ts
+++ b/test/scripts/apidoc/examplesAndDeprecations.spec.ts
@@ -111,6 +111,15 @@ describe('examples and deprecations', () => {
           expect(spy).not.toHaveBeenCalled();
         }
       }
+
+      // Verify @see tag
+      extractTagContent('@see', signature).forEach((link) => {
+        if (link.startsWith('faker')) {
+          // Expected @see faker.xxx.yyy()
+          expect(link, 'Expect method reference to contain ()').toContain('(');
+          expect(link, 'Expect method reference to contain ()').toContain(')');
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
Checks that all `@see faker` method references to contain `(...)`.

**Invalid:**  `@see faker.helpers.arrayElement`
**Valid:**  `@see faker.helpers.arrayElement()`

Note: I'm not sure whether empty `()` are the correct way to have. Especially, if the method requires parameters.