### PR TITLE
fix(internal): Fix typo in deprecation message

### DIFF
--- a/src/internal/deprecated.ts
+++ b/src/internal/deprecated.ts
@@ -41,7 +41,7 @@ export function deprecated(opts: DeprecatedOptions): void {
   }
 
   if (opts.proposed) {
-    message += `. Please use ${opts.proposed} instead.`;
+    message += `. Please use ${opts.proposed} instead`;
   }
 
   console.warn(`${message}.`);


### PR DESCRIPTION
Remove duplicate dot at EOL.

````diff
- [@faker-js/faker]: faker.image.lorempicsum.avatar() is deprecated since v7.3 and will be removed in v8.0. Please use faker.internet.avatar() instead..
+ [@faker-js/faker]: faker.image.lorempicsum.avatar() is deprecated since v7.3 and will be removed in v8.0. Please use faker.internet.avatar() instead.
````