### PR TITLE
chore(address): remove obsolete TODO

### DIFF
--- a/src/modules/address/index.ts
+++ b/src/modules/address/index.ts
@@ -465,7 +465,6 @@ export class Address {
    * faker.address.nearbyGPSCoordinate([33, -170]) // [ '33.0165', '-170.0636' ]
    * faker.address.nearbyGPSCoordinate([33, -170], 1000, true) // [ '37.9163', '-179.2408' ]
    */
-  // TODO ST-DDT 2022-02-10: Allow coordinate parameter to be [string, string].
   nearbyGPSCoordinate(
     coordinate?: [latitude: number, longitude: number],
     radius: number = 10,


### PR DESCRIPTION
As discussed in a previous team meeting. We won't support string coordinates in the long run, so it doesn't make sense to allow it as input parameter either.

Suggested workaround: The user should use type coercion if necessary while passing the parameters.