### PR TITLE
test(internet): fix username expecting numbers with length 2

### DIFF
--- a/test/internet.spec.ts
+++ b/test/internet.spec.ts
@@ -101,7 +101,7 @@ describe('internet', () => {
 
           expect(prefix).includes('Aiden.Harann55');
           expect(prefix).toMatch(
-            /^(Aiden\.Harann55((\d{2})|([._][A-Za-z]*(\d{2})?)))/
+            /^(Aiden\.Harann55((\d{1,2})|([._][A-Za-z]*(\d{1,2})?)))/
           );
           expect(faker.definitions.internet.free_email).toContain(suffix);
         });
@@ -117,7 +117,7 @@ describe('internet', () => {
 
           expect(prefix).includes('Aiden');
           expect(prefix).toMatch(
-            /^Aiden((\d{2})|([._]Harann\d{2})|([._](Harann)))/
+            /^Aiden((\d{1,2})|([._]Harann\d{1,2})|([._](Harann)))/
           );
           expect(faker.definitions.internet.free_email).toContain(suffix);
         });
@@ -147,7 +147,7 @@ describe('internet', () => {
           const [prefix, suffix] = email.split('@');
 
           expect(prefix).toMatch(
-            /^Mike((\d{2})|([.!#$%&'*+-/=?^_`{|}~]Smith\d{2})|([.!#$%&'*+-/=?^_`{|}~]Smith))/
+            /^Mike((\d{1,2})|([.!#$%&'*+-/=?^_`{|}~]Smith\d{1,2})|([.!#$%&'*+-/=?^_`{|}~]Smith))/
           );
           expect(faker.definitions.internet.free_email).toContain(suffix);
         });
@@ -251,7 +251,7 @@ describe('internet', () => {
           expect(username).toBeTypeOf('string');
           expect(username).includes('Aiden');
           expect(username).toMatch(
-            /^Aiden((\d{2})|([._]Harann\d{2})|([._](Harann)))/
+            /^Aiden((\d{1,2})|([._]Harann\d{1,2})|([._](Harann)))/
           );
         });
       });


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->
Found in #1059. 

The implementation of `internet.username()` uses the provided first and last name and can append a random number to them. This number is between 0 and 99 (inclusive). 
https://github.com/faker-js/faker/blob/93ef876e54886c2b13afda2e69e1b656dbbdc1f0/src/modules/internet/index.ts#L142-L145

The test on the other hand side uses a regex that expects the email to have a number (if existing) that has at least a length of 2.

This PR fixes the described issue.