### PR TITLE
docs: add `@since` tags to all methods

### DIFF
--- a/docs/.vitepress/components/api-docs/method.ts
+++ b/docs/.vitepress/components/api-docs/method.ts
@@ -6,6 +6,7 @@ export interface Method {
   readonly returns: string;
   readonly examples: string; // HTML
   readonly deprecated: boolean;
+  readonly since: string;
   readonly seeAlsos: string[];
 }
 

--- a/docs/.vitepress/components/api-docs/method.vue
+++ b/docs/.vitepress/components/api-docs/method.vue
@@ -19,6 +19,12 @@ function seeAlsoToUrl(see: string): string {
 
     <div v-html="props.method.description"></div>
 
+    <div v-if="props.method.since">
+      <p>
+        <em>Available since v<span v-html="props.method.since" /></em>
+      </p>
+    </div>
+
     <MethodParameters
       v-if="props.method.parameters.length > 0"
       :parameters="props.method.parameters"

--- a/scripts/apidoc/signature.ts
+++ b/scripts/apidoc/signature.ts
@@ -21,11 +21,11 @@ import { faker } from '../../src';
 import {
   extractRawExamples,
   extractSeeAlsos,
+  extractSince,
   formatTypescript,
   isDeprecated,
   joinTagParts,
   pathOutputDir,
-  since,
 } from './utils';
 
 export function prettifyMethodName(method: string): string {
@@ -154,7 +154,7 @@ export function analyzeSignature(
     title: prettyMethodName,
     description: mdToHtml(toBlock(signature.comment)),
     parameters: parameters,
-    since: since(signature),
+    since: extractSince(signature),
     returns: typeToText(signature.type),
     examples: mdToHtml(`${code}ts\n${examples}${code}`),
     deprecated: isDeprecated(signature),

--- a/scripts/apidoc/signature.ts
+++ b/scripts/apidoc/signature.ts
@@ -25,6 +25,7 @@ import {
   isDeprecated,
   joinTagParts,
   pathOutputDir,
+  since,
 } from './utils';
 
 export function prettifyMethodName(method: string): string {
@@ -153,6 +154,7 @@ export function analyzeSignature(
     title: prettyMethodName,
     description: mdToHtml(toBlock(signature.comment)),
     parameters: parameters,
+    since: since(signature),
     returns: typeToText(signature.type),
     examples: mdToHtml(`${code}ts\n${examples}${code}`),
     deprecated: isDeprecated(signature),

--- a/scripts/apidoc/utils.ts
+++ b/scripts/apidoc/utils.ts
@@ -154,6 +154,6 @@ export function isDeprecated(signature: SignatureReflection): boolean {
  *
  * @returns the contents of the @since tag
  */
-export function since(signature: SignatureReflection): string {
+export function extractSince(signature: SignatureReflection): string {
   return extractTagContent('@since', signature).join().trim();
 }

--- a/scripts/apidoc/utils.ts
+++ b/scripts/apidoc/utils.ts
@@ -146,3 +146,14 @@ export function joinTagParts(parts?: CommentDisplayPart[]): string | undefined {
 export function isDeprecated(signature: SignatureReflection): boolean {
   return extractTagContent('@deprecated', signature).length > 0;
 }
+
+/**
+ * Extracts the "since" tag from the provided signature.
+ *
+ * @param signature The signature to check.
+ *
+ * @returns the contents of the @since tag
+ */
+export function since(signature: SignatureReflection): string {
+  return extractTagContent('@since', signature).join().trim();
+}

--- a/src/modules/address/index.ts
+++ b/src/modules/address/index.ts
@@ -102,7 +102,6 @@ export class Address {
    * @example
    * faker.address.cityPrefix() // 'East'
    *
-   *
    * @since 2.0.1
    *
    * @deprecated

--- a/src/modules/address/index.ts
+++ b/src/modules/address/index.ts
@@ -28,6 +28,7 @@ export class Address {
    * faker.address.zipCode() // '17839'
    * faker.address.zipCode('####') // '6925'
    *
+   * @since 2.0.1
    */
   zipCode(format?: string): string {
     // if zip format is not specified, use the zip format defined for the locale
@@ -54,6 +55,8 @@ export class Address {
    * @example
    * fakerUS.address.zipCodeByState("AK") // '99595'
    * fakerUS.address.zipCodeByState("??") // '47683-9880'
+   *
+   * @since 5.0.0
    */
   zipCodeByState(state: string): string {
     const zipRange = this.faker.definitions.address.postcode_by_state?.[state];
@@ -70,6 +73,8 @@ export class Address {
    *
    * @example
    * faker.address.city() // 'East Jarretmouth'
+   *
+   * @since 2.0.1
    */
   city(format?: string | number): string {
     if (format != null) {
@@ -97,6 +102,9 @@ export class Address {
    * @example
    * faker.address.cityPrefix() // 'East'
    *
+   *
+   * @since 2.0.1
+   *
    * @deprecated
    * Use `faker.address.city()` instead.
    */
@@ -120,6 +128,8 @@ export class Address {
    * @example
    * faker.address.citySuffix() // 'mouth'
    *
+   * @since 2.0.1
+   *
    * @deprecated
    * Use `faker.address.city()` instead.
    */
@@ -141,6 +151,8 @@ export class Address {
    *
    * @example
    * faker.address.cityName() // 'San Rafael'
+   *
+   * @since 5.5.0
    */
   cityName(): string {
     return this.faker.helpers.arrayElement(
@@ -153,6 +165,8 @@ export class Address {
    *
    * @example
    * faker.address.buildingNumber() // '379'
+   *
+   * @since 6.2.0
    */
   buildingNumber(): string {
     const format = this.faker.helpers.arrayElement(
@@ -167,6 +181,8 @@ export class Address {
    *
    * @example
    * faker.address.street() // 'Schroeder Isle'
+   *
+   * @since 7.0.0
    */
   street(): string {
     const format = this.faker.helpers.arrayElement(
@@ -180,6 +196,8 @@ export class Address {
    *
    * @example
    * fakerDE.address.streetName() // 'Cavill Avenue'
+   *
+   * @since 2.0.1
    */
   streetName(): string {
     if (this.faker.definitions.address.street_name == null) {
@@ -208,6 +226,8 @@ export class Address {
    * faker.address.streetAddress() // '0917 O'Conner Estates'
    * faker.address.streetAddress(false) // '34830 Erdman Hollow'
    * faker.address.streetAddress(true) // '3393 Ronny Way Apt. 742'
+   *
+   * @since 2.0.1
    */
   streetAddress(useFullAddress: boolean = false): string {
     const formats = this.faker.definitions.address.street_address;
@@ -223,6 +243,8 @@ export class Address {
    *
    * @example
    * faker.address.streetSuffix() // 'Streets'
+   *
+   * @since 2.0.1
    *
    * @deprecated Use faker.address.street() instead.
    */
@@ -246,6 +268,8 @@ export class Address {
    * @example
    * fakerGH.address.streetPrefix() // 'Boame'
    *
+   * @since 3.0.0
+   *
    * @deprecated Use faker.address.street() instead.
    */
   streetPrefix(): string {
@@ -266,6 +290,8 @@ export class Address {
    *
    * @example
    * faker.address.secondaryAddress() // 'Apt. 861'
+   *
+   * @since 2.0.1
    */
   secondaryAddress(): string {
     return this.faker.helpers.replaceSymbolWithNumber(
@@ -280,6 +306,8 @@ export class Address {
    *
    * @example
    * faker.address.county() // 'Cambridgeshire'
+   *
+   * @since 2.0.1
    */
   county(): string {
     return this.faker.helpers.arrayElement(
@@ -292,6 +320,8 @@ export class Address {
    *
    * @example
    * faker.address.country() // 'Greece'
+   *
+   * @since 2.0.1
    */
   country(): string {
     return this.faker.helpers.arrayElement(
@@ -309,6 +339,8 @@ export class Address {
    * faker.address.countryCode() // 'SJ'
    * faker.address.countryCode('alpha-2') // 'GA'
    * faker.address.countryCode('alpha-3') // 'TJK'
+   *
+   * @since 3.0.0
    */
   countryCode(alphaCode: 'alpha-2' | 'alpha-3' = 'alpha-2'): string {
     const key =
@@ -322,6 +354,8 @@ export class Address {
    *
    * @example
    * faker.address.state() // 'Georgia'
+   *
+   * @since 2.0.1
    */
   state(): string {
     return this.faker.helpers.arrayElement(
@@ -334,6 +368,8 @@ export class Address {
    *
    * @example
    * faker.address.stateAbbr() // 'ND'
+   *
+   * @since 2.0.1
    */
   stateAbbr(): string {
     return this.faker.helpers.arrayElement(
@@ -351,6 +387,8 @@ export class Address {
    * @example
    * faker.address.latitude() // '-30.9501'
    * faker.address.latitude(10, -10, 5) // '2.68452'
+   *
+   * @since 2.0.1
    */
   latitude(max: number = 90, min: number = -90, precision: number = 4): string {
     return this.faker.datatype
@@ -372,6 +410,8 @@ export class Address {
    * @example
    * faker.address.longitude() // '-154.0226'
    * faker.address.longitude(10, -10, 5) // '-4.03620'
+   *
+   * @since 2.0.1
    */
   longitude(
     max: number = 180,
@@ -397,6 +437,8 @@ export class Address {
    * faker.address.direction() // 'Northeast'
    * faker.address.direction(false) // 'South'
    * faker.address.direction(true) // 'NE'
+   *
+   * @since 5.0.0
    */
   direction(useAbbr: boolean = false): string {
     if (!useAbbr) {
@@ -419,6 +461,8 @@ export class Address {
    * faker.address.cardinalDirection() // 'North'
    * faker.address.cardinalDirection(false) // 'South'
    * faker.address.cardinalDirection(true) // 'N'
+   *
+   * @since 5.0.0
    */
   cardinalDirection(useAbbr: boolean = false): string {
     if (!useAbbr) {
@@ -441,6 +485,8 @@ export class Address {
    * faker.address.ordinalDirection() // 'Northeast'
    * faker.address.ordinalDirection(false) // 'Northwest'
    * faker.address.ordinalDirection(true) // 'NE'
+   *
+   * @since 5.0.0
    */
   ordinalDirection(useAbbr: boolean = false): string {
     if (!useAbbr) {
@@ -465,6 +511,8 @@ export class Address {
    * faker.address.nearbyGPSCoordinate() // [ '33.8475', '-170.5953' ]
    * faker.address.nearbyGPSCoordinate([33, -170]) // [ '33.0165', '-170.0636' ]
    * faker.address.nearbyGPSCoordinate([33, -170], 1000, true) // [ '37.9163', '-179.2408' ]
+   *
+   * @since 5.0.0
    */
   nearbyGPSCoordinate(
     coordinate?: [latitude: number, longitude: number],
@@ -521,6 +569,8 @@ export class Address {
    *
    * @example
    * faker.address.timeZone() // 'Pacific/Guam'
+   *
+   * @since 5.1.0
    */
   timeZone(): string {
     return this.faker.helpers.arrayElement(

--- a/src/modules/animal/index.ts
+++ b/src/modules/animal/index.ts
@@ -19,6 +19,8 @@ export class Animal {
    *
    * @example
    * faker.animal.dog() // 'Irish Water Spaniel'
+   *
+   * @since 5.5.0
    */
   dog(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.dog);
@@ -29,6 +31,8 @@ export class Animal {
    *
    * @example
    * faker.animal.cat() // 'Singapura'
+   *
+   * @since 5.5.0
    */
   cat(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.cat);
@@ -39,6 +43,8 @@ export class Animal {
    *
    * @example
    * faker.animal.snake() // 'Eyelash viper'
+   *
+   * @since 5.5.0
    */
   snake(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.snake);
@@ -49,6 +55,8 @@ export class Animal {
    *
    * @example
    * faker.animal.bear() // 'Asian black bear'
+   *
+   * @since 5.5.0
    */
   bear(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.bear);
@@ -59,6 +67,8 @@ export class Animal {
    *
    * @example
    * faker.animal.lion() // 'Northeast Congo Lion'
+   *
+   * @since 5.5.0
    */
   lion(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.lion);
@@ -69,6 +79,8 @@ export class Animal {
    *
    * @example
    * faker.animal.cetacean() // 'Spinner Dolphin'
+   *
+   * @since 5.5.0
    */
   cetacean(): string {
     return this.faker.helpers.arrayElement(
@@ -81,6 +93,8 @@ export class Animal {
    *
    * @example
    * faker.animal.horse() // 'Swedish Warmblood'
+   *
+   * @since 5.5.0
    */
   horse(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.horse);
@@ -91,6 +105,8 @@ export class Animal {
    *
    * @example
    * faker.animal.bird() // 'Buller's Shearwater'
+   *
+   * @since 5.5.0
    */
   bird(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.bird);
@@ -101,6 +117,8 @@ export class Animal {
    *
    * @example
    * faker.animal.cow() // 'Brava'
+   *
+   * @since 5.5.0
    */
   cow(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.cow);
@@ -111,6 +129,8 @@ export class Animal {
    *
    * @example
    * faker.animal.fish() // 'Mandarin fish'
+   *
+   * @since 5.5.0
    */
   fish(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.fish);
@@ -121,6 +141,8 @@ export class Animal {
    *
    * @example
    * faker.animal.crocodilia() // 'Philippine Crocodile'
+   *
+   * @since 5.5.0
    */
   crocodilia(): string {
     return this.faker.helpers.arrayElement(
@@ -133,6 +155,8 @@ export class Animal {
    *
    * @example
    * faker.animal.insect() // 'Pyramid ant'
+   *
+   * @since 5.5.0
    */
   insect(): string {
     return this.faker.helpers.arrayElement(
@@ -145,6 +169,8 @@ export class Animal {
    *
    * @example
    * faker.animal.rabbit() // 'Florida White'
+   *
+   * @since 5.5.0
    */
   rabbit(): string {
     return this.faker.helpers.arrayElement(
@@ -157,6 +183,8 @@ export class Animal {
    *
    * @example
    * faker.animal.rodent() // 'Cuscomys ashanika'
+   *
+   * @since 7.4.0
    */
   rodent(): string {
     return this.faker.helpers.arrayElement(
@@ -169,6 +197,8 @@ export class Animal {
    *
    * @example
    * faker.animal.type() // 'crocodilia'
+   *
+   * @since 5.5.0
    */
   type(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.animal.type);

--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -478,8 +478,6 @@ export class Color {
    * faker.color.hwb() // [201, 0.21, 0.31]
    *
    * @since 7.0.0
-   *
-   * @since 7.0.0
    */
   hwb(): number[];
   /**
@@ -535,7 +533,6 @@ export class Color {
    * faker.color.hwb({ format: 'decimal' }) // [201, 0.21, 0.31]
    * faker.color.hwb({ format: 'css' }) // hwb(194 0% 0%)
    * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
-   *
    *
    * @since 7.0.0
    */

--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -241,6 +241,8 @@ export class Color {
    * faker.color.rgb({ format: 'hex', casing: 'lower' }) // '#ffffff'
    * faker.color.rgb({ format: 'css' }) // 'rgb(255, 0, 0)'
    * faker.color.rgb({ format: 'binary' }) // '10000000 00000000 11111111'
+   *
+   * @since 7.0.0
    */
   rgb(options?: {
     prefix?: string;
@@ -259,6 +261,8 @@ export class Color {
    * faker.color.rgb() // '0xffffFF'
    * faker.color.rgb({ format: 'decimal' }) // [255, 255, 255]
    * faker.color.rgb({ format: 'decimal', includeAlpha: true }) // [255, 255, 255, 0.4]
+   *
+   * @since 7.0.0
    */
   rgb(options?: {
     format?: NumberColorFormat;
@@ -284,6 +288,8 @@ export class Color {
    * faker.color.rgb({ format: 'css' }) // 'rgb(255, 0, 0)'
    * faker.color.rgb({ format: 'binary' }) // '10000000 00000000 11111111'
    * faker.color.rgb({ format: 'decimal', includeAlpha: true }) // [255, 255, 255, 0.4]
+   *
+   * @since 7.0.0
    */
   rgb(options?: {
     prefix?: string;
@@ -345,6 +351,8 @@ export class Color {
    * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
    * faker.color.cmyk({ format: 'css' }) // cmyk(100%, 0%, 0%, 0%)
    * faker.color.cmyk({ format: 'binary' }) // (8-32 bits) x 4
+   *
+   * @since 7.0.0
    */
   cmyk(options?: { format?: StringColorFormat }): string;
   /**
@@ -356,6 +364,8 @@ export class Color {
    * @example
    * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
    * faker.color.cmyk({ format: 'decimal' }) // [0.31, 0.52, 0.32, 0.43]
+   *
+   * @since 7.0.0
    */
   cmyk(options?: { format?: NumberColorFormat }): number[];
   /**
@@ -369,6 +379,8 @@ export class Color {
    * faker.color.cmyk({ format: 'decimal' }) // [0.31, 0.52, 0.32, 0.43]
    * faker.color.cmyk({ format: 'css' }) // cmyk(100%, 0%, 0%, 0%)
    * faker.color.cmyk({ format: 'binary' }) // (8-32 bits) x 4
+   *
+   * @since 7.0.0
    */
   cmyk(options?: { format?: ColorFormat }): string | number[];
   cmyk(options?: { format?: ColorFormat }): string | number[] {
@@ -400,6 +412,8 @@ export class Color {
    * faker.color.hsl({ format: 'css', includeAlpha: true }) // hsl(0deg 100% 50% / 0.5)
    * faker.color.hsl({ format: 'binary' }) // (8-32 bits) x 3
    * faker.color.hsl({ format: 'binary', includeAlpha: true }) // (8-32 bits) x 4
+   *
+   * @since 7.0.0
    */
   hsl(options?: { format?: StringColorFormat; includeAlpha?: boolean }): string;
   /**
@@ -413,6 +427,8 @@ export class Color {
    * faker.color.hsl() // [201, 0.23, 0.32]
    * faker.color.hsl({ format: 'decimal' }) // [300, 0.21, 0.52]
    * faker.color.hsl({ format: 'decimal', includeAlpha: true }) // [300, 0.21, 0.52, 0.28]
+   *
+   * @since 7.0.0
    */
   hsl(options?: {
     format?: NumberColorFormat;
@@ -433,6 +449,8 @@ export class Color {
    * faker.color.hsl({ format: 'css', includeAlpha: true }) // hsl(0deg 100% 50% / 0.5)
    * faker.color.hsl({ format: 'binary' }) // (8-32 bits) x 3
    * faker.color.hsl({ format: 'binary', includeAlpha: true }) // (8-32 bits) x 4
+   *
+   * @since 7.0.0
    */
   hsl(options?: {
     format?: ColorFormat;
@@ -460,6 +478,8 @@ export class Color {
    * faker.color.hwb() // [201, 0.21, 0.31]
    *
    * @since 7.0.0
+   *
+   * @since 7.0.0
    */
   hwb(): number[];
   /**
@@ -472,6 +492,8 @@ export class Color {
    * faker.color.hwb() // [201, 0.21, 0.31]
    * faker.color.hwb({ format: 'css' }) // hwb(194 0% 0%)
    * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   * @since 7.0.0
    */
   hwb(options?: { format?: StringColorFormat }): string;
   /**
@@ -483,6 +505,8 @@ export class Color {
    * @example
    * faker.color.hwb() // [201, 0.21, 0.31]
    * faker.color.hwb({ format: 'decimal' }) // [201, 0.21, 0.31]
+   *
+   * @since 7.0.0
    */
   hwb(options?: { format?: NumberColorFormat }): number[];
   /**
@@ -496,6 +520,8 @@ export class Color {
    * faker.color.hwb({ format: 'decimal' }) // [201, 0.21, 0.31]
    * faker.color.hwb({ format: 'css' }) // hwb(194 0% 0%)
    * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   * @since 7.0.0
    */
   hwb(options?: { format?: ColorFormat }): string | number[];
   /**
@@ -509,6 +535,9 @@ export class Color {
    * faker.color.hwb({ format: 'decimal' }) // [201, 0.21, 0.31]
    * faker.color.hwb({ format: 'css' }) // hwb(194 0% 0%)
    * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   *
+   * @since 7.0.0
    */
   hwb(options?: { format?: ColorFormat }): string | number[] {
     const hsl: number[] = [this.faker.datatype.number({ min: 0, max: 360 })];
@@ -537,6 +566,8 @@ export class Color {
    * faker.color.lab() // [0.832133, -80.3245, 100.1234]
    * faker.color.lab({ format: 'css' }) // lab(29.2345% 39.3825 20.0664)
    * faker.color.lab({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   * @since 7.0.0
    */
   lab(options?: { format?: StringColorFormat }): string;
   /**
@@ -548,6 +579,8 @@ export class Color {
    * @example
    * faker.color.lab() // [0.832133, -80.3245, 100.1234]
    * faker.color.lab({ format: 'decimal' }) // [0.856773, -80.2345, 100.2341]
+   *
+   * @since 7.0.0
    */
   lab(options?: { format?: NumberColorFormat }): number[];
   /**
@@ -561,6 +594,8 @@ export class Color {
    * faker.color.lab({ format: 'decimal' }) // [0.856773, -80.2345, 100.2341]
    * faker.color.lab({ format: 'css' }) // lab(29.2345% 39.3825 20.0664)
    * faker.color.lab({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   * @since 7.0.0
    */
   lab(options?: { format?: ColorFormat }): string | number[];
   lab(options?: { format?: ColorFormat }): string | number[] {
@@ -600,6 +635,8 @@ export class Color {
    * faker.color.lch() // [0.522345, 72.2, 56.2]
    * faker.color.lch({ format: 'css' }) // lch(52.2345% 72.2 56.2)
    * faker.color.lch({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   * @since 7.0.0
    */
   lch(options?: { format?: StringColorFormat }): string;
   /**
@@ -614,6 +651,8 @@ export class Color {
    * @example
    * faker.color.lch() // [0.522345, 72.2, 56.2]
    * faker.color.lch({ format: 'decimal' }) // [0.522345, 72.2, 56.2]
+   *
+   * @since 7.0.0
    */
   lch(options?: { format?: NumberColorFormat }): number[];
   /**
@@ -630,6 +669,8 @@ export class Color {
    * faker.color.lch({ format: 'decimal' }) // [0.522345, 72.2, 56.2]
    * faker.color.lch({ format: 'css' }) // lch(52.2345% 72.2 56.2)
    * faker.color.lch({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   * @since 7.0.0
    */
   lch(options?: { format?: ColorFormat }): string | number[];
   lch(options?: { format?: ColorFormat }): string | number[] {
@@ -664,6 +705,8 @@ export class Color {
    * faker.color.colorByCSSColorSpace() // [0.93, 1, 0.82]
    * faker.color.colorByCSSColorSpace({ format: 'css', space: 'display-p3' }) // color(display-p3 0.12 1 0.23)
    * faker.color.colorByCSSColorSpace({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   * @since 7.0.0
    */
   colorByCSSColorSpace(options?: {
     format?: StringColorFormat;
@@ -679,6 +722,8 @@ export class Color {
    * @example
    * faker.color.colorByCSSColorSpace() // [0.93, 1, 0.82]
    * faker.color.colorByCSSColorSpace({ format: 'decimal' }) // [0.12, 0.21, 0.31]
+   *
+   * @since 7.0.0
    */
   colorByCSSColorSpace(options?: {
     format?: NumberColorFormat;
@@ -696,6 +741,8 @@ export class Color {
    * faker.color.colorByCSSColorSpace({ format: 'decimal' }) // [0.12, 0.21, 0.31]
    * faker.color.colorByCSSColorSpace({ format: 'css', space: 'display-p3' }) // color(display-p3 0.12 1 0.23)
    * faker.color.colorByCSSColorSpace({ format: 'binary' }) // (8-32 bits x 3)
+   *
+   * @since 7.0.0
    */
   colorByCSSColorSpace(options?: {
     format?: ColorFormat;

--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -170,6 +170,8 @@ export class Color {
    *
    * @example
    * faker.color.human() // 'red'
+   *
+   * @since 7.0.0
    */
   human(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.color.human);
@@ -181,6 +183,8 @@ export class Color {
    *
    * @example
    * faker.color.space() // 'sRGB'
+   *
+   * @since 7.0.0
    */
   space(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.color.space);
@@ -191,6 +195,8 @@ export class Color {
    *
    * @example
    * faker.color.cssSupportedFunction() // 'rgb'
+   *
+   * @since 7.0.0
    */
   cssSupportedFunction(): string {
     return this.faker.helpers.arrayElement(CSS_FUNCTIONS);
@@ -201,6 +207,8 @@ export class Color {
    *
    * @example
    * faker.color.cssSupportedSpace() // 'display-p3'
+   *
+   * @since 7.0.0
    */
   cssSupportedSpace(): string {
     return this.faker.helpers.arrayElement(CSS_SPACES);
@@ -211,6 +219,8 @@ export class Color {
    *
    * @example
    * faker.color.rgb() // '0xffffFF'
+   *
+   * @since 7.0.0
    */
   rgb(): string;
   /**
@@ -321,6 +331,8 @@ export class Color {
    *
    * @example
    * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
+   *
+   * @since 7.0.0
    */
   cmyk(): number[];
   /**
@@ -371,6 +383,8 @@ export class Color {
    *
    * @example
    * faker.color.hsl() // [201, 0.23, 0.32]
+   *
+   * @since 7.0.0
    */
   hsl(): number[];
   /**
@@ -444,6 +458,8 @@ export class Color {
    *
    * @example
    * faker.color.hwb() // [201, 0.21, 0.31]
+   *
+   * @since 7.0.0
    */
   hwb(): number[];
   /**
@@ -507,6 +523,8 @@ export class Color {
    *
    * @example
    * faker.color.lab() // [0.832133, -80.3245, 100.1234]
+   *
+   * @since 7.0.0
    */
   lab(): number[];
   /**
@@ -565,6 +583,8 @@ export class Color {
    *
    * @example
    * faker.color.lch() // [0.522345, 72.2, 56.2]
+   *
+   * @since 7.0.0
    */
   lch(): number[];
   /**
@@ -629,6 +649,8 @@ export class Color {
    *
    * @example
    * faker.color.colorByCSSColorSpace() // [0.93, 1, 0.82]
+   *
+   * @since 7.0.0
    */
   colorByCSSColorSpace(): number[];
   /**

--- a/src/modules/commerce/index.ts
+++ b/src/modules/commerce/index.ts
@@ -23,6 +23,8 @@ export class Commerce {
    * @example
    * faker.commerce.color() // 'red'
    *
+   * @since 3.0.0
+   *
    * @deprecated
    * Use `faker.color.human()` instead.
    */
@@ -41,6 +43,8 @@ export class Commerce {
    *
    * @example
    * faker.commerce.department() // 'Garden'
+   *
+   * @since 3.0.0
    */
   department(): string {
     return this.faker.helpers.arrayElement(
@@ -53,6 +57,8 @@ export class Commerce {
    *
    * @example
    * faker.commerce.productName() // 'Incredible Soft Gloves'
+   *
+   * @since 3.0.0
    */
   productName(): string {
     return `${this.productAdjective()} ${this.productMaterial()} ${this.product()}`;
@@ -72,6 +78,8 @@ export class Commerce {
    * faker.commerce.price(100, 200) // 154.00
    * faker.commerce.price(100, 200, 0) // 133
    * faker.commerce.price(100, 200, 0, '$') // $114
+   *
+   * @since 3.0.0
    */
   price(
     min: number = 1,
@@ -98,6 +106,8 @@ export class Commerce {
    *
    * @example
    * faker.commerce.productAdjective() // 'Handcrafted'
+   *
+   * @since 3.0.0
    */
   productAdjective(): string {
     return this.faker.helpers.arrayElement(
@@ -110,6 +120,8 @@ export class Commerce {
    *
    * @example
    * faker.commerce.productMaterial() // 'Rubber'
+   *
+   * @since 3.0.0
    */
   productMaterial(): string {
     return this.faker.helpers.arrayElement(
@@ -122,6 +134,8 @@ export class Commerce {
    *
    * @example
    * faker.commerce.product() // 'Computer'
+   *
+   * @since 3.0.0
    */
   product(): string {
     return this.faker.helpers.arrayElement(
@@ -134,6 +148,8 @@ export class Commerce {
    *
    * @example
    * faker.commerce.productDescription() // 'Andy shoes are designed to keeping...'
+   *
+   * @since 5.0.0
    */
   productDescription(): string {
     return this.faker.helpers.arrayElement(

--- a/src/modules/company/index.ts
+++ b/src/modules/company/index.ts
@@ -20,6 +20,8 @@ export class Company {
    *
    * @example
    * faker.company.suffixes() // [ 'Inc', 'and Sons', 'LLC', 'Group' ]
+   *
+   * @since 2.0.1
    */
   suffixes(): string[] {
     // Don't want the source array exposed to modification, so return a copy
@@ -33,6 +35,8 @@ export class Company {
    *
    * @example
    * faker.company.name() // 'Zieme, Hauck and McClure'
+   *
+   * @since 7.4.0
    */
   name(format?: number): string {
     if (format != null) {
@@ -70,6 +74,8 @@ export class Company {
    * @example
    * faker.company.companyName() // 'Zieme, Hauck and McClure'
    *
+   * @since 2.0.1
+   *
    * @deprecated Use `faker.company.name()` instead
    */
   companyName(format?: number): string {
@@ -88,6 +94,8 @@ export class Company {
    *
    * @example
    * faker.company.companySuffix() // 'and Sons'
+   *
+   * @since 2.0.1
    */
   companySuffix(): string {
     return this.faker.helpers.arrayElement(this.suffixes());
@@ -98,6 +106,8 @@ export class Company {
    *
    * @example
    * faker.company.catchPhrase() // 'Upgradable systematic flexibility'
+   *
+   * @since 2.0.1
    */
   catchPhrase(): string {
     return [
@@ -112,6 +122,8 @@ export class Company {
    *
    * @example
    * faker.company.bs() // 'cultivate synergistic e-markets'
+   *
+   * @since 2.0.1
    */
   bs(): string {
     return [this.bsBuzz(), this.bsAdjective(), this.bsNoun()].join(' ');
@@ -122,6 +134,8 @@ export class Company {
    *
    * @example
    * faker.company.catchPhraseAdjective() // 'Multi-tiered'
+   *
+   * @since 2.0.1
    */
   catchPhraseAdjective(): string {
     return this.faker.helpers.arrayElement(
@@ -134,6 +148,8 @@ export class Company {
    *
    * @example
    * faker.company.catchPhraseDescriptor() // 'composite'
+   *
+   * @since 2.0.1
    */
   catchPhraseDescriptor(): string {
     return this.faker.helpers.arrayElement(
@@ -146,6 +162,8 @@ export class Company {
    *
    * @example
    * faker.company.catchPhraseNoun() // 'leverage'
+   *
+   * @since 2.0.1
    */
   catchPhraseNoun(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.company.noun);
@@ -156,6 +174,8 @@ export class Company {
    *
    * @example
    * faker.company.bsAdjective() // 'one-to-one'
+   *
+   * @since 2.0.1
    */
   bsAdjective(): string {
     return this.faker.helpers.arrayElement(
@@ -168,6 +188,8 @@ export class Company {
    *
    * @example
    * faker.company.bsBuzz() // 'empower'
+   *
+   * @since 2.0.1
    */
   bsBuzz(): string {
     return this.faker.helpers.arrayElement(
@@ -180,6 +202,8 @@ export class Company {
    *
    * @example
    * faker.company.bsNoun() // 'paradigms'
+   *
+   * @since 2.0.1
    */
   bsNoun(): string {
     return this.faker.helpers.arrayElement(

--- a/src/modules/database/index.ts
+++ b/src/modules/database/index.ts
@@ -19,6 +19,8 @@ export class Database {
    *
    * @example
    * faker.database.column() // 'createdAt'
+   *
+   * @since 4.0.0
    */
   column(): string {
     return this.faker.helpers.arrayElement(
@@ -31,6 +33,8 @@ export class Database {
    *
    * @example
    * faker.database.type() // 'timestamp'
+   *
+   * @since 4.0.0
    */
   type(): string {
     return this.faker.helpers.arrayElement(
@@ -43,6 +47,8 @@ export class Database {
    *
    * @example
    * faker.database.collation() // 'utf8_unicode_ci'
+   *
+   * @since 4.0.0
    */
   collation(): string {
     return this.faker.helpers.arrayElement(
@@ -55,6 +61,8 @@ export class Database {
    *
    * @example
    * faker.database.engine() // 'ARCHIVE'
+   *
+   * @since 4.0.0
    */
   engine(): string {
     return this.faker.helpers.arrayElement(
@@ -67,6 +75,8 @@ export class Database {
    *
    * @example
    * faker.database.mongodbObjectId() // 'e175cac316a79afdd0ad3afb'
+   *
+   * @since 6.2.0
    */
   mongodbObjectId(): string {
     return this.faker.datatype.hexadecimal({

--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -34,6 +34,8 @@ export class Datatype {
    * faker.datatype.number({ max: 100 }) // 42
    * faker.datatype.number({ precision: 0.01 }) // 64246.18
    * faker.datatype.number({ min: 10, max: 100, precision: 0.01 }) // 36.94
+   *
+   * @since 5.5.0
    */
   number(
     options: number | { min?: number; max?: number; precision?: number } = 99999
@@ -76,6 +78,8 @@ export class Datatype {
    * faker.datatype.float({ max: 100 }) // 28.11
    * faker.datatype.float({ precision: 0.1 }) // 84055.3
    * faker.datatype.float({ min: 10, max: 100, precision: 0.001 }) // 57.315
+   *
+   * @since 5.5.0
    */
   float(
     options?: number | { min?: number; max?: number; precision?: number }
@@ -112,6 +116,8 @@ export class Datatype {
    * faker.datatype.datetime() // '2089-04-17T18:03:24.956Z'
    * faker.datatype.datetime(1893456000000) // '2022-03-28T07:00:56.876Z'
    * faker.datatype.datetime({ min: 1577836800000, max: 1893456000000 }) // '2021-09-12T07:13:00.255Z'
+   *
+   * @since 5.5.0
    */
   datetime(options: number | { min?: number; max?: number } = {}): Date {
     const minMax = 8640000000000000;
@@ -138,6 +144,8 @@ export class Datatype {
    * @example
    * faker.datatype.string() // 'Zo!.:*e>wR'
    * faker.datatype.string(5) // '6Bye8'
+   *
+   * @since 5.5.0
    */
   string(length = 10): string {
     const maxLength = Math.pow(2, 20);
@@ -164,6 +172,8 @@ export class Datatype {
    *
    * @example
    * faker.datatype.uuid() // '4136cd0b-d90b-4af7-b485-5d1ded8db252'
+   *
+   * @since 5.5.0
    */
   uuid(): string {
     const RFC4122_TEMPLATE = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
@@ -180,6 +190,8 @@ export class Datatype {
    *
    * @example
    * faker.datatype.boolean() // false
+   *
+   * @since 5.5.0
    */
   boolean(): boolean {
     return !!this.number(1);
@@ -202,6 +214,8 @@ export class Datatype {
    * faker.datatype.hexadecimal({ length: 10, case: 'upper' }) // '0xE3F38014FB'
    * faker.datatype.hexadecimal({ prefix: '', case: 'lower' }) // 'd'
    * faker.datatype.hexadecimal({ length: 10, prefix: '0x', case: 'mixed' }) // '0xAdE330a4D1'
+   *
+   * @since 6.1.2
    */
   hexadecimal(
     options:
@@ -265,6 +279,8 @@ export class Datatype {
    *
    * @example
    * faker.datatype.json() // `{"foo":"mxz.v8ISij","bar":29154,"bike":8658,"a":"GxTlw$nuC:","b":40693,"name":"%'<FTou{7X","prop":"X(bd4iT>77"}`
+   *
+   * @since 5.5.0
    */
   json(): string {
     const properties = ['foo', 'bar', 'bike', 'a', 'b', 'name', 'prop'];
@@ -285,6 +301,8 @@ export class Datatype {
    * @example
    * faker.datatype.array() // [ 94099, 85352, 'Hz%T.C\\l;8', '|#gmtw3otS', '2>:rJ|3$&d', 56864, 'Ss2-p0RXSI', 51084, 2039, 'mNEU[.r0Vf' ]
    * faker.datatype.array(3) // [ 61845, 'SK7H$W3:d*', 'm[%7N8*GVK' ]
+   *
+   * @since 5.5.0
    */
   array(length = 10): Array<string | number> {
     return Array.from<string | number>({ length }).map(() =>
@@ -307,6 +325,8 @@ export class Datatype {
    * faker.datatype.bigInt({ min: 1000000n }) // 431433n
    * faker.datatype.bigInt({ max: 100n }) // 42n
    * faker.datatype.bigInt({ min: 10n, max: 100n }) // 36n
+   *
+   * @since 6.0.0
    */
   bigInt(
     options?:

--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -45,6 +45,8 @@ export class _Date {
    * faker.date.past() // '2021-12-03T05:40:44.408Z'
    * faker.date.past(10) // '2017-10-25T21:34:19.488Z'
    * faker.date.past(10, '2020-01-01T00:00:00.000Z') // '2017-08-18T02:59:12.350Z'
+   *
+   * @since 2.0.1
    */
   past(years?: number, refDate?: string | Date | number): Date {
     const date = toDate(refDate);
@@ -72,6 +74,8 @@ export class _Date {
    * faker.date.future() // '2022-11-19T05:52:49.100Z'
    * faker.date.future(10) // '2030-11-23T09:38:28.710Z'
    * faker.date.future(10, '2020-01-01T00:00:00.000Z') // '2020-12-13T22:45:10.252Z'
+   *
+   * @since 2.0.1
    */
   future(years?: number, refDate?: string | Date | number): Date {
     const date = toDate(refDate);
@@ -95,6 +99,8 @@ export class _Date {
    *
    * @example
    * faker.date.between('2020-01-01T00:00:00.000Z', '2030-01-01T00:00:00.000Z') // '2026-05-16T02:22:53.002Z'
+   *
+   * @since 2.0.1
    */
   between(from: string | Date | number, to: string | Date | number): Date {
     const fromMs = toDate(from).getTime();
@@ -120,6 +126,8 @@ export class _Date {
    * // ]
    * faker.date.betweens('2020-01-01T00:00:00.000Z', '2030-01-01T00:00:00.000Z', 2)
    * // [ 2023-05-02T16:00:00.000Z, 2026-09-01T08:00:00.000Z ]
+   *
+   * @since 5.4.0
    */
   betweens(
     from: string | Date | number,
@@ -147,6 +155,8 @@ export class _Date {
    * faker.date.recent() // '2022-02-04T02:09:35.077Z'
    * faker.date.recent(10) // '2022-01-29T06:12:12.829Z'
    * faker.date.recent(10, '2020-01-01T00:00:00.000Z') // '2019-12-27T18:11:19.117Z'
+   *
+   * @since 2.0.1
    */
   recent(days?: number, refDate?: string | Date | number): Date {
     const date = toDate(refDate);
@@ -174,6 +184,8 @@ export class _Date {
    * faker.date.soon() // '2022-02-05T09:55:39.216Z'
    * faker.date.soon(10) // '2022-02-11T05:14:39.138Z'
    * faker.date.soon(10, '2020-01-01T00:00:00.000Z') // '2020-01-01T02:40:44.990Z'
+   *
+   * @since 5.0.0
    */
   soon(days?: number, refDate?: string | Date | number): Date {
     const date = toDate(refDate);
@@ -201,6 +213,8 @@ export class _Date {
    * faker.date.month({ abbr: true }) // 'Feb'
    * faker.date.month({ context: true }) // 'June'
    * faker.date.month({ abbr: true, context: true }) // 'Sep'
+   *
+   * @since 3.0.1
    */
   month(options?: { abbr?: boolean; context?: boolean }): string {
     const abbr = options?.abbr ?? false;
@@ -235,6 +249,8 @@ export class _Date {
    * faker.date.weekday({ abbr: true }) // 'Thu'
    * faker.date.weekday({ context: true }) // 'Thursday'
    * faker.date.weekday({ abbr: true, context: true }) // 'Fri'
+   *
+   * @since 3.0.1
    */
   weekday(options?: { abbr?: boolean; context?: boolean }): string {
     const abbr = options?.abbr ?? false;
@@ -276,6 +292,8 @@ export class _Date {
    * faker.date.birthdate() // 1977-07-10T01:37:30.719Z
    * faker.date.birthdate({ min: 18, max: 65, mode: 'age' }) // 2003-11-02T20:03:20.116Z
    * faker.date.birthdate({ min: 1900, max: 2000, mode: 'year' }) // 1940-08-20T08:53:07.538Z
+   *
+   * @since 7.0.0
    */
   birthdate(
     options: {

--- a/src/modules/fake/index.ts
+++ b/src/modules/fake/index.ts
@@ -59,6 +59,8 @@ export class Fake {
    * faker.fake('You can call me at {{phone.number(!## ### #####!)}}.') // 'You can call me at 202 555 973722.'
    * faker.fake('I flipped the coin and got: {{helpers.arrayElement(["heads", "tails"])}}') // 'I flipped the coin and got: tails'
    *
+   * @since 3.0.0
+   *
    * @deprecated Use faker.helpers.fake() instead.
    */
   fake(str: string): string {

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -24,6 +24,8 @@ export class Finance {
    * @example
    * faker.finance.account() // 92842238
    * faker.finance.account(5) // 32564
+   *
+   * @since 2.0.1
    */
   account(length?: number): string {
     length = length || 8;
@@ -41,6 +43,8 @@ export class Finance {
    *
    * @example
    * faker.finance.accountName() // 'Personal Loan Account'
+   *
+   * @since 2.0.1
    */
   accountName(): string {
     return [
@@ -56,6 +60,8 @@ export class Finance {
    *
    * @example
    * faker.finance.routingNumber() // '522814402'
+   *
+   * @since 5.0.0
    */
   routingNumber(): string {
     const routingNumber =
@@ -85,6 +91,8 @@ export class Finance {
    * faker.finance.mask(3) // '(...342)'
    * faker.finance.mask(3, false) // '...236'
    * faker.finance.mask(3, false, false) // '298'
+   *
+   * @since 2.0.1
    */
   mask(length?: number, parens?: boolean, ellipsis?: boolean): string {
     // set defaults
@@ -125,6 +133,8 @@ export class Finance {
    * faker.finance.amount(5, 10, 0) // '8'
    * faker.finance.amount(5, 10, 2, '$') // '$5.85'
    * faker.finance.amount(5, 10, 5, '', true) // '9,75067'
+   *
+   * @since 2.0.1
    */
   amount(
     min: number = 0,
@@ -156,6 +166,8 @@ export class Finance {
    *
    * @example
    * faker.finance.transactionType() // 'payment'
+   *
+   * @since 2.0.1
    */
   transactionType(): string {
     return this.faker.helpers.arrayElement(
@@ -169,6 +181,8 @@ export class Finance {
    *
    * @example
    * faker.finance.currencyCode() // 'USD'
+   *
+   * @since 2.0.1
    */
   currencyCode(): string {
     return this.faker.helpers.objectValue(
@@ -181,6 +195,8 @@ export class Finance {
    *
    * @example
    * faker.finance.currencyName() // 'US Dollar'
+   *
+   * @since 2.0.1
    */
   currencyName(): string {
     return this.faker.helpers.objectKey(
@@ -193,6 +209,8 @@ export class Finance {
    *
    * @example
    * faker.finance.currencySymbol() // '$'
+   *
+   * @since 2.0.1
    */
   currencySymbol(): string {
     let symbol: string;
@@ -209,6 +227,8 @@ export class Finance {
    *
    * @example
    * faker.finance.bitcoinAddress() // '3ySdvCkTLVy7gKD4j6JfSaf5d'
+   *
+   * @since 3.1.0
    */
   bitcoinAddress(): string {
     const addressLength = this.faker.datatype.number({ min: 25, max: 34 });
@@ -228,6 +248,8 @@ export class Finance {
    *
    * @example
    * faker.finance.litecoinAddress() // 'MoQaSTGWBRXkWfyxKbNKuPrAWGELzcW'
+   *
+   * @since 5.0.0
    */
   litecoinAddress(): string {
     const addressLength = this.faker.datatype.number({ min: 26, max: 33 });
@@ -251,6 +273,8 @@ export class Finance {
    * faker.finance.creditCardNumber() // '4427163488662'
    * faker.finance.creditCardNumber('visa') // '4882664999007'
    * faker.finance.creditCardNumber('63[7-9]#-####-####-###L') // '6375-3265-4676-6646'
+   *
+   * @since 5.0.0
    */
   creditCardNumber(issuer = ''): string {
     let format: string;
@@ -276,6 +300,8 @@ export class Finance {
    *
    * @example
    * faker.finance.creditCardCVV() // '506'
+   *
+   * @since 5.0.0
    */
   creditCardCVV(): string {
     let cvv = '';
@@ -290,6 +316,8 @@ export class Finance {
    *
    * @example
    * faker.finance.creditCardIssuer() // 'discover'
+   *
+   * @since 6.3.0
    */
   creditCardIssuer(): string {
     return this.faker.helpers.objectKey(
@@ -306,6 +334,8 @@ export class Finance {
    * @example
    * faker.finance.pin() // '5067'
    * faker.finance.pin(6) // '213789'
+   *
+   * @since 6.2.0
    */
   pin(length: number = 4): string {
     if (length < 1) {
@@ -319,6 +349,8 @@ export class Finance {
    *
    * @example
    * faker.finance.ethereumAddress() // '0xf03dfeecbafc5147241cc4c4ca20b3c9dfd04c4a'
+   *
+   * @since 5.0.0
    */
   ethereumAddress(): string {
     const address = this.faker.datatype.hexadecimal({
@@ -339,6 +371,8 @@ export class Finance {
    * faker.finance.iban() // 'TR736918640040966092800056'
    * faker.finance.iban(true) // 'FR20 8008 2330 8984 74S3 Z620 224'
    * faker.finance.iban(true, 'DE') // 'DE84 1022 7075 0900 1170 01'
+   *
+   * @since 4.0.0
    */
   iban(formatted: boolean = false, countryCode?: string): string {
     const ibanFormat = countryCode
@@ -397,6 +431,8 @@ export class Finance {
    *
    * @example
    * faker.finance.bic() // 'WYAUPGX1432'
+   *
+   * @since 4.0.0
    */
   bic(): string {
     const bankIdentifier = this.faker.random.alpha({
@@ -420,6 +456,8 @@ export class Finance {
    * @example
    * faker.finance.transactionDescription()
    * // 'invoice transaction at Kilback - Durgan using card ending with ***(...4316) for UAH 783.82 in account ***16168663'
+   *
+   * @since 5.1.0
    */
   transactionDescription(): string {
     const amount = this.amount();

--- a/src/modules/git/index.ts
+++ b/src/modules/git/index.ts
@@ -19,6 +19,8 @@ export class Git {
    *
    * @example
    * faker.git.branch() // 'feed-parse'
+   *
+   * @since 5.0.0
    */
   branch(): string {
     const noun = this.faker.hacker.noun().replace(' ', '-');
@@ -42,6 +44,8 @@ export class Git {
    * // Date: Sat Feb 05 2022 15:09:18 GMT+0100 (Mitteleuropäische Normalzeit)
    * //
    * //     copy primary system
+   *
+   * @since 5.0.0
    */
   commitEntry(
     options: {
@@ -80,6 +84,8 @@ export class Git {
    *
    * @example
    * faker.git.commitMessage() // 'reboot cross-platform driver'
+   *
+   * @since 5.0.0
    */
   commitMessage(): string {
     return `${this.faker.hacker.verb()} ${this.faker.hacker.adjective()} ${this.faker.hacker.noun()}`;
@@ -90,6 +96,8 @@ export class Git {
    *
    * @example
    * faker.git.commitSha() // '2c6e3880fd94ddb7ef72d34e683cdc0c47bec6e6'
+   *
+   * @since 5.0.0
    */
   commitSha(): string {
     return this.faker.datatype.hexadecimal({
@@ -104,6 +112,8 @@ export class Git {
    *
    * @example
    * faker.git.shortSha() // '6155732'
+   *
+   * @since 5.0.0
    */
   shortSha(): string {
     return this.faker.datatype.hexadecimal({

--- a/src/modules/hacker/index.ts
+++ b/src/modules/hacker/index.ts
@@ -19,6 +19,8 @@ export class Hacker {
    *
    * @example
    * faker.hacker.abbreviation() // 'THX'
+   *
+   * @since 2.0.1
    */
   abbreviation(): string {
     return this.faker.helpers.arrayElement(
@@ -31,6 +33,8 @@ export class Hacker {
    *
    * @example
    * faker.hacker.adjective() // 'cross-platform'
+   *
+   * @since 2.0.1
    */
   adjective(): string {
     return this.faker.helpers.arrayElement(
@@ -43,6 +47,8 @@ export class Hacker {
    *
    * @example
    * faker.hacker.noun() // 'system'
+   *
+   * @since 2.0.1
    */
   noun(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.hacker.noun);
@@ -53,6 +59,8 @@ export class Hacker {
    *
    * @example
    * faker.hacker.verb() // 'copy'
+   *
+   * @since 2.0.1
    */
   verb(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.hacker.verb);
@@ -63,6 +71,8 @@ export class Hacker {
    *
    * @example
    * faker.hacker.ingverb() // 'navigating'
+   *
+   * @since 2.0.1
    */
   ingverb(): string {
     return this.faker.helpers.arrayElement(
@@ -76,6 +86,8 @@ export class Hacker {
    * @example
    * faker.hacker.phrase()
    * // 'If we override the card, we can get to the HDD feed through the back-end HDD sensor!'
+   *
+   * @since 2.0.1
    */
   phrase(): string {
     const data = {

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -30,6 +30,8 @@ export class Helpers {
    * @example
    * faker.helpers.slugify() // ''
    * faker.helpers.slugify("Hello world!") // 'Hello-world'
+   *
+   * @since 2.0.1
    */
   slugify(string: string = ''): string {
     return string
@@ -49,6 +51,8 @@ export class Helpers {
    * faker.helpers.replaceSymbolWithNumber('#####') // '04812'
    * faker.helpers.replaceSymbolWithNumber('!####') // '27378'
    * faker.helpers.replaceSymbolWithNumber('Your pin is: !####') // '29841'
+   *
+   * @since 2.0.1
    */
   replaceSymbolWithNumber(string: string = '', symbol: string = '#'): string {
     let str = '';
@@ -79,6 +83,8 @@ export class Helpers {
    * faker.helpers.replaceSymbols('?????') // 'ZYRQQ'
    * faker.helpers.replaceSymbols('*****') // '4Z3P7'
    * faker.helpers.replaceSymbols('Your pin is: #?*#?*') // '0T85L1'
+   *
+   * @since 3.0.0
    */
   replaceSymbols(string: string = ''): string {
     const alpha = [
@@ -139,6 +145,8 @@ export class Helpers {
    * @example
    * faker.helpers.replaceCreditCardSymbols() // '6453-4876-8626-8995-3771'
    * faker.helpers.replaceCreditCardSymbols('1234-[4-9]-##!!-L') // '1234-9-5298-2'
+   *
+   * @since 5.0.0
    */
   replaceCreditCardSymbols(
     string: string = '6453-####-####-####-###L',
@@ -163,6 +171,8 @@ export class Helpers {
    * faker.helpers.repeatString('Hello world! ') // ''
    * faker.helpers.repeatString('Hello world! ', 1) // 'Hello world! '
    * faker.helpers.repeatString('Hello world! ', 2) // 'Hello world! Hello world! '
+   *
+   * @since 5.0.0
    *
    * @deprecated Use [String.prototype.repeat()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat) instead.
    */
@@ -192,6 +202,8 @@ export class Helpers {
    * faker.helpers.regexpStyleStringParse('#{2,9}') // '#######'
    * faker.helpers.regexpStyleStringParse('[500-15000]') // '8375'
    * faker.helpers.regexpStyleStringParse('#{3}test[1-5]') // '###test3'
+   *
+   * @since 5.0.0
    */
   regexpStyleStringParse(string: string = ''): string {
     // Deal with range repeat `{min,max}`
@@ -262,6 +274,8 @@ export class Helpers {
    * @example
    * faker.helpers.shuffle() // []
    * faker.helpers.shuffle(['a', 'b', 'c']) // [ 'b', 'c', 'a' ]
+   *
+   * @since 2.0.1
    */
   shuffle<T>(o?: T[]): T[] {
     if (o == null || o.length === 0) {
@@ -290,6 +304,8 @@ export class Helpers {
    * faker.helpers.uniqueArray(faker.random.word, 50)
    * faker.helpers.uniqueArray(faker.definitions.name.first_name, 6)
    * faker.helpers.uniqueArray(["Hello", "World", "Goodbye"], 2)
+   *
+   * @since 6.0.0
    */
   uniqueArray<T>(source: readonly T[] | (() => T), length: number): T[] {
     if (Array.isArray(source)) {
@@ -323,6 +339,8 @@ export class Helpers {
    *   count: () => `${faker.datatype.number()}`,
    *   word: "this word",
    * }) // 'I found 57591 instances of "this word".'
+   *
+   * @since 2.0.1
    */
   mustache(
     str: string | undefined,
@@ -355,6 +373,8 @@ export class Helpers {
    * faker.helpers.maybe(() => 'Hello World!') // 'Hello World!'
    * faker.helpers.maybe(() => 'Hello World!', { probability: 0.1 }) // undefined
    * faker.helpers.maybe(() => 'Hello World!', { probability: 0.9 }) // 'Hello World!'
+   *
+   * @since 6.3.0
    */
   maybe<T>(
     callback: () => T,
@@ -374,6 +394,8 @@ export class Helpers {
    *
    * @example
    * faker.helpers.objectKey({ myProperty: 'myValue' }) // 'myProperty'
+   *
+   * @since 6.3.0
    */
   objectKey<T extends Record<string, unknown>>(object: T): keyof T {
     const array: Array<keyof T> = Object.keys(object);
@@ -387,6 +409,8 @@ export class Helpers {
    *
    * @example
    * faker.helpers.objectValue({ myProperty: 'myValue' }) // 'myValue'
+   *
+   * @since 6.3.0
    */
   objectValue<T extends Record<string, unknown>>(object: T): T[keyof T] {
     const key = this.faker.helpers.objectKey(object);
@@ -401,6 +425,8 @@ export class Helpers {
    *
    * @example
    * faker.helpers.arrayElement(['cat', 'dog', 'mouse']) // 'dog'
+   *
+   * @since 6.3.0
    */
   arrayElement<T = string>(
     // TODO @Shinigami92 2022-04-30: We want to remove this default value, but currently it's not possible because some definitions could be empty
@@ -427,6 +453,8 @@ export class Helpers {
    * @example
    * faker.helpers.arrayElements(['cat', 'dog', 'mouse']) // ['mouse', 'cat']
    * faker.helpers.arrayElements([1, 2, 3, 4, 5], 2) // [4, 2]
+   *
+   * @since 6.3.0
    */
   arrayElements<T>(
     // TODO @Shinigami92 2022-04-30: We want to remove this default value, but currently it's not possible because some definitions could be empty
@@ -503,6 +531,8 @@ export class Helpers {
    * faker.helpers.fake('Good Morning {{name.firstName}}!') // 'Good Morning Estelle!'
    * faker.helpers.fake('You can call me at {{phone.number(!## ### #####!)}}.') // 'You can call me at 202 555 973722.'
    * faker.helpers.fake('I flipped the coin and got: {{helpers.arrayElement(["heads", "tails"])}}') // 'I flipped the coin and got: tails'
+   *
+   * @since 7.4.0
    */
   fake(str: string): string {
     // if incoming str parameter is not provided, return error message
@@ -611,6 +641,8 @@ export class Helpers {
    *
    * @example
    * faker.helpers.unique(faker.name.firstName) // 'Corbin'
+   *
+   * @since 7.5.0
    */
   unique<Method extends (...parameters) => RecordKey>(
     method: Method,

--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -42,6 +42,8 @@ export class Image {
    * faker.image.image() // 'https://loremflickr.com/640/480/city'
    * faker.image.image(1234, 2345) // 'https://loremflickr.com/1234/2345/sports'
    * faker.image.image(1234, 2345, true) // 'https://loremflickr.com/1234/2345/nature?56789'
+   *
+   * @since 2.0.1
    */
   image(width?: number, height?: number, randomize?: boolean): string {
     const categories: MethodsOf<Image, Image['image']> = [
@@ -72,6 +74,8 @@ export class Image {
    * @example
    * faker.image.avatar()
    * // 'https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/170.jpg'
+   *
+   * @since 2.0.1
    */
   avatar(): string {
     return this.faker.internet.avatar();
@@ -90,6 +94,8 @@ export class Image {
    * faker.image.imageUrl(1234, 2345) // 'https://loremflickr.com/1234/2345'
    * faker.image.imageUrl(1234, 2345, 'cat') // 'https://loremflickr.com/1234/2345/cat'
    * faker.image.imageUrl(1234, 2345, 'cat', true) // 'https://loremflickr.com/1234/2345/cat?6849'
+   *
+   * @since 2.0.1
    */
   imageUrl(
     width?: number,
@@ -122,6 +128,8 @@ export class Image {
    * faker.image.abstract() // 'https://loremflickr.com/640/480/abstract'
    * faker.image.abstract(1234, 2345) // 'https://loremflickr.com/1234/2345/abstract'
    * faker.image.abstract(1234, 2345, true) // 'https://loremflickr.com/1234/2345/abstract?56789'
+   *
+   * @since 2.0.1
    */
   abstract(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'abstract', randomize);
@@ -138,6 +146,8 @@ export class Image {
    * faker.image.animals() // 'https://loremflickr.com/640/480/animals'
    * faker.image.animals(1234, 2345) // 'https://loremflickr.com/1234/2345/animals'
    * faker.image.animals(1234, 2345, true) // 'https://loremflickr.com/1234/2345/animals?56789'
+   *
+   * @since 2.0.1
    */
   animals(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'animals', randomize);
@@ -154,6 +164,8 @@ export class Image {
    * faker.image.business() // 'https://loremflickr.com/640/480/business'
    * faker.image.business(1234, 2345) // 'https://loremflickr.com/1234/2345/business'
    * faker.image.business(1234, 2345, true) // 'https://loremflickr.com/1234/2345/business?56789'
+   *
+   * @since 2.0.1
    */
   business(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'business', randomize);
@@ -170,6 +182,8 @@ export class Image {
    * faker.image.cats() // 'https://loremflickr.com/640/480/cats'
    * faker.image.cats(1234, 2345) // 'https://loremflickr.com/1234/2345/cats'
    * faker.image.cats(1234, 2345, true) // 'https://loremflickr.com/1234/2345/cats?56789'
+   *
+   * @since 2.0.1
    */
   cats(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'cats', randomize);
@@ -186,6 +200,8 @@ export class Image {
    * faker.image.city() // 'https://loremflickr.com/640/480/city'
    * faker.image.city(1234, 2345) // 'https://loremflickr.com/1234/2345/city'
    * faker.image.city(1234, 2345, true) // 'https://loremflickr.com/1234/2345/city?56789'
+   *
+   * @since 2.0.1
    */
   city(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'city', randomize);
@@ -202,6 +218,8 @@ export class Image {
    * faker.image.food() // 'https://loremflickr.com/640/480/food'
    * faker.image.food(1234, 2345) // 'https://loremflickr.com/1234/2345/food'
    * faker.image.food(1234, 2345, true) // 'https://loremflickr.com/1234/2345/food?56789'
+   *
+   * @since 2.0.1
    */
   food(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'food', randomize);
@@ -218,6 +236,8 @@ export class Image {
    * faker.image.nightlife() // 'https://loremflickr.com/640/480/nightlife'
    * faker.image.nightlife(1234, 2345) // 'https://loremflickr.com/1234/2345/nightlife'
    * faker.image.nightlife(1234, 2345, true) // 'https://loremflickr.com/1234/2345/nightlife?56789'
+   *
+   * @since 2.0.1
    */
   nightlife(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'nightlife', randomize);
@@ -234,6 +254,8 @@ export class Image {
    * faker.image.fashion() // 'https://loremflickr.com/640/480/fashion'
    * faker.image.fashion(1234, 2345) // 'https://loremflickr.com/1234/2345/fashion'
    * faker.image.fashion(1234, 2345, true) // 'https://loremflickr.com/1234/2345/fashion?56789'
+   *
+   * @since 2.0.1
    */
   fashion(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'fashion', randomize);
@@ -250,6 +272,8 @@ export class Image {
    * faker.image.people() // 'https://loremflickr.com/640/480/people'
    * faker.image.people(1234, 2345) // 'https://loremflickr.com/1234/2345/people'
    * faker.image.people(1234, 2345, true) // 'https://loremflickr.com/1234/2345/people?56789'
+   *
+   * @since 2.0.1
    */
   people(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'people', randomize);
@@ -266,6 +290,8 @@ export class Image {
    * faker.image.nature() // 'https://loremflickr.com/640/480/nature'
    * faker.image.nature(1234, 2345) // 'https://loremflickr.com/1234/2345/nature'
    * faker.image.nature(1234, 2345, true) // 'https://loremflickr.com/1234/2345/nature?56789'
+   *
+   * @since 2.0.1
    */
   nature(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'nature', randomize);
@@ -282,6 +308,8 @@ export class Image {
    * faker.image.sports() // 'https://loremflickr.com/640/480/sports'
    * faker.image.sports(1234, 2345) // 'https://loremflickr.com/1234/2345/sports'
    * faker.image.sports(1234, 2345, true) // 'https://loremflickr.com/1234/2345/sports?56789'
+   *
+   * @since 2.0.1
    */
   sports(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'sports', randomize);
@@ -298,6 +326,8 @@ export class Image {
    * faker.image.technics() // 'https://loremflickr.com/640/480/technics'
    * faker.image.technics(1234, 2345) // 'https://loremflickr.com/1234/2345/technics'
    * faker.image.technics(1234, 2345, true) // 'https://loremflickr.com/1234/2345/technics?56789'
+   *
+   * @since 2.0.1
    */
   technics(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'technics', randomize);
@@ -314,6 +344,8 @@ export class Image {
    * faker.image.transport() // 'https://loremflickr.com/640/480/transport'
    * faker.image.transport(1234, 2345) // 'https://loremflickr.com/1234/2345/transport'
    * faker.image.transport(1234, 2345, true) // 'https://loremflickr.com/1234/2345/transport?56789'
+   *
+   * @since 2.0.1
    */
   transport(width?: number, height?: number, randomize?: boolean): string {
     return this.imageUrl(width, height, 'transport', randomize);
@@ -328,6 +360,8 @@ export class Image {
    *
    * @example
    * faker.image.dataUri() // 'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http...'
+   *
+   * @since 4.0.0
    */
   dataUri(width?: number, height?: number, color: string = 'grey'): string {
     const svgString = `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" baseProfile="full" width="${width}" height="${height}"><rect width="100%" height="100%" fill="${color}"/><text x="${

--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -40,6 +40,8 @@ export class Internet {
    * @example
    * faker.internet.avatar()
    * // 'https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/315.jpg'
+   *
+   * @since 2.0.1
    */
   avatar(): string {
     return `https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/${this.faker.datatype.number(
@@ -62,6 +64,8 @@ export class Internet {
    * faker.internet.email('Jeanne', 'Doe') // 'Jeanne63@yahoo.com'
    * faker.internet.email('Jeanne', 'Doe', 'example.fakerjs.dev') // 'Jeanne_Doe88@example.fakerjs.dev'
    * faker.internet.email('Jeanne', 'Doe', 'example.fakerjs.dev', { allowSpecialCharacters: true }) // 'Jeanne%Doe88@example.fakerjs.dev'
+   *
+   * @since 2.0.1
    */
   email(
     firstName?: string,
@@ -104,6 +108,8 @@ export class Internet {
    * faker.internet.exampleEmail() // 'Helmer.Graham23@example.com'
    * faker.internet.exampleEmail('Jeanne', 'Doe') // 'Jeanne96@example.net'
    * faker.internet.exampleEmail('Jeanne', 'Doe', { allowSpecialCharacters: true }) // 'Jeanne%Doe88@example.com'
+   *
+   * @since 3.1.0
    */
   exampleEmail(
     firstName?: string,
@@ -125,6 +131,8 @@ export class Internet {
    * @example
    * faker.internet.userName() // 'Nettie_Zboncak40'
    * faker.internet.userName('Jeanne', 'Doe') // 'Jeanne98'
+   *
+   * @since 2.0.1
    */
   userName(firstName?: string, lastName?: string): string {
     let result: string;
@@ -156,6 +164,8 @@ export class Internet {
    * @example
    * faker.internet.protocol() // 'http'
    * faker.internet.protocol() // 'https'
+   *
+   * @since 2.1.5
    */
   protocol(): 'http' | 'https' {
     const protocols: ['http', 'https'] = ['http', 'https'];
@@ -175,6 +185,8 @@ export class Internet {
    *
    * @example
    * faker.internet.httpMethod() // 'PATCH'
+   *
+   * @since 5.4.0
    */
   httpMethod(): 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' {
     const httpMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] = [
@@ -196,6 +208,8 @@ export class Internet {
    * @example
    * faker.internet.httpStatusCode() // 200
    * faker.internet.httpStatusCode({ types: ['success', 'serverError'] }) // 500
+   *
+   * @since 7.0.0
    */
   httpStatusCode(
     options: { types?: ReadonlyArray<HTTPStatusCodeType> } = {}
@@ -216,6 +230,8 @@ export class Internet {
    *
    * @example
    * faker.internet.url() // 'https://remarkable-hackwork.info'
+   *
+   * @since 2.1.5
    */
   url(): string {
     return `${this.protocol()}://${this.domainName()}`;
@@ -226,6 +242,8 @@ export class Internet {
    *
    * @example
    * faker.internet.domainName() // 'slow-timer.info'
+   *
+   * @since 2.0.1
    */
   domainName(): string {
     return `${this.domainWord()}.${this.domainSuffix()}`;
@@ -237,6 +255,8 @@ export class Internet {
    * @example
    * faker.internet.domainSuffix() // 'com'
    * faker.internet.domainSuffix() // 'name'
+   *
+   * @since 2.0.1
    */
   domainSuffix(): string {
     return this.faker.helpers.arrayElement(
@@ -250,6 +270,8 @@ export class Internet {
    * @example
    * faker.internet.domainWord() // 'close-reality'
    * faker.internet.domainWord() // 'weird-cytoplasm'
+   *
+   * @since 2.0.1
    */
   domainWord(): string {
     return `${this.faker.word.adjective()}-${this.faker.word.noun()}`
@@ -264,6 +286,8 @@ export class Internet {
    *
    * @example
    * faker.internet.ip() // '245.108.222.0'
+   *
+   * @since 2.0.1
    */
   ip(): string {
     // TODO @Shinigami92 2022-03-21: We may want to return a IPv4 or IPv6 address here in a later major release
@@ -275,6 +299,8 @@ export class Internet {
    *
    * @example
    * faker.internet.ipv4() // '245.108.222.0'
+   *
+   * @since 6.1.1
    */
   ipv4(): string {
     const randNum = () => {
@@ -294,6 +320,8 @@ export class Internet {
    *
    * @example
    * faker.internet.ipv6() // '269f:1230:73e3:318d:842b:daab:326d:897b'
+   *
+   * @since 4.0.0
    */
   ipv6(): string {
     const randHash = () => {
@@ -333,6 +361,8 @@ export class Internet {
    *
    * @example
    * faker.internet.port() // '9414'
+   *
+   * @since 5.4.0
    */
   port(): number {
     return this.faker.datatype.number({ min: 0, max: 65535 });
@@ -344,6 +374,8 @@ export class Internet {
    * @example
    * faker.internet.userAgent()
    * // 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_8_8)  AppleWebKit/536.0.2 (KHTML, like Gecko) Chrome/27.0.849.0 Safari/536.0.2'
+   *
+   * @since 2.0.1
    */
   userAgent(): string {
     return random_ua.generate(this.faker);
@@ -362,6 +394,8 @@ export class Internet {
    * @example
    * faker.internet.color() // '#30686e'
    * faker.internet.color(100, 100, 100) // '#4e5f8b'
+   *
+   * @since 2.0.1
    */
   color(
     redBase: number = 0,
@@ -387,6 +421,8 @@ export class Internet {
    *
    * @example
    * faker.internet.mac() // '32:8e:2e:09:c6:05'
+   *
+   * @since 3.0.0
    */
   mac(sep?: string): string {
     let i: number;
@@ -423,6 +459,8 @@ export class Internet {
    * faker.internet.password(20, true) // 'lawetimufozujosodedi'
    * faker.internet.password(20, true, /[A-Z]/) // 'HMAQDFFYLDDUTBKVNFVS'
    * faker.internet.password(20, true, /[A-Z]/, 'Hello ') // 'Hello IREOXTDWPERQSB'
+   *
+   * @since 2.0.1
    */
   password(
     len: number = 15,
@@ -475,6 +513,8 @@ export class Internet {
    * @example
    * faker.internet.emoji() // '🥰'
    * faker.internet.emoji({ types: ['food', 'nature'] }) // '🥐'
+   *
+   * @since 6.2.0
    */
   emoji(options: { types?: ReadonlyArray<EmojiType> } = {}): string {
     const {

--- a/src/modules/lorem/index.ts
+++ b/src/modules/lorem/index.ts
@@ -22,6 +22,8 @@ export class Lorem {
    * @example
    * faker.lorem.word() // 'temporibus'
    * faker.lorem.word(5) // 'velit'
+   *
+   * @since 3.1.0
    */
   word(length?: number): string {
     const hasRightLength = (word: string) => word.length === length;
@@ -43,6 +45,8 @@ export class Lorem {
    * @example
    * faker.lorem.words() // 'qui praesentium pariatur'
    * faker.lorem.words(10) // 'debitis consectetur voluptatem non doloremque ipsum autem totam eum ratione'
+   *
+   * @since 2.0.1
    */
   words(num: number = 3): string {
     const words: string[] = [];
@@ -60,6 +64,8 @@ export class Lorem {
    * @example
    * faker.lorem.sentence() // 'Voluptatum cupiditate suscipit autem eveniet aut dolorem aut officiis distinctio.'
    * faker.lorem.sentence(5) // 'Laborum voluptatem officiis est et.'
+   *
+   * @since 2.0.1
    */
   sentence(wordCount?: number): string {
     if (wordCount == null) {
@@ -77,6 +83,8 @@ export class Lorem {
    *
    * @example
    * faker.lorem.slug() // 'dolores-illo-est'
+   *
+   * @since 4.0.0
    */
   slug(wordCount?: number): string {
     const words = this.words(wordCount);
@@ -96,6 +104,8 @@ export class Lorem {
    * faker.lorem.sentences(2, '\n')
    * // 'Et rerum a unde tempora magnam sit nisi.
    * // Et perspiciatis ipsam omnis.'
+   *
+   * @since 2.0.1
    */
   sentences(sentenceCount?: number, separator: string = ' '): string {
     if (sentenceCount == null) {
@@ -116,6 +126,8 @@ export class Lorem {
    * @example
    * faker.lorem.paragraph() // 'Non architecto nam unde sint. Ex tenetur dolor facere optio aut consequatur. Ea laudantium reiciendis repellendus.'
    * faker.lorem.paragraph() // 'Animi possimus nemo consequuntur ut ea et tempore unde qui. Quis corporis esse occaecati.'
+   *
+   * @since 2.0.1
    */
   paragraph(sentenceCount: number = 3): string {
     return this.sentences(sentenceCount + this.faker.datatype.number(3));
@@ -143,6 +155,8 @@ export class Lorem {
    * faker.lorem.paragraphs(2, '<br/>\n')
    * // 'Eos magnam aut qui accusamus. Sapiente quas culpa totam excepturi. Blanditiis totam distinctio occaecati dignissimos cumque atque qui officiis.<br/>
    * // Nihil quis vel consequatur. Blanditiis commodi deserunt sunt animi dolorum. A optio porro hic dolorum fugit aut et sint voluptas. Minima ad sed ipsa est non dolores.'
+   *
+   * @since 2.0.1
    */
   paragraphs(paragraphCount: number = 3, separator: string = '\n'): string {
     const paragraphs: string[] = [];
@@ -163,6 +177,8 @@ export class Lorem {
    * // Quis ut dolor dolores facilis possimus tempore voluptates.
    * // Iure nam officia optio cumque.
    * // Dolor tempora iusto.'
+   *
+   * @since 3.1.0
    */
   text(): string {
     const methods: Array<keyof Lorem> = [
@@ -195,6 +211,8 @@ export class Lorem {
    * faker.lorem.lines()
    * // 'Soluta deserunt eos quam reiciendis libero autem enim nam ut.
    * // Voluptate aut aut.'
+   *
+   * @since 3.1.0
    */
   lines(lineCount?: number): string {
     if (lineCount == null) {

--- a/src/modules/mersenne/index.ts
+++ b/src/modules/mersenne/index.ts
@@ -28,6 +28,8 @@ export class Mersenne {
    * @example
    * faker.mersenne.rand() // 15515
    * faker.mersenne.rand(1000, 500) // 578
+   *
+   * @since 5.5.0
    */
   rand(max = 32768, min = 0): number {
     if (min > max) {
@@ -44,6 +46,8 @@ export class Mersenne {
    *
    * @param S The seed to use.
    * @throws If the seed is not a `number`.
+   *
+   * @since 5.5.0
    */
   seed(S: number): void {
     if (typeof S !== 'number') {
@@ -60,6 +64,8 @@ export class Mersenne {
    *
    * @param A The seed to use.
    * @throws If the seed is not a `number[]`.
+   *
+   * @since 5.5.0
    */
   seed_array(A: number[]): void {
     if (typeof A !== 'object') {

--- a/src/modules/music/index.ts
+++ b/src/modules/music/index.ts
@@ -19,6 +19,8 @@ export class Music {
    *
    * @example
    * faker.music.genre() // 'Reggae'
+   *
+   * @since 5.2.0
    */
   genre(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.music.genre);
@@ -29,6 +31,8 @@ export class Music {
    *
    * @example
    * faker.music.songName() // 'White Christmas'
+   *
+   * @since 7.1.0
    */
   songName(): string {
     return this.faker.helpers.arrayElement(

--- a/src/modules/name/index.ts
+++ b/src/modules/name/index.ts
@@ -96,6 +96,8 @@ export class Name {
    * faker.name.firstName() // 'Antwan'
    * faker.name.firstName('female') // 'Victoria'
    * faker.name.firstName('male') // 'Tom'
+   *
+   * @since 2.0.1
    */
   firstName(sex?: SexType): string {
     const { first_name, female_first_name, male_first_name } =
@@ -118,6 +120,8 @@ export class Name {
    * faker.name.lastName() // 'Hauck'
    * faker.name.lastName('female') // 'Grady'
    * faker.name.lastName('male') // 'Barton'
+   *
+   * @since 2.0.1
    */
   lastName(sex?: SexType): string {
     const { last_name, female_last_name, male_last_name } =
@@ -140,6 +144,8 @@ export class Name {
    * faker.name.middleName() // 'James'
    * faker.name.middleName('female') // 'Eloise'
    * faker.name.middleName('male') // 'Asher'
+   *
+   * @since 5.2.0
    */
   middleName(sex?: SexType): string {
     const { middle_name, female_middle_name, male_middle_name } =
@@ -167,6 +173,8 @@ export class Name {
    * faker.name.findName('Marcella', '', 'female') // 'Mrs. Marcella Huels'
    * faker.name.findName(undefined, 'Beer') // 'Mr. Alfonso Beer'
    * faker.name.findName(undefined, undefined, 'male') // 'Fernando Schaefer'
+   *
+   * @since 2.0.1
    *
    * @deprecated Use faker.name.fullName() instead.
    */
@@ -196,6 +204,8 @@ export class Name {
    * faker.name.fullName({ firstName: 'Marcella', sex: 'female' }) // 'Mrs. Marcella Huels'
    * faker.name.fullName({ lastName: 'Beer' }) // 'Mr. Alfonso Beer'
    * faker.name.fullName({ sex: 'male' }) // 'Fernando Schaefer'
+   *
+   * @since 7.4.0
    */
   fullName(
     options: {
@@ -253,6 +263,8 @@ export class Name {
    *
    * @example
    * faker.name.gender() // 'Trans*Man'
+   *
+   * @since 5.0.0
    */
   gender(binary?: boolean): string {
     if (binary) {
@@ -279,6 +291,8 @@ export class Name {
    *
    * @example
    * faker.name.sex() // 'female'
+   *
+   * @since 7.5.0
    */
   sex(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.name.sex);
@@ -289,6 +303,8 @@ export class Name {
    *
    * @example
    * faker.name.sexType() // Sex.Female
+   *
+   * @since 7.5.0
    */
   sexType(): SexType {
     return this.faker.helpers.objectValue(Sex);
@@ -303,6 +319,8 @@ export class Name {
    * faker.name.prefix() // 'Miss'
    * faker.name.prefix('female') // 'Ms.'
    * faker.name.prefix('male') // 'Mr.'
+   *
+   * @since 2.0.1
    */
   prefix(sex?: SexType): string {
     const { prefix, female_prefix, male_prefix } = this.faker.definitions.name;
@@ -319,6 +337,8 @@ export class Name {
    *
    * @example
    * faker.name.suffix() // 'DDS'
+   *
+   * @since 2.0.1
    */
   suffix(): string {
     // TODO @Shinigami92 2022-03-21: Add female_suffix and male_suffix
@@ -330,6 +350,8 @@ export class Name {
    *
    * @example
    * faker.name.jobTitle() // 'Global Accounts Engineer'
+   *
+   * @since 3.0.0
    */
   jobTitle(): string {
     return `${this.jobDescriptor()} ${this.jobArea()} ${this.jobType()}`;
@@ -340,6 +362,8 @@ export class Name {
    *
    * @example
    * faker.name.jobDescriptor() // 'Customer'
+   *
+   * @since 3.0.0
    */
   jobDescriptor(): string {
     return this.faker.helpers.arrayElement(
@@ -352,6 +376,8 @@ export class Name {
    *
    * @example
    * faker.name.jobArea() // 'Brand'
+   *
+   * @since 3.0.0
    */
   jobArea(): string {
     return this.faker.helpers.arrayElement(
@@ -364,6 +390,8 @@ export class Name {
    *
    * @example
    * faker.name.jobType() // 'Assistant'
+   *
+   * @since 3.0.0
    */
   jobType(): string {
     return this.faker.helpers.arrayElement(

--- a/src/modules/phone/index.ts
+++ b/src/modules/phone/index.ts
@@ -27,6 +27,8 @@ export class Phone {
    * faker.phone.phoneNumber('501-###-###') // '501-039-841'
    * faker.phone.phoneNumber('+48 91 ### ## ##') // '+48 91 463 61 70'
    *
+   * @since 2.0.1
+   *
    * @deprecated Use faker.phone.number() instead.
    */
   phoneNumber(format?: string): string {
@@ -48,6 +50,8 @@ export class Phone {
    * faker.phone.number() // '961-770-7727'
    * faker.phone.number('501-###-###') // '501-039-841'
    * faker.phone.number('+48 91 ### ## ##') // '+48 91 463 61 70'
+   *
+   * @since 7.3.0
    */
   number(format?: string): string {
     format =
@@ -69,6 +73,8 @@ export class Phone {
    * @example
    * faker.phone.phoneNumberFormat() // '943-627-0355'
    * faker.phone.phoneNumberFormat(3) // '282.652.3201'
+   *
+   * @since 2.0.1
    *
    * @deprecated
    * Use faker.phone.phoneNumber() instead.
@@ -95,6 +101,8 @@ export class Phone {
    * @example
    * faker.phone.phoneFormats() // '!##.!##.####'
    *
+   * @since 2.0.1
+   *
    * @deprecated
    * Use `faker.phone.phoneNumber()` instead.
    */
@@ -115,6 +123,8 @@ export class Phone {
    *
    * @example
    * faker.phone.imei() // '13-850175-913761-7'
+   *
+   * @since 6.2.0
    */
   imei(): string {
     return this.faker.helpers.replaceCreditCardSymbols(

--- a/src/modules/random/index.ts
+++ b/src/modules/random/index.ts
@@ -113,6 +113,8 @@ export class Random {
    *
    * @example
    * faker.random.word() // 'Seamless'
+   *
+   * @since 3.1.0
    */
   word(): string {
     const wordMethods = [
@@ -228,6 +230,8 @@ export class Random {
    * @example
    * faker.random.words() // 'neural'
    * faker.random.words(5) // 'copy Handcrafted bus client-server Point'
+   *
+   * @since 3.1.0
    */
   words(count?: number): string {
     const words: string[] = [];
@@ -249,6 +253,8 @@ export class Random {
    *
    * @example
    * faker.random.locale() // 'el'
+   *
+   * @since 3.1.0
    */
   locale(): string {
     return this.faker.helpers.arrayElement(Object.keys(this.faker.locales));
@@ -267,6 +273,8 @@ export class Random {
    * faker.random.alpha() // 'b'
    * faker.random.alpha(10) // 'qccrabobaf'
    * faker.random.alpha({ count: 5, casing: 'upper', bannedChars: ['A'] }) // 'DTCIC'
+   *
+   * @since 5.0.0
    */
   alpha(
     options:
@@ -351,6 +359,8 @@ export class Random {
    * faker.random.alphaNumeric() // '2'
    * faker.random.alphaNumeric(5) // '3e5v7'
    * faker.random.alphaNumeric(5, { bannedChars: ["a"] }) // 'xszlm'
+   *
+   * @since 3.1.0
    */
   alphaNumeric(
     count: number = 1,
@@ -415,6 +425,8 @@ export class Random {
    * faker.random.numeric(42) // '56434563150765416546479875435481513188548'
    * faker.random.numeric(42, { allowLeadingZeros: true }) // '00564846278453876543517840713421451546115'
    * faker.random.numeric(6, { bannedDigits: ['0'] }) // '943228'
+   *
+   * @since 6.3.0
    */
   numeric(
     length: number = 1,

--- a/src/modules/science/index.ts
+++ b/src/modules/science/index.ts
@@ -50,6 +50,8 @@ export class Science {
    * faker.science.chemicalElement() // { symbol: 'H', name: 'Hydrogen', atomicNumber: 1 }
    * faker.science.chemicalElement() // { symbol: 'Xe', name: 'Xenon', atomicNumber: 54 }
    * faker.science.chemicalElement() // { symbol: 'Ce', name: 'Cerium', atomicNumber: 58 }
+   *
+   * @since 7.2.0
    */
   chemicalElement(): ChemicalElement {
     return this.faker.helpers.arrayElement(
@@ -64,6 +66,8 @@ export class Science {
    * faker.science.unit() // { name: 'meter', symbol: 'm' }
    * faker.science.unit() // { name: 'second', symbol: 's' }
    * faker.science.unit() // { name: 'mole', symbol: 'mol' }
+   *
+   * @since 7.2.0
    */
   unit(): Unit {
     return this.faker.helpers.arrayElement(this.faker.definitions.science.unit);

--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -55,6 +55,8 @@ export class System {
    * @example
    * faker.system.fileName() // 'self_enabling_accountability_toys.kpt'
    * faker.system.fileName({ extensionCount: 2 }) // 'bike_table.res.vcs'
+   *
+   * @since 3.1.0
    */
   fileName(
     options: {
@@ -89,6 +91,8 @@ export class System {
    * @example
    * faker.system.commonFileName() // 'dollar.jpg'
    * faker.system.commonFileName('txt') // 'global_borders_wyoming.txt'
+   *
+   * @since 3.1.0
    */
   commonFileName(ext?: string): string {
     const str = this.fileName({ extensionCount: 0 });
@@ -101,6 +105,8 @@ export class System {
    *
    * @example
    * faker.system.mimeType() // 'video/vnd.vivo'
+   *
+   * @since 3.1.0
    */
   mimeType(): string {
     const mimeTypeKeys = Object.keys(this.faker.definitions.system.mimeTypes);
@@ -113,6 +119,8 @@ export class System {
    *
    * @example
    * faker.system.commonFileType() // 'audio'
+   *
+   * @since 3.1.0
    */
   commonFileType(): string {
     return this.faker.helpers.arrayElement(commonFileTypes);
@@ -123,6 +131,8 @@ export class System {
    *
    * @example
    * faker.system.commonFileExt() // 'gif'
+   *
+   * @since 3.1.0
    */
   commonFileExt(): string {
     return this.fileExt(this.faker.helpers.arrayElement(commonMimeTypes));
@@ -133,6 +143,8 @@ export class System {
    *
    * @example
    * faker.system.fileType() // 'message'
+   *
+   * @since 3.1.0
    */
   fileType(): string {
     const typeSet = new Set<string>();
@@ -156,6 +168,8 @@ export class System {
    * @example
    * faker.system.fileExt() // 'emf'
    * faker.system.fileExt('application/json') // 'json'
+   *
+   * @since 3.1.0
    */
   fileExt(mimeType?: string): string {
     if (typeof mimeType === 'string') {
@@ -183,6 +197,8 @@ export class System {
    *
    * @example
    * faker.system.directoryPath() // '/etc/mail'
+   *
+   * @since 3.1.0
    */
   directoryPath(): string {
     const paths = this.faker.definitions.system.directoryPaths;
@@ -194,6 +210,8 @@ export class System {
    *
    * @example
    * faker.system.filePath() // '/usr/local/src/money.dotx'
+   *
+   * @since 3.1.0
    */
   // TODO @prisis 2022-01-25: add a parameter to have the possibility to have one or two ext on file.
   filePath(): string {
@@ -205,6 +223,8 @@ export class System {
    *
    * @example
    * faker.system.semver() // '1.1.2'
+   *
+   * @since 3.1.0
    */
   semver(): string {
     return [
@@ -226,6 +246,8 @@ export class System {
    * faker.system.networkInterface({ interfaceType: 'wl' }) // 'wlo1'
    * faker.system.networkInterface({ interfaceSchema: 'mac' }) // 'enx000c29c00000'
    * faker.system.networkInterface({ interfaceType: 'en', interfaceSchema: 'pci' }) // 'enp5s0f1d0'
+   *
+   * @since 7.4.0
    */
   networkInterface(
     options: {
@@ -288,6 +310,8 @@ export class System {
    * faker.system.cron({ includeYear: false }) // '45 23 * * 6'
    * faker.system.cron({ includeNonStandard: false }) // '45 23 * * 6'
    * faker.system.cron({ includeNonStandard: true }) // '@yearly'
+   *
+   * @since 7.5.0
    */
   cron(
     options: {

--- a/src/modules/unique/index.ts
+++ b/src/modules/unique/index.ts
@@ -44,6 +44,8 @@ export class Unique {
    * @example
    * faker.unique(faker.name.firstName) // 'Corbin'
    *
+   * @since 5.0.0
+   *
    * @deprecated Use faker.helpers.unique() instead.
    */
   unique<Method extends (...parameters) => RecordKey>(

--- a/src/modules/vehicle/index.ts
+++ b/src/modules/vehicle/index.ts
@@ -19,6 +19,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.vehicle() // 'BMW Explorer'
+   *
+   * @since 5.0.0
    */
   vehicle(): string {
     return `${this.manufacturer()} ${this.model()}`;
@@ -29,6 +31,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.manufacturer() // 'Ford'
+   *
+   * @since 5.0.0
    */
   manufacturer(): string {
     return this.faker.helpers.arrayElement(
@@ -41,6 +45,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.model() // 'Explorer'
+   *
+   * @since 5.0.0
    */
   model(): string {
     return this.faker.helpers.arrayElement(
@@ -53,6 +59,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.type() // 'Coupe'
+   *
+   * @since 5.0.0
    */
   type(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.vehicle.type);
@@ -63,6 +71,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.fuel() // 'Electric'
+   *
+   * @since 5.0.0
    */
   fuel(): string {
     return this.faker.helpers.arrayElement(this.faker.definitions.vehicle.fuel);
@@ -73,6 +83,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.vin() // 'YV1MH682762184654'
+   *
+   * @since 5.0.0
    */
   vin(): string {
     const bannedChars = ['o', 'i', 'q', 'O', 'I', 'Q'];
@@ -95,6 +107,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.color() // 'red'
+   *
+   * @since 5.0.0
    */
   color(): string {
     return this.faker.color.human();
@@ -105,6 +119,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.vrm() // 'MF56UPA'
+   *
+   * @since 5.4.0
    */
   vrm(): string {
     return `${this.faker.random.alpha({
@@ -124,6 +140,8 @@ export class Vehicle {
    *
    * @example
    * faker.vehicle.bicycle() // 'Adventure Road Bicycle'
+   *
+   * @since 5.5.0
    */
   bicycle(): string {
     return this.faker.helpers.arrayElement(

--- a/src/modules/word/index.ts
+++ b/src/modules/word/index.ts
@@ -48,6 +48,8 @@ export class Word {
    * faker.word.adjective() // 'pungent'
    * faker.word.adjective(5) // 'slimy'
    * faker.word.adjective(100) // 'complete'
+   *
+   * @since 6.0.0
    */
   adjective(length?: number): string {
     return this.faker.helpers.arrayElement(
@@ -67,6 +69,8 @@ export class Word {
    * faker.word.adverb() // 'quarrelsomely'
    * faker.word.adverb(5) // 'madly'
    * faker.word.adverb(100) // 'sadly'
+   *
+   * @since 6.0.0
    */
   adverb(length?: number): string {
     return this.faker.helpers.arrayElement(
@@ -86,6 +90,8 @@ export class Word {
    * faker.word.conjunction() // 'in order that'
    * faker.word.conjunction(5) // 'since'
    * faker.word.conjunction(100) // 'as long as'
+   *
+   * @since 6.0.0
    */
   conjunction(length?: number): string {
     return this.faker.helpers.arrayElement(
@@ -105,6 +111,8 @@ export class Word {
    * faker.word.interjection() // 'gah'
    * faker.word.interjection(5) // 'fooey'
    * faker.word.interjection(100) // 'yowza'
+   *
+   * @since 6.0.0
    */
   interjection(length?: number): string {
     return this.faker.helpers.arrayElement(
@@ -124,6 +132,8 @@ export class Word {
    * faker.word.noun() // 'external'
    * faker.word.noun(5) // 'front'
    * faker.word.noun(100) // 'care'
+   *
+   * @since 6.0.0
    */
   noun(length?: number): string {
     return this.faker.helpers.arrayElement(
@@ -143,6 +153,8 @@ export class Word {
    * faker.word.preposition() // 'without'
    * faker.word.preposition(5) // 'abaft'
    * faker.word.preposition(100) // 'an'
+   *
+   * @since 6.0.0
    */
   preposition(length?: number): string {
     return this.faker.helpers.arrayElement(
@@ -162,6 +174,8 @@ export class Word {
    * faker.word.verb() // 'act'
    * faker.word.verb(5) // 'tinge'
    * faker.word.verb(100) // 'mess'
+   *
+   * @since 6.0.0
    */
   verb(length?: number): string {
     return this.faker.helpers.arrayElement(

--- a/test/scripts/apidoc/examplesAndDeprecations.spec.ts
+++ b/test/scripts/apidoc/examplesAndDeprecations.spec.ts
@@ -9,6 +9,7 @@ import { selectApiModules } from '../../../scripts/apidoc/moduleMethods';
 import {
   extractRawExamples,
   extractSeeAlsos,
+  extractSince,
   extractTagContent,
   isDeprecated,
 } from '../../../scripts/apidoc/utils';
@@ -119,6 +120,8 @@ describe('examples and deprecations', () => {
           expect(link, 'Expect method reference to contain ()').toContain(')');
         }
       });
+
+      expect(extractSince(signature), '@since to be present').toBeTruthy();
     });
   });
 });

--- a/test/scripts/apidoc/signature.example.ts
+++ b/test/scripts/apidoc/signature.example.ts
@@ -240,4 +240,13 @@ export class SignatureTest {
   methodWithMultipleSeeMarkers(): number {
     return 0;
   }
+
+  /**
+   * Test with since marker.
+   *
+   * @since 1.0.0
+   */
+  methodWithSinceMarker(): number {
+    return 0;
+  }
 }

--- a/test/scripts/apidoc/signature.expected.json
+++ b/test/scripts/apidoc/signature.expected.json
@@ -11,6 +11,7 @@
         "description": "<p>The boolean parameter.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">defaultBooleanParamMethod</span><span style=\"color: #A6ACCD\">(c: boolean </span><span style=\"color: #89DDFF\">=</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #FF9CAC\">true</span><span style=\"color: #A6ACCD\">): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -27,6 +28,7 @@
         "description": "<p>The function parameter.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">functionParamMethod</span><span style=\"color: #A6ACCD\">(fn: </span><span style=\"color: #89DDFF\">(</span><span style=\"color: #A6ACCD\">a</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #FFCB6B\">string</span><span style=\"color: #89DDFF\">)</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #C792EA\">=&gt;</span><span style=\"color: #A6ACCD\"> number): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -43,6 +45,7 @@
         "description": "<p><code>'a'</code> or <code>'b'</code>.</p>\n"
       }
     ],
+    "since": "",
     "returns": "string",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">literalUnionParamMethod</span><span style=\"color: #A6ACCD\">(value: </span><span style=\"color: #89DDFF\">&#39;</span><span style=\"color: #C3E88D\">a</span><span style=\"color: #89DDFF\">&#39;</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">|</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">&#39;</span><span style=\"color: #C3E88D\">b</span><span style=\"color: #89DDFF\">&#39;</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">|</span><span style=\"color: #A6ACCD\"> string): string</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -53,6 +56,7 @@
     "title": "Method With Deprecated",
     "description": "<p>Test with deprecated and see marker.</p>\n",
     "parameters": [],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">methodWithDeprecated</span><span style=\"color: #A6ACCD\">(): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": true,
@@ -63,6 +67,7 @@
     "title": "Method With Example",
     "description": "<p>Test with example marker.</p>\n",
     "parameters": [],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">methodWithExample</span><span style=\"color: #A6ACCD\">(): number</span></span>\n<span class=\"line\"><span style=\"color: #A6ACCD\">test</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #A6ACCD\">apidoc</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">methodWithExample</span><span style=\"color: #A6ACCD\">() </span><span style=\"color: #676E95\">// 0</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -73,6 +78,7 @@
     "title": "Method With Multiple See Markers",
     "description": "<p>Test with multiple see markers.</p>\n",
     "parameters": [],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">methodWithMultipleSeeMarkers</span><span style=\"color: #A6ACCD\">(): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -80,6 +86,17 @@
       "test.apidoc.methodWithExample()",
       "test.apidoc.methodWithDeprecated()"
     ]
+  },
+  "methodWithSinceMarker": {
+    "name": "methodWithSinceMarker",
+    "title": "Method With Since Marker",
+    "description": "<p>Test with since marker.</p>\n",
+    "parameters": [],
+    "since": "1.0.0",
+    "returns": "number",
+    "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">methodWithSinceMarker</span><span style=\"color: #A6ACCD\">(): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
+    "deprecated": false,
+    "seeAlsos": []
   },
   "multiParamMethod": {
     "name": "multiParamMethod",
@@ -103,6 +120,7 @@
         "description": "<p>The boolean parameter.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">multiParamMethod</span><span style=\"color: #A6ACCD\">(a: number</span><span style=\"color: #89DDFF\">,</span><span style=\"color: #A6ACCD\"> b</span><span style=\"color: #89DDFF\">?:</span><span style=\"color: #A6ACCD\"> string</span><span style=\"color: #89DDFF\">,</span><span style=\"color: #A6ACCD\"> c: boolean </span><span style=\"color: #89DDFF\">=</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #FF9CAC\">true</span><span style=\"color: #A6ACCD\">): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -113,6 +131,7 @@
     "title": "No Param Method",
     "description": "<p>Test with no parameters.</p>\n",
     "parameters": [],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">noParamMethod</span><span style=\"color: #A6ACCD\">(): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -129,6 +148,7 @@
         "description": "<p>The string parameter.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">optionalStringParamMethod</span><span style=\"color: #A6ACCD\">(b</span><span style=\"color: #89DDFF\">?:</span><span style=\"color: #A6ACCD\"> string): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -173,6 +193,7 @@
         "description": "<p>The number parameter. It also has a more complex description.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">optionsInlineParamMethodWithDefaults</span><span style=\"color: #A6ACCD\">(a: </span><span style=\"color: #89DDFF\">{</span></span>\n<span class=\"line\"><span style=\"color: #A6ACCD\">  </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> number</span></span>\n<span class=\"line\"><span style=\"color: #89DDFF\">}</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">=</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">{</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F78C6C\">1</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">},</span><span style=\"color: #A6ACCD\"> b: </span><span style=\"color: #89DDFF\">{</span></span>\n<span class=\"line\"><span style=\"color: #A6ACCD\">  </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> number</span></span>\n<span class=\"line\"><span style=\"color: #89DDFF\">}</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">=</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">{</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F78C6C\">1</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">},</span><span style=\"color: #A6ACCD\"> c: </span><span style=\"color: #89DDFF\">{</span></span>\n<span class=\"line\"><span style=\"color: #A6ACCD\">  </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> number</span></span>\n<span class=\"line\"><span style=\"color: #89DDFF\">}</span><span style=\"color: #A6ACCD\">): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -201,6 +222,7 @@
         "description": "<p>Parameter with inner jsdocs default.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">optionsInterfaceParamMethodWithDefaults</span><span style=\"color: #A6ACCD\">(a: ParameterOptionsInterfaceA </span><span style=\"color: #89DDFF\">=</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">{</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F78C6C\">1</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">},</span><span style=\"color: #A6ACCD\"> b: ParameterOptionsInterfaceB </span><span style=\"color: #89DDFF\">=</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">{</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F78C6C\">1</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">},</span><span style=\"color: #A6ACCD\"> c: ParameterOptionsInterfaceC): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -237,6 +259,7 @@
         "description": "<p>The method parameter.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">optionsParamMethod</span><span style=\"color: #A6ACCD\">(options: </span><span style=\"color: #89DDFF\">{</span></span>\n<span class=\"line\"><span style=\"color: #A6ACCD\">  </span><span style=\"color: #F07178\">a</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> number</span><span style=\"color: #89DDFF\">,</span></span>\n<span class=\"line\"><span style=\"color: #A6ACCD\">  </span><span style=\"color: #F07178\">b</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> string</span><span style=\"color: #89DDFF\">,</span></span>\n<span class=\"line\"><span style=\"color: #A6ACCD\">  </span><span style=\"color: #F07178\">c</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> boolean</span><span style=\"color: #89DDFF\">,</span></span>\n<span class=\"line\"><span style=\"color: #A6ACCD\">  </span><span style=\"color: #82AAFF\">d</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">()</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #C792EA\">=&gt;</span><span style=\"color: #A6ACCD\"> string</span></span>\n<span class=\"line\"><span style=\"color: #89DDFF\">}</span><span style=\"color: #A6ACCD\">): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -265,6 +288,7 @@
         "description": "<p>Parameter with inner jsdocs default.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">optionsTypeParamMethodWithDefaults</span><span style=\"color: #A6ACCD\">(a: ParameterOptionsTypeA </span><span style=\"color: #89DDFF\">=</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">{</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F78C6C\">1</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">},</span><span style=\"color: #A6ACCD\"> b: ParameterOptionsTypeB </span><span style=\"color: #89DDFF\">=</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">{</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F07178\">value</span><span style=\"color: #89DDFF\">:</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #F78C6C\">1</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">},</span><span style=\"color: #A6ACCD\"> c: ParameterOptionsTypeC): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -281,6 +305,7 @@
         "description": "<p>The number parameter.</p>\n"
       }
     ],
+    "since": "",
     "returns": "number",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">requiredNumberParamMethod</span><span style=\"color: #A6ACCD\">(a: number): number</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,
@@ -297,6 +322,7 @@
         "description": "<p><code>'a'</code> or <code>'b'</code>.</p>\n"
       }
     ],
+    "since": "",
     "returns": "string",
     "examples": "<div class=\"language-ts\"><button class=\"copy\"></button><span class=\"lang\">ts</span><pre v-pre><code><span class=\"line\"><span style=\"color: #A6ACCD\">faker</span><span style=\"color: #89DDFF\">.</span><span style=\"color: #82AAFF\">stringUnionParamMethod</span><span style=\"color: #A6ACCD\">(value: </span><span style=\"color: #89DDFF\">&#39;</span><span style=\"color: #C3E88D\">a</span><span style=\"color: #89DDFF\">&#39;</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">|</span><span style=\"color: #A6ACCD\"> </span><span style=\"color: #89DDFF\">&#39;</span><span style=\"color: #C3E88D\">b</span><span style=\"color: #89DDFF\">&#39;</span><span style=\"color: #A6ACCD\">): string</span></span>\n<span class=\"line\"></span></code></pre>\n</div>",
     "deprecated": false,


### PR DESCRIPTION
Following on from discussion in https://github.com/faker-js/faker/discussions/1241 i added `@since` jsdoc tags to all existing public methods, and exposed this in the documentation:

<img width="750" alt="image" src="https://user-images.githubusercontent.com/152770/188712441-4e94612b-2724-4b8d-89bc-3f82f4d0fb7e.png">

This is a one-off large diff for this initial integration, in future it would just be necessary to add `@since` tags for any newly added methods.