### PR TITLE
chore: mark mersenne as deprecated (internal)

### DIFF
--- a/src/faker.ts
+++ b/src/faker.ts
@@ -79,6 +79,9 @@ export class Faker {
   readonly fake: FakeModule['fake'] = new FakeModule(this).fake;
   readonly unique: UniqueModule['unique'] = new UniqueModule(this).unique;
 
+  /**
+   * @deprecated Internal. Use faker.datatype.number() or faker.seed() instead.
+   */
   readonly mersenne: MersenneModule = new MersenneModule();
   readonly random: RandomModule = new RandomModule(this);
 

--- a/src/modules/mersenne/index.ts
+++ b/src/modules/mersenne/index.ts
@@ -3,6 +3,8 @@ import Gen from './twister';
 
 /**
  * Module to generate seed based random numbers.
+ *
+ * @deprecated Internal. Use faker.datatype.number() or faker.seed() instead.
  */
 export class MersenneModule {
   private gen = new Gen();


### PR DESCRIPTION
Marks the Mersenne Module as deprecated, because it will be an internal module in the future.

Preparatory work for #1348 .