### PR TITLE
infra: set renovate schedule to weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,9 +3,7 @@
   "extends": ["config:base", "schedule:daily", "group:allNonMajor"],
   "labels": ["c: dependencies"],
   "reviewersFromCodeOwners": true,
-  "schedule": [
-    "at 12am on Monday"
-  ],
+  "schedule": ["at 12am on Monday"],
   "rangeStrategy": "bump",
   "packageRules": [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,11 @@
   "extends": ["config:base", "schedule:daily", "group:allNonMajor"],
   "labels": ["c: dependencies"],
   "reviewersFromCodeOwners": true,
+  "schedule": [
+    // We must use the * wildcard for minutes, as Renovate doesn't support minute granularity
+    // Every minute, between 12:00 AM and 12:59 AM, only on Monday (minutes are not suppoted)
+    "* 0 * * MON"
+  ],
   "rangeStrategy": "bump",
   "packageRules": [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,9 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:daily", "group:allNonMajor"],
+  "extends": ["config:base", "schedule:earlyMondays", "group:allNonMajor"],
   "labels": ["c: dependencies"],
   "reviewersFromCodeOwners": true,
-  "schedule": ["at 12am on Monday"],
   "rangeStrategy": "bump",
   "packageRules": [
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,9 +4,7 @@
   "labels": ["c: dependencies"],
   "reviewersFromCodeOwners": true,
   "schedule": [
-    // We must use the * wildcard for minutes, as Renovate doesn't support minute granularity
-    // Every minute, between 12:00 AM and 12:59 AM, only on Monday (minutes are not suppoted)
-    "* 0 * * MON"
+    "at 12am on Monday"
   ],
   "rangeStrategy": "bump",
   "packageRules": [


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->
This PR changes the interval from "at any time" to a weekly basis every Monday morning via a [cron](https://crontab.guru/crontab.5.html) expression. 

Important reference links:
- [Renovate schedule config](https://docs.renovatebot.com/configuration-options/#schedule)
- [Cron expression descriptor (for cron expression validation)](https://crontab.cronhub.io/)