### PR TITLE
docs(website): remove API in guide section

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -144,10 +144,6 @@ export default defineConfig({
             },
           ],
         },
-        {
-          text: 'API',
-          items: apiPages,
-        },
       ],
       '/api/': [
         {


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->
This PR removes the `API` section on the `Guide` page.

Fixes #1326 