### PR TITLE
fix(finance): Update Belarusian Ruble to new version

### DIFF
--- a/src/locales/en/finance/currency.ts
+++ b/src/locales/en/finance/currency.ts
@@ -88,8 +88,8 @@ export default {
     symbol: 'P',
   },
   'Belarussian Ruble': {
-    code: 'BYR',
-    symbol: 'p.',
+    code: 'BYN',
+    symbol: 'Rbl',
   },
   'Belize Dollar': {
     code: 'BZD',


### PR DESCRIPTION
I updated the code and symbol according to wikipedia. 
See https://en.wikipedia.org/wiki/Belarusian_rubel#Third_rubel,_2016%E2%80%93present

