### PR TITLE
docs(datatype): fix hexadecimal jsdoc

### DIFF
--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -197,7 +197,7 @@ export class Datatype {
    * faker.datatype.hexadecimal() // '0xB'
    * faker.datatype.hexadecimal({ length: 10 }) // '0xaE13d044cB'
    * faker.datatype.hexadecimal({ prefix: '0x' }) // '0xE'
-   * faker.datatype.hexadecimal({ case: 'lower' }) // 'f'
+   * faker.datatype.hexadecimal({ case: 'lower' }) // '0xf'
    * faker.datatype.hexadecimal({ length: 10, prefix: '#' }) // '#f12a974eB1'
    * faker.datatype.hexadecimal({ length: 10, case: 'upper' }) // '0xE3F38014FB'
    * faker.datatype.hexadecimal({ prefix: '', case: 'lower' }) // 'd'


### PR DESCRIPTION
Fix errant jsdoc to account for the default `prefix` now being `0x`