### PR TITLE
test: fix fake test expectation

### DIFF
--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -588,7 +588,7 @@ describe('helpers', () => {
 
         it('should be able to handle random }} brackets', () => {
           expect(faker.helpers.fake('}}hello{{random.alpha}}')).toMatch(
-            /^}}hello[a-z]$/
+            /^}}hello[a-zA-Z]$/
           );
         });
 


### PR DESCRIPTION
The test uses the following template with `fake()`:

`'}}hello{{random.alpha}}'`

Starting with v8 the new default for the `casing` option is `mixed`, thus the regex has to be updated.

https://next.fakerjs.dev/api/random.html#alpha