### PR TITLE
docs: update order of headings to be semantically correct

### DIFF
--- a/docs/guide/migration-guide-v5.md
+++ b/docs/guide/migration-guide-v5.md
@@ -34,7 +34,7 @@ If you depend on a specific version of Faker you still can reference the version
 Faker now ships with its own types! Remove `@types/faker` from your `package.json` to avoid conflicts.
 :::
 
-### Tree-shaking
+## Tree-shaking
 
 :::warning
 Tree shaking is not yet fully supported due to some structural issues. But we plan to make Faker fully tree-shakable in the future.

--- a/docs/guide/migration-guide-v5.md
+++ b/docs/guide/migration-guide-v5.md
@@ -2,7 +2,7 @@
 
 [[toc]]
 
-### ESM Support
+## ESM Support
 
 **New Format**: We're now ESM compatible! We've dropped the Browser bundle in favor of ESM.
 
@@ -16,7 +16,7 @@ So if you'd like to use `Faker` in the **browser**, simply include it using a [J
 </script>
 ```
 
-### Remove all references to `faker` from your project. The new package is located at `@faker-js/faker`
+## Remove all references to `faker` from your project. The new package is located at `@faker-js/faker`
 
 :::warning
 You **MUST** swap all references from the `faker` package to the new `@faker-js/faker` package.
@@ -28,7 +28,7 @@ If you depend on a specific version of Faker you still can reference the version
 `npm i @faker-js/faker@5.5.3 -D` will work just fine 😄.
 :::
 
-### TypeScript
+## TypeScript
 
 :::tip TypeScript Improvements
 Faker now ships with its own types! Remove `@types/faker` from your `package.json` to avoid conflicts.

--- a/docs/guide/migration-guide-v6.md
+++ b/docs/guide/migration-guide-v6.md
@@ -2,11 +2,11 @@
 
 [[toc]]
 
-### Node 12 no longer supported
+## Node 12 no longer supported
 
 You need at least Node 14 to use Faker.
 
-### Default export removed
+## Default export removed
 
 If you were previously importing faker like this:
 
@@ -20,7 +20,7 @@ You must instead use:
 import { faker } from '@faker-js/faker';
 ```
 
-### Deprecated methods changed
+## Deprecated methods changed
 
 Several methods were renamed or moved:
 
@@ -39,7 +39,7 @@ Several methods were renamed or moved:
 | faker.datatype.hexaDecimal | faker.datatype.hexadecimal                             |
 | faker.name.title           | faker.name.jobTitle                                    |
 
-### Deprecated methods removed
+## Deprecated methods removed
 
 Some methods were removed without a direct alternative. If you are using any of these methods you should build an object containing the specific properties you need.
 


### PR DESCRIPTION
These changes ensures that headings are in a logical order in several files using markdown.

> For example, the heading level following an h1 element should be an h2 element, not an h3 element.

source:  https://dequeuniversity.com/rules/axe/4.4/heading-order