### PR TITLE
test: extend vitest with (not) toContainDuplicates

### DIFF
--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -143,7 +143,7 @@ describe('helpers', () => {
           });
 
           // Check uniqueness
-          expect(subset).toBeUnique();
+          expect(subset).not.toContainDuplicates();
         });
 
         it('should return a subset of fixed length with random elements in the array', () => {
@@ -346,7 +346,7 @@ describe('helpers', () => {
           const input = ['a', 'a', 'a', 'a,', 'a', 'a', 'a', 'a', 'b'];
           const length = 2;
           const unique = faker.helpers.uniqueArray(input, length);
-          expect(unique).toBeUnique();
+          expect(unique).not.toContainDuplicates();
           expect(unique).toHaveLength(length);
         });
 
@@ -356,14 +356,14 @@ describe('helpers', () => {
             faker.definitions.hacker.noun,
             length
           );
-          expect(unique).toBeUnique();
+          expect(unique).not.toContainDuplicates();
           expect(unique).toHaveLength(length);
         });
 
         it('function returns unique array', () => {
           const length = faker.datatype.number({ min: 1, max: 6 });
           const unique = faker.helpers.uniqueArray(faker.lorem.word, length);
-          expect(unique).toBeUnique();
+          expect(unique).not.toContainDuplicates();
           expect(unique).toHaveLength(length);
         });
 
@@ -378,7 +378,7 @@ describe('helpers', () => {
           const input = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
           const length = input.length + 1;
           const unique = faker.helpers.uniqueArray(input, length);
-          expect(unique).toBeUnique();
+          expect(unique).not.toContainDuplicates();
           expect(unique).toHaveLength(input.length);
         });
 

--- a/test/locales.spec.ts
+++ b/test/locales.spec.ts
@@ -33,7 +33,7 @@ describe('locale', () => {
             describe(definitionName, () => {
               function testArraySample<T>(arr: T[]) {
                 it('should not have duplicate entries', () => {
-                  expect(arr).toBeUnique();
+                  expect(arr).not.toContainDuplicates();
                 });
               }
 

--- a/test/vitest-extensions.ts
+++ b/test/vitest-extensions.ts
@@ -1,20 +1,25 @@
 import { expect } from 'vitest';
 
 expect.extend({
-  toBeUnique<T>(received: T[]) {
+  toContainDuplicates<T>(received: T[]) {
+    const { isNot } = this;
+
     const uniques = new Set(received);
     const duplications = received.filter((entry) => !uniques.delete(entry));
     const uniqueDuplication = [...new Set(duplications)];
 
     return {
-      pass: uniqueDuplication.length === 0,
-      message: () => `Duplicated values are: [${uniqueDuplication.join(', ')}]`,
+      pass: uniqueDuplication.length !== 0,
+      message: () =>
+        isNot
+          ? `Duplicated values are [${uniqueDuplication.join(', ')}]`
+          : `No duplicate values in [${received.join(', ')}]`,
     };
   },
 });
 
 interface CustomMatchers {
-  toBeUnique(): void;
+  toContainDuplicates(): void;
 }
 
 declare global {


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->

Improving some tests with https://vitest.dev/api/#expect-extend

Not sure if there is even a better way instead of importing the ts file all over again