### PR TITLE
docs: fix browser usage

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -53,9 +53,10 @@ const randomEmail = faker.internet.email(); // Kassandra.Haley@erich.biz
 ### Browser
 
 ```html
-<script type="text/javascript" src="https://unpkg.com/@faker-js/faker"></script>
+<!-- Since v6 only type=module is supported -->
+<script type="module">
+  import { faker } from 'https://cdn.skypack.dev/@faker-js/faker';
 
-<script>
   // Caitlyn Kerluke
   const randomName = faker.name.fullName();
 
@@ -65,7 +66,7 @@ const randomEmail = faker.internet.email(); // Kassandra.Haley@erich.biz
 ```
 
 :::tip Note
-Using the browser is great for experimenting 👍. However, due to all of the strings Faker uses to generate fake data, **Faker is a large package**. It's `> 5 MiB` minified. **Please avoid deploying Faker in your web app.**
+Using the browser is great for experimenting 👍. However, due to all of the strings Faker uses to generate fake data, **Faker is a large package**. It's `> 5 MiB` minified. **Please avoid deploying the full Faker in your web app.**
 :::
 
 ### CDN/Deno


### PR DESCRIPTION
our docs point to some invalid usage
since v6 we only support using type module for browser
this supersede #1001

tested it locally with a static `index.html`