### PR TITLE
docs: improve usage guide for selective readers

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -112,6 +112,8 @@ Let's create our first user factory function:
 ```ts
 import { faker } from '@faker-js/faker';
 
+class User { ... }
+
 function createRandomUser(): User {
   return {
     _id: faker.datatype.uuid(),


### PR DESCRIPTION
Some users (including me) tend to read only code blocks that contains actual code (and not data structures).
Thus it is easily missed that `User` is a custom/example data-structure that we defined ourselves.

This PR adds a tiny hint to the first code example, so it becomes clear that `User` is a example data-structure even if you read only that example.

I also considered adding the hint to all examples, but that code block is more or less the entry point so it should be sufficient to add it there.

Ref: [Discord User Question](https://discord.com/channels/929487054990110771/929544761122111498/1026029789347336252)