### PR TITLE
feat(datatype): introduce probability option to boolean

### DIFF
--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -192,13 +192,30 @@ export class DatatypeModule {
   /**
    * Returns the boolean value true or false.
    *
+   * @param options Options object or the probability (`[0.00, 1.00]`) of returning `true`. Should be between `0` and `1`. Defaults to `0.5`.
+   * @param options.probability The probability (`[0.00, 1.00]`) of returning `true`. Should be between `0` and `1`. Defaults to `0.5`.
+   *
    * @example
    * faker.datatype.boolean() // false
+   * faker.datatype.boolean(0.9) // true
    *
    * @since 5.5.0
    */
-  boolean(): boolean {
-    return !!this.number(1);
+  boolean(options: number | { probability?: number } = {}): boolean {
+    if (typeof options === 'number') {
+      options = {
+        probability: options,
+      };
+    }
+    const { probability = 0.5 } = options;
+    if (probability <= 0) {
+      return false;
+    }
+    if (probability >= 1) {
+      // This check is required to avoid returning false when float() returns 1
+      return true;
+    }
+    return this.faker.datatype.float({ min: 0, max: 1 }) < probability;
   }
 
   /**

--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -192,8 +192,15 @@ export class DatatypeModule {
   /**
    * Returns the boolean value true or false.
    *
-   * @param options Options object or the probability (`[0.00, 1.00]`) of returning `true`. Should be between `0` and `1`. Defaults to `0.5`.
-   * @param options.probability The probability (`[0.00, 1.00]`) of returning `true`. Should be between `0` and `1`. Defaults to `0.5`.
+   * **Note:**
+   * A probability of `0.75` results in `true` being returned `75%` of the calls; likewise `0.3` => `30%`.
+   * If the probability is zero or below, it will always return false.
+   * If the probability is one or above, it will always return true.
+   * The probability is limited to two decimal places.
+   * Please keep in mind that the result depends on the seed and is not random.
+   *
+   * @param options The optional options object or the probability (`[0.00, 1.00]`) of returning `true`. Defaults to `0.5`.
+   * @param options.probability The probability (`[0.00, 1.00]`) of returning `true`. Defaults to `0.5`.
    *
    * @example
    * faker.datatype.boolean() // false

--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -198,6 +198,7 @@ export class DatatypeModule {
    * @example
    * faker.datatype.boolean() // false
    * faker.datatype.boolean(0.9) // true
+   * faker.datatype.boolean({ probability: 0.1 }) // false
    *
    * @since 5.5.0
    */

--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -197,7 +197,6 @@ export class DatatypeModule {
    * If the probability is `<= 0.0`, it will always return `false`.
    * If the probability is `>= 1.0`, it will always return `true`.
    * The probability is limited to two decimal places.
-   * Please keep in mind that the result depends on the seed and is not random.
    *
    * @param options The optional options object or the probability (`[0.00, 1.00]`) of returning `true`. Defaults to `0.5`.
    * @param options.probability The probability (`[0.00, 1.00]`) of returning `true`. Defaults to `0.5`.

--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -216,7 +216,7 @@ export class DatatypeModule {
       // This check is required to avoid returning false when float() returns 1
       return true;
     }
-    return this.faker.datatype.float({ min: 0, max: 1 }) < probability;
+    return this.float({ min: 0, max: 1 }) < probability;
   }
 
   /**

--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -194,8 +194,8 @@ export class DatatypeModule {
    *
    * **Note:**
    * A probability of `0.75` results in `true` being returned `75%` of the calls; likewise `0.3` => `30%`.
-   * If the probability is zero or below, it will always return false.
-   * If the probability is one or above, it will always return true.
+   * If the probability is `<= 0.0`, it will always return `false`.
+   * If the probability is `>= 1.0`, it will always return `true`.
    * The probability is limited to two decimal places.
    * Please keep in mind that the result depends on the seed and is not random.
    *

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -393,13 +393,13 @@ export class FinanceModule {
         if (bban.type === 'a') {
           s += this.faker.helpers.arrayElement(iban.alpha);
         } else if (bban.type === 'c') {
-          if (this.faker.datatype.number(100) < 80) {
+          if (this.faker.datatype.boolean(0.8)) {
             s += this.faker.datatype.number(9);
           } else {
             s += this.faker.helpers.arrayElement(iban.alpha);
           }
         } else {
-          if (c >= 3 && this.faker.datatype.number(100) < 30) {
+          if (c >= 3 && this.faker.datatype.boolean(0.3)) {
             if (this.faker.datatype.boolean()) {
               s += this.faker.helpers.arrayElement(iban.pattern100);
               c -= 2;

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -354,8 +354,7 @@ export class HelpersModule {
     callback: () => T,
     options: { probability?: number } = {}
   ): T | undefined {
-    const { probability = 0.5 } = options;
-    if (this.faker.datatype.float({ min: 0, max: 1 }) < probability) {
+    if (this.faker.datatype.boolean(options)) {
       return callback();
     }
     return undefined;

--- a/test/__snapshots__/datatype.spec.ts.snap
+++ b/test/__snapshots__/datatype.spec.ts.snap
@@ -40,6 +40,8 @@ exports[`datatype > 42 > boolean > noArgs 5`] = `false`;
 
 exports[`datatype > 42 > boolean > with probability 1`] = `true`;
 
+exports[`datatype > 42 > boolean > with probability option 1`] = `false`;
+
 exports[`datatype > 42 > datetime > noArgs 1`] = `2031-03-14T21:33:22.114Z`;
 
 exports[`datatype > 42 > datetime > with given number 1`] = `1994-03-20T17:23:00.629Z`;
@@ -158,6 +160,8 @@ exports[`datatype > 1211 > boolean > noArgs 5`] = `true`;
 
 exports[`datatype > 1211 > boolean > with probability 1`] = `false`;
 
+exports[`datatype > 1211 > boolean > with probability option 1`] = `false`;
+
 exports[`datatype > 1211 > datetime > noArgs 1`] = `2092-02-20T03:42:04.341Z`;
 
 exports[`datatype > 1211 > datetime > with given number 1`] = `2000-06-14T02:54:42.082Z`;
@@ -275,6 +279,8 @@ exports[`datatype > 1337 > boolean > noArgs 4`] = `true`;
 exports[`datatype > 1337 > boolean > noArgs 5`] = `true`;
 
 exports[`datatype > 1337 > boolean > with probability 1`] = `true`;
+
+exports[`datatype > 1337 > boolean > with probability option 1`] = `false`;
 
 exports[`datatype > 1337 > datetime > noArgs 1`] = `2018-10-28T08:46:11.896Z`;
 

--- a/test/__snapshots__/datatype.spec.ts.snap
+++ b/test/__snapshots__/datatype.spec.ts.snap
@@ -2,25 +2,25 @@
 
 exports[`datatype > 42 > array > noArgs 1`] = `
 [
-  79654,
-  "2eiXX/J/*&",
-  86617,
-  60111,
-  70807,
-  "\\"&{dnx4!1}",
-  61748,
-  61165,
-  "!I#<QYF-%<",
-  "C6K)jZ3DP|",
+  "ky2eiXX/J/",
+  "&Kq@X.b]\\"&",
+  72199,
+  93855,
+  "!1}2Z=YQ!I",
+  "<QYF-%<{C6",
+  ")jZ3DP|XL%",
+  60754,
+  17052,
+  "'\\"yxzUlD=\\"",
 ]
 `;
 
 exports[`datatype > 42 > array > with length 1`] = `
 [
-  79654,
-  "2eiXX/J/*&",
-  86617,
-  60111,
+  "ky2eiXX/J/",
+  "&Kq@X.b]\\"&",
+  72199,
+  93855,
 ]
 `;
 
@@ -28,15 +28,17 @@ exports[`datatype > 42 > bigInt > noArgs 1`] = `379177551410048n`;
 
 exports[`datatype > 42 > bigInt > with value 1`] = `37n`;
 
-exports[`datatype > 42 > boolean 1`] = `false`;
+exports[`datatype > 42 > boolean > noArgs 1`] = `true`;
 
-exports[`datatype > 42 > boolean 2`] = `true`;
+exports[`datatype > 42 > boolean > noArgs 2`] = `false`;
 
-exports[`datatype > 42 > boolean 3`] = `true`;
+exports[`datatype > 42 > boolean > noArgs 3`] = `false`;
 
-exports[`datatype > 42 > boolean 4`] = `false`;
+exports[`datatype > 42 > boolean > noArgs 4`] = `true`;
 
-exports[`datatype > 42 > boolean 5`] = `true`;
+exports[`datatype > 42 > boolean > noArgs 5`] = `false`;
+
+exports[`datatype > 42 > boolean > with probability 1`] = `true`;
 
 exports[`datatype > 42 > datetime > noArgs 1`] = `2031-03-14T21:33:22.114Z`;
 
@@ -80,7 +82,7 @@ exports[`datatype > 42 > hexadecimal > with length, prefix, and casing 1`] = `"0
 
 exports[`datatype > 42 > hexadecimal > with prefix 1`] = `"0x8"`;
 
-exports[`datatype > 42 > json 1`] = `"{\\"foo\\":79654,\\"bar\\":\\"2eiXX/J/*&\\",\\"bike\\":86617,\\"a\\":60111,\\"b\\":70807,\\"name\\":\\"\\\\\\"&{dnx4!1}\\",\\"prop\\":61748}"`;
+exports[`datatype > 42 > json 1`] = `"{\\"foo\\":\\"ky2eiXX/J/\\",\\"bar\\":\\"&Kq@X.b]\\\\\\"&\\",\\"bike\\":72199,\\"a\\":93855,\\"b\\":\\"!1}2Z=YQ!I\\",\\"name\\":\\"<QYF-%<{C6\\",\\"prop\\":\\")jZ3DP|XL%\\"}"`;
 
 exports[`datatype > 42 > number > noArgs 1`] = `37454`;
 
@@ -118,25 +120,25 @@ exports[`datatype > 42 > uuid 5`] = `"d95f4984-24c2-410f-ac63-400d3bbbcc91"`;
 
 exports[`datatype > 1211 > array > noArgs 1`] = `
 [
-  "Kti5-}$_/\`",
-  76408,
-  35403,
-  69406,
-  "l\\"h^]dnwI<",
-  "|p|5KWu3/C",
-  "|Jh!E=x\\"RH",
-  "/5V<1bEQuA",
-  "p=DW9F=V1(",
-  "7a6.$boN\\\\7",
+  45901,
+  77826,
+  "-}$_/\`4hHA",
+  "afl\\"h^]dnw",
+  "<q|p|5KWu3",
+  "CZ|Jh!E=x\\"",
+  42131,
+  15894,
+  "V<1bEQuA|p",
+  "DW9F=V1(U7",
 ]
 `;
 
 exports[`datatype > 1211 > array > with length 1`] = `
 [
-  "Kti5-}$_/\`",
-  76408,
-  35403,
-  69406,
+  45901,
+  77826,
+  "-}$_/\`4hHA",
+  "afl\\"h^]dnw",
 ]
 `;
 
@@ -144,15 +146,17 @@ exports[`datatype > 1211 > bigInt > noArgs 1`] = `948721906162743n`;
 
 exports[`datatype > 1211 > bigInt > with value 1`] = `8n`;
 
-exports[`datatype > 1211 > boolean 1`] = `true`;
+exports[`datatype > 1211 > boolean > noArgs 1`] = `false`;
 
-exports[`datatype > 1211 > boolean 2`] = `false`;
+exports[`datatype > 1211 > boolean > noArgs 2`] = `true`;
 
-exports[`datatype > 1211 > boolean 3`] = `true`;
+exports[`datatype > 1211 > boolean > noArgs 3`] = `false`;
 
-exports[`datatype > 1211 > boolean 4`] = `true`;
+exports[`datatype > 1211 > boolean > noArgs 4`] = `false`;
 
-exports[`datatype > 1211 > boolean 5`] = `false`;
+exports[`datatype > 1211 > boolean > noArgs 5`] = `true`;
+
+exports[`datatype > 1211 > boolean > with probability 1`] = `false`;
 
 exports[`datatype > 1211 > datetime > noArgs 1`] = `2092-02-20T03:42:04.341Z`;
 
@@ -196,7 +200,7 @@ exports[`datatype > 1211 > hexadecimal > with length, prefix, and casing 1`] = `
 
 exports[`datatype > 1211 > hexadecimal > with prefix 1`] = `"0xE"`;
 
-exports[`datatype > 1211 > json 1`] = `"{\\"foo\\":\\"Kti5-}$_/\`\\",\\"bar\\":76408,\\"bike\\":35403,\\"a\\":69406,\\"b\\":\\"l\\\\\\"h^]dnwI<\\",\\"name\\":\\"|p|5KWu3/C\\",\\"prop\\":\\"|Jh!E=x\\\\\\"RH\\"}"`;
+exports[`datatype > 1211 > json 1`] = `"{\\"foo\\":45901,\\"bar\\":77826,\\"bike\\":\\"-}$_/\`4hHA\\",\\"a\\":\\"afl\\\\\\"h^]dnw\\",\\"b\\":\\"<q|p|5KWu3\\",\\"name\\":\\"CZ|Jh!E=x\\\\\\"\\",\\"prop\\":42131}"`;
 
 exports[`datatype > 1211 > number > noArgs 1`] = `92852`;
 
@@ -234,25 +238,25 @@ exports[`datatype > 1211 > uuid 5`] = `"7b91ce88-effb-4d1d-93bb-ad759e00b86c"`;
 
 exports[`datatype > 1337 > array > noArgs 1`] = `
 [
-  56052,
-  21258,
-  54308,
-  3397,
-  23538,
-  "X9@{:e=+kD",
-  62850,
-  12505,
-  "|/Jqjjj!BL",
-  38106,
+  "U/4:SK$>6Q",
+  26194,
+  "{:e=+kD)[B",
+  "e|/Jqjjj!B",
+  "GDWQgC2M;q",
+  40502,
+  44050,
+  ".Gm3tRwnZ2",
+  95735,
+  42541,
 ]
 `;
 
 exports[`datatype > 1337 > array > with length 1`] = `
 [
-  56052,
-  21258,
-  54308,
-  3397,
+  "U/4:SK$>6Q",
+  26194,
+  "{:e=+kD)[B",
+  "e|/Jqjjj!B",
 ]
 `;
 
@@ -260,15 +264,17 @@ exports[`datatype > 1337 > bigInt > noArgs 1`] = `251225403255239n`;
 
 exports[`datatype > 1337 > bigInt > with value 1`] = `25n`;
 
-exports[`datatype > 1337 > boolean 1`] = `false`;
+exports[`datatype > 1337 > boolean > noArgs 1`] = `true`;
 
-exports[`datatype > 1337 > boolean 2`] = `true`;
+exports[`datatype > 1337 > boolean > noArgs 2`] = `false`;
 
-exports[`datatype > 1337 > boolean 3`] = `false`;
+exports[`datatype > 1337 > boolean > noArgs 3`] = `true`;
 
-exports[`datatype > 1337 > boolean 4`] = `false`;
+exports[`datatype > 1337 > boolean > noArgs 4`] = `true`;
 
-exports[`datatype > 1337 > boolean 5`] = `false`;
+exports[`datatype > 1337 > boolean > noArgs 5`] = `true`;
+
+exports[`datatype > 1337 > boolean > with probability 1`] = `true`;
 
 exports[`datatype > 1337 > datetime > noArgs 1`] = `2018-10-28T08:46:11.896Z`;
 
@@ -312,7 +318,7 @@ exports[`datatype > 1337 > hexadecimal > with length, prefix, and casing 1`] = `
 
 exports[`datatype > 1337 > hexadecimal > with prefix 1`] = `"0x5"`;
 
-exports[`datatype > 1337 > json 1`] = `"{\\"foo\\":56052,\\"bar\\":21258,\\"bike\\":54308,\\"a\\":3397,\\"b\\":23538,\\"name\\":\\"X9@{:e=+kD\\",\\"prop\\":62850}"`;
+exports[`datatype > 1337 > json 1`] = `"{\\"foo\\":\\"U/4:SK$>6Q\\",\\"bar\\":26194,\\"bike\\":\\"{:e=+kD)[B\\",\\"a\\":\\"e|/Jqjjj!B\\",\\"b\\":\\"GDWQgC2M;q\\",\\"name\\":40502,\\"prop\\":44050}"`;
 
 exports[`datatype > 1337 > number > noArgs 1`] = `26202`;
 

--- a/test/__snapshots__/finance.spec.ts.snap
+++ b/test/__snapshots__/finance.spec.ts.snap
@@ -16,9 +16,9 @@ exports[`finance > 42 > amount > with min 1`] = `"380.79"`;
 
 exports[`finance > 42 > amount > with min and max and dec and symbol 1`] = `"$24.98160"`;
 
-exports[`finance > 42 > bic > noArgs 1`] = `"UYETSCLL"`;
+exports[`finance > 42 > bic > noArgs 1`] = `"UYETSCLLG53"`;
 
-exports[`finance > 42 > bic > with branch code 1`] = `"JUYEPSSL5G5"`;
+exports[`finance > 42 > bic > with branch code 1`] = `"JUYEPSSLXXX"`;
 
 exports[`finance > 42 > bitcoinAddress 1`] = `"3XbJMAAara64sSkA9HD24YHQWd1bZbB"`;
 
@@ -42,7 +42,7 @@ exports[`finance > 42 > iban > noArgs 1`] = `"GT30Y75110867098F1E3542612J4"`;
 
 exports[`finance > 42 > iban > with formatted 1`] = `"GT30 Y751 1086 7098 F1E3 5426 12J4"`;
 
-exports[`finance > 42 > iban > with formatted and countryCode 1`] = `"DE05 7175 0200 8600 6098 92"`;
+exports[`finance > 42 > iban > with formatted and countryCode 1`] = `"DE47 7175 0020 0086 0600 97"`;
 
 exports[`finance > 42 > litecoinAddress 1`] = `"3XbJMAAara64sSkA9HD24YHQWd1b"`;
 
@@ -82,9 +82,9 @@ exports[`finance > 1211 > amount > with min 1`] = `"929.24"`;
 
 exports[`finance > 1211 > amount > with min and max and dec and symbol 1`] = `"$47.14081"`;
 
-exports[`finance > 1211 > bic > noArgs 1`] = `"LXUFBTZ15O7"`;
+exports[`finance > 1211 > bic > noArgs 1`] = `"LXUFBTZ1"`;
 
-exports[`finance > 1211 > bic > with branch code 1`] = `"YLXUDE4ZXXX"`;
+exports[`finance > 1211 > bic > with branch code 1`] = `"YLXUDE4ZO5O"`;
 
 exports[`finance > 1211 > bitcoinAddress 1`] = `"1TMe8Z3EaFdLqmaGKP1LEEJQVriSZRZdsAUc9nC"`;
 
@@ -104,11 +104,11 @@ exports[`finance > 1211 > currencySymbol 1`] = `"₭"`;
 
 exports[`finance > 1211 > ethereumAddress 1`] = `"0xeadb42f0e3f4a973fab0aeefce96dfcf49cd438d"`;
 
-exports[`finance > 1211 > iban > noArgs 1`] = `"TN0382001124170679299069"`;
+exports[`finance > 1211 > iban > noArgs 1`] = `"TN4282016024170679299006"`;
 
-exports[`finance > 1211 > iban > with formatted 1`] = `"TN03 8200 1124 1706 7929 9069"`;
+exports[`finance > 1211 > iban > with formatted 1`] = `"TN42 8201 6024 1706 7929 9006"`;
 
-exports[`finance > 1211 > iban > with formatted and countryCode 1`] = `"DE63 4709 0026 0041 7067 89"`;
+exports[`finance > 1211 > iban > with formatted and countryCode 1`] = `"DE41 4700 9026 0417 0679 42"`;
 
 exports[`finance > 1211 > litecoinAddress 1`] = `"MTMe8Z3EaFdLqmaGKP1LEEJQVriSZRZds"`;
 
@@ -148,9 +148,9 @@ exports[`finance > 1337 > amount > with min 1`] = `"269.40"`;
 
 exports[`finance > 1337 > amount > with min and max and dec and symbol 1`] = `"$20.48098"`;
 
-exports[`finance > 1337 > bic > noArgs 1`] = `"OEFHLYG1"`;
+exports[`finance > 1337 > bic > noArgs 1`] = `"OEFHLYG18IL"`;
 
-exports[`finance > 1337 > bic > with branch code 1`] = `"GOEFFIJGXXX"`;
+exports[`finance > 1337 > bic > with branch code 1`] = `"GOEFFIJGB8I"`;
 
 exports[`finance > 1337 > bitcoinAddress 1`] = `"3adhxs2jewAgkYgJi7No6Cn8JZarS"`;
 
@@ -170,11 +170,11 @@ exports[`finance > 1337 > currencySymbol 1`] = `"$"`;
 
 exports[`finance > 1337 > ethereumAddress 1`] = `"0x5c346ba075bd57f5a62b82d72af39cbbb07a98cb"`;
 
-exports[`finance > 1337 > iban > noArgs 1`] = `"FO7710540350900318"`;
+exports[`finance > 1337 > iban > noArgs 1`] = `"FO5610050250090318"`;
 
-exports[`finance > 1337 > iban > with formatted 1`] = `"FO77 1054 0350 9003 18"`;
+exports[`finance > 1337 > iban > with formatted 1`] = `"FO56 1005 0250 0903 18"`;
 
-exports[`finance > 1337 > iban > with formatted and countryCode 1`] = `"DE61 0020 5032 5090 0300 40"`;
+exports[`finance > 1337 > iban > with formatted and countryCode 1`] = `"DE04 0200 5032 5009 0304 06"`;
 
 exports[`finance > 1337 > litecoinAddress 1`] = `"Madhxs2jewAgkYgJi7No6Cn8JZar"`;
 

--- a/test/__snapshots__/helpers.spec.ts.snap
+++ b/test/__snapshots__/helpers.spec.ts.snap
@@ -65,9 +65,9 @@ exports[`helpers > 42 > replaceSymbolWithNumber > some string 1`] = `"^123456789
 
 exports[`helpers > 42 > replaceSymbols > noArgs 1`] = `""`;
 
-exports[`helpers > 42 > replaceSymbols > only symbols 1`] = `"3UE7UP"`;
+exports[`helpers > 42 > replaceSymbols > only symbols 1`] = `"3U17U5"`;
 
-exports[`helpers > 42 > replaceSymbols > some string 1`] = `"^1234567890ß´°!\\"§$%&/()=J\`+7E,..-;:_"`;
+exports[`helpers > 42 > replaceSymbols > some string 1`] = `"^1234567890ß´°!\\"§$%&/()=J\`+71,..-;:_"`;
 
 exports[`helpers > 42 > shuffle > noArgs 1`] = `[]`;
 
@@ -181,9 +181,9 @@ exports[`helpers > 1211 > replaceSymbolWithNumber > some string 1`] = `"^1234567
 
 exports[`helpers > 1211 > replaceSymbols > noArgs 1`] = `""`;
 
-exports[`helpers > 1211 > replaceSymbols > only symbols 1`] = `"9LU2DA"`;
+exports[`helpers > 1211 > replaceSymbols > only symbols 1`] = `"9L72D0"`;
 
-exports[`helpers > 1211 > replaceSymbols > some string 1`] = `"^1234567890ß´°!\\"§$%&/()=Y\`+4U,..-;:_"`;
+exports[`helpers > 1211 > replaceSymbols > some string 1`] = `"^1234567890ß´°!\\"§$%&/()=Y\`+47,..-;:_"`;
 
 exports[`helpers > 1211 > shuffle > noArgs 1`] = `[]`;
 
@@ -287,9 +287,9 @@ exports[`helpers > 1337 > replaceSymbolWithNumber > some string 1`] = `"^1234567
 
 exports[`helpers > 1337 > replaceSymbols > noArgs 1`] = `""`;
 
-exports[`helpers > 1337 > replaceSymbols > only symbols 1`] = `"2O22O0"`;
+exports[`helpers > 1337 > replaceSymbols > only symbols 1`] = `"2OF2OA"`;
 
-exports[`helpers > 1337 > replaceSymbols > some string 1`] = `"^1234567890ß´°!\\"§$%&/()=G\`+52,..-;:_"`;
+exports[`helpers > 1337 > replaceSymbols > some string 1`] = `"^1234567890ß´°!\\"§$%&/()=G\`+5F,..-;:_"`;
 
 exports[`helpers > 1337 > shuffle > noArgs 1`] = `[]`;
 

--- a/test/__snapshots__/internet.spec.ts.snap
+++ b/test/__snapshots__/internet.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`internet > 42 > httpStatusCode > noArgs 1`] = `207`;
 
 exports[`internet > 42 > httpStatusCode > with options 1`] = `410`;
 
-exports[`internet > 42 > ip 1`] = `"cf2b:c992:7210:7d59:2ba0:0fbd:f302:f294"`;
+exports[`internet > 42 > ip 1`] = `"203.243.46.187"`;
 
 exports[`internet > 42 > ipv4 1`] = `"95.203.243.46"`;
 
@@ -98,7 +98,7 @@ exports[`internet > 1211 > httpStatusCode > noArgs 1`] = `505`;
 
 exports[`internet > 1211 > httpStatusCode > with options 1`] = `429`;
 
-exports[`internet > 1211 > ip 1`] = `"117.228.199.57"`;
+exports[`internet > 1211 > ip 1`] = `"7ec3:2f0a:2a3c:652b:bd0c:aabd:e64d:fdf3"`;
 
 exports[`internet > 1211 > ipv4 1`] = `"237.117.228.199"`;
 
@@ -162,7 +162,7 @@ exports[`internet > 1337 > httpStatusCode > noArgs 1`] = `205`;
 
 exports[`internet > 1337 > httpStatusCode > with options 1`] = `407`;
 
-exports[`internet > 1337 > ip 1`] = `"8234:8705:3894:5f4b:41c6:1a52:bf27:dccc"`;
+exports[`internet > 1337 > ip 1`] = `"143.40.54.71"`;
 
 exports[`internet > 1337 > ipv4 1`] = `"67.143.40.54"`;
 

--- a/test/__snapshots__/internet.spec.ts.snap
+++ b/test/__snapshots__/internet.spec.ts.snap
@@ -52,7 +52,7 @@ exports[`internet > 42 > port 1`] = `24545`;
 
 exports[`internet > 42 > protocol 1`] = `"http"`;
 
-exports[`internet > 42 > url > noArgs 1`] = `"https://staid-veil.biz"`;
+exports[`internet > 42 > url > noArgs 1`] = `"https://staid-veil.biz/"`;
 
 exports[`internet > 42 > url > with slash appended 1`] = `"https://hasty-shin.org/"`;
 
@@ -116,7 +116,7 @@ exports[`internet > 1211 > port 1`] = `60851`;
 
 exports[`internet > 1211 > protocol 1`] = `"https"`;
 
-exports[`internet > 1211 > url > noArgs 1`] = `"https://jubilant-temple.net/"`;
+exports[`internet > 1211 > url > noArgs 1`] = `"https://jubilant-temple.net"`;
 
 exports[`internet > 1211 > url > with slash appended 1`] = `"https://vibrant-infix.org/"`;
 
@@ -180,7 +180,7 @@ exports[`internet > 1337 > port 1`] = `17172`;
 
 exports[`internet > 1337 > protocol 1`] = `"http"`;
 
-exports[`internet > 1337 > url > noArgs 1`] = `"https://neat-chopstick.biz"`;
+exports[`internet > 1337 > url > noArgs 1`] = `"https://neat-chopstick.biz/"`;
 
 exports[`internet > 1337 > url > with slash appended 1`] = `"https://fair-migration.com/"`;
 

--- a/test/__snapshots__/system.spec.ts.snap
+++ b/test/__snapshots__/system.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`system > 42 > cron > noArgs 1`] = `"* 19 * 3 5"`;
 
 exports[`system > 42 > cron > with includeNonStandard false 1`] = `"* 19 * 3 5"`;
 
-exports[`system > 42 > cron > with includeNonStandard true 1`] = `"@yearly"`;
+exports[`system > 42 > cron > with includeNonStandard true 1`] = `"* 19 * 3 5"`;
 
 exports[`system > 42 > cron > with includeYear false 1`] = `"* 19 * 3 5"`;
 
@@ -90,7 +90,7 @@ exports[`system > 1211 > cron > noArgs 1`] = `"55 * 28 * 1"`;
 
 exports[`system > 1211 > cron > with includeNonStandard false 1`] = `"55 * 28 * 1"`;
 
-exports[`system > 1211 > cron > with includeNonStandard true 1`] = `"@hourly"`;
+exports[`system > 1211 > cron > with includeNonStandard true 1`] = `"55 * 28 * 1"`;
 
 exports[`system > 1211 > cron > with includeYear false 1`] = `"55 * 28 * 1"`;
 
@@ -168,7 +168,7 @@ exports[`system > 1337 > cron > noArgs 1`] = `"15 13 5 * *"`;
 
 exports[`system > 1337 > cron > with includeNonStandard false 1`] = `"15 13 5 * *"`;
 
-exports[`system > 1337 > cron > with includeNonStandard true 1`] = `"@yearly"`;
+exports[`system > 1337 > cron > with includeNonStandard true 1`] = `"15 13 5 * *"`;
 
 exports[`system > 1337 > cron > with includeYear false 1`] = `"15 13 5 * *"`;
 

--- a/test/datatype.spec.ts
+++ b/test/datatype.spec.ts
@@ -57,7 +57,9 @@ describe('datatype', () => {
     t.itRepeated('uuid', 5);
 
     t.describe('boolean', (t) => {
-      t.itRepeated('noArgs', 5).it('with probability', 0.42);
+      t.itRepeated('noArgs', 5)
+        .it('with probability', 0.42)
+        .it('with probability option', { probability: 0.13 });
     });
 
     t.describe('hexadecimal', (t) => {

--- a/test/datatype.spec.ts
+++ b/test/datatype.spec.ts
@@ -56,7 +56,9 @@ describe('datatype', () => {
 
     t.itRepeated('uuid', 5);
 
-    t.itRepeated('boolean', 5);
+    t.describe('boolean', (t) => {
+      t.itRepeated('noArgs', 5).it('with probability', 0.42);
+    });
 
     t.describe('hexadecimal', (t) => {
       t.it('noArgs')
@@ -316,6 +318,57 @@ describe('datatype', () => {
         it('generates a boolean value', () => {
           const bool = faker.datatype.boolean();
           expect(bool).toBeTypeOf('boolean');
+        });
+
+        it('generates false for probability = 0', () => {
+          const bool = faker.datatype.boolean(0);
+          expect(bool).toBe(false);
+        });
+
+        it('generates true for probability = 1', () => {
+          const bool = faker.datatype.boolean(1);
+          expect(bool).toBe(true);
+        });
+
+        it.each([-5, 0.42, 5])(
+          'generates a boolean value with given probability',
+          (probability) => {
+            const bool = faker.datatype.boolean(probability);
+            expect(bool).toBeTypeOf('boolean');
+          }
+        );
+
+        it('generates a boolean value for empty options', () => {
+          const bool = faker.datatype.boolean({});
+          expect(bool).toBeTypeOf('boolean');
+        });
+
+        it('generates false for { probability: 0 }', () => {
+          const bool = faker.datatype.boolean({ probability: 0 });
+          expect(bool).toBe(false);
+        });
+
+        it('generates true for { probability: 1 }', () => {
+          const bool = faker.datatype.boolean({ probability: 1 });
+          expect(bool).toBe(true);
+        });
+
+        it.each([-5, 0.42, 5])(
+          'generates a boolean value with given probability option',
+          (probability) => {
+            const bool = faker.datatype.boolean({ probability });
+            expect(bool).toBeTypeOf('boolean');
+          }
+        );
+
+        it('should not mutate the input object', () => {
+          const filledOptions: { probability?: number } = Object.freeze({
+            probability: 1,
+          });
+          expect(() => faker.datatype.boolean(filledOptions)).not.toThrow();
+
+          const emptyOptions: { probability?: number } = Object.freeze({});
+          expect(() => faker.datatype.boolean(emptyOptions)).not.toThrow();
         });
       });
 

--- a/test/system.spec.ts
+++ b/test/system.spec.ts
@@ -420,7 +420,7 @@ describe('system', () => {
         );
 
         it('should return non-standard cron expressions', () => {
-          const validResults = ['1', '2', '5', '*', '@'];
+          const validResults = ['1', '2', '3', '5', '*', '@'];
           expect(
             faker.system.cron({ includeNonStandard: true })[0],
             'generated cron, string should contain non-standard cron labels'


### PR DESCRIPTION
Throughout our code base the have some locations that use probabilities to decide what to do.
This PR merges these occurrences into our `datatype.boolean()` method and thus provides this option to others.

<details>
<summary>Docs Preview</summary>

![grafik](https://user-images.githubusercontent.com/1579362/197338265-7090cd51-2baa-484e-b203-e10aa83c98af.png)

</details>
