### PR TITLE
docs: fix note containers in usage guide

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -34,7 +34,7 @@ const randomEmail = faker.internet.email(); // Kassandra.Haley@erich.biz
 </script>
 ```
 
-:::note
+::: info NOTE
 Using the browser is great for experimenting 👍. However, due to all of the strings Faker uses to generate fake data, **Faker is a large package**. It's `> 5 MiB` minified. **Please avoid deploying the full Faker in your web app.**
 :::
 
@@ -47,7 +47,7 @@ const randomName = faker.name.findName(); // Willie Bahringer
 const randomEmail = faker.internet.email(); // Tomasa_Ferry14@hotmail.com
 ```
 
-:::note
+::: info NOTE
 It is highly recommended to use version tags when importing libraries in Deno, e.g: `import { faker } from "https://cdn.skypack.dev/@faker-js/faker@v7.4.0"`. Add `?dts` to import with type definitions: `import { faker } from "https://cdn.skypack.dev/@faker-js/faker@v7.4.0?dts"`.
 :::
 


### PR DESCRIPTION
**before:**

<img width="614" alt="Screen Shot 2022-10-08 at 07 51 49" src="https://user-images.githubusercontent.com/45778229/194679305-4f407dfe-85c0-404e-ba95-93298b071456.png">

**after:**

<img width="613" alt="Screen Shot 2022-10-08 at 07 52 03" src="https://user-images.githubusercontent.com/45778229/194679314-61016b6e-0653-4005-b543-b4a11b1f98dc.png">
