### PR TITLE
docs: remove redundant TOCs

### DIFF
--- a/docs/about/announcements/2022-01-14.md
+++ b/docs/about/announcements/2022-01-14.md
@@ -10,8 +10,6 @@ _January 14th, 2022_
 
 We want the project to have a fresh start and become _even cooler_.
 
-[[toc]]
-
 ## What is Faker?
 
 Faker is a library that generates fake (but reasonable) data for you. Mock data. Data for testing, development, and the like.

--- a/docs/guide/migration-guide-v5.md
+++ b/docs/guide/migration-guide-v5.md
@@ -1,7 +1,5 @@
 # Migrating from Faker v5 to v6
 
-[[toc]]
-
 ## ESM Support
 
 **New Format**: We're now ESM compatible! We've dropped the Browser bundle in favor of ESM.

--- a/docs/guide/migration-guide-v6.md
+++ b/docs/guide/migration-guide-v6.md
@@ -1,7 +1,5 @@
 # Migrating from Faker v6 to v7
 
-[[toc]]
-
 ## Node 12 no longer supported
 
 You need at least Node 14 to use Faker.


### PR DESCRIPTION
With vitepress 1 (alpha) tocs are no longer needed as there is a separate sidebar for that as well.

[Example:](https://fakerjs.dev/guide/migration-guide-v6.html)

![grafik](https://user-images.githubusercontent.com/1579362/188987233-da67ddd9-3593-4aea-bdbe-06c36e8c6b9d.png)
