### PR TITLE
ci: renovate unset pr hourly limit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:earlyMondays", "group:allNonMajor"],
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays",
+    "group:allNonMajor",
+    ":prHourlyLimitNone"
+  ],
   "labels": ["c: dependencies"],
   "reviewersFromCodeOwners": true,
   "rangeStrategy": "bump",


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->

`config:base` sets the PR hourly limit to 2
This change unset this
This change is needed as we only let renovate create PRs on early monday