### PR TITLE
feat: introduce faker.clone and derive

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -275,3 +275,188 @@ We will update these docs once a replacement is available.
 :::
 
 Congratulations, you should now be able to create any complex object you desire. Happy faking 🥳.
+
+## Create multiple complex objects
+
+Sometimes having a single one of your complex objects isn't enough.
+Imagine having a list view/database of some kind you want to populate:
+
+| ID        | First Name | Last Name |
+| --------- | ---------- | --------- |
+| 6fbe024f… | Tatyana    | Koch      |
+| 862f3ccb… | Hans       | Donnelly  |
+| b452acd6… | Judy       | Boehm     |
+
+The values are directly created using this method:
+
+```ts
+import { faker } from '@faker-js/faker';
+
+function createRandomUser(): User {
+  return {
+    _id: faker.string.uuid(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+  };
+}
+
+const users = Array.from({ length: 3 }, () => createRandomUser());
+```
+
+After some time you notice that you need a new column `createdDate`.
+
+You modify the method to also create that:
+
+```ts
+function createRandomUser(): User {
+  return {
+    _id: faker.string.uuid(),
+    firstName: faker.person.firstName(),
+    lastName: faker.person.lastName(),
+    createdDate: faker.date.past(),
+  };
+}
+```
+
+Now let's have a look at our table again:
+
+| ID        | First Name | Last Name | Created Date |
+| --------- | ---------- | --------- | ------------ |
+| 6fbe024f… | Tatyana    | Koch      | 2022-12-28   |
+| 62f3ccbf… | Kacie      | Pouros    | 2023-04-06   |
+| 52acd600… | Aron       | Von       | 2023-05-04   |
+
+Suddenly the second line onwards look different.
+
+Why? Because calling `faker.date.past()` consumes a value from the seed changing all subsequent values.
+
+There are two solutions to that:
+
+1. Set the seed explicitly before creating the data for that row:
+
+```ts
+const users = Array.from({ length: 3 }, (_, i) => {
+  faker.seed(i);
+  return createRandomUser();
+});
+```
+
+Which is very straightforward, but comes at the disadvantage, that you change the seed of your faker instance.
+This might cause issues, if you have lists of groups that contains lists of users. Each group contains the same users because the seed is reset.
+
+2. Derive a new faker instance for each user you create.
+
+```ts
+function createRandomUser(faker: Faker): User {
+  const derivedFaker = faker.derive();
+  return {
+    _id: derivedFaker.string.uuid(),
+    firstName: derivedFaker.person.firstName(),
+    lastName: derivedFaker.person.lastName(),
+    createdDate: derivedFaker.date.past(),
+  };
+}
+
+const users = Array.from({ length: 3 }, () => createRandomUser(faker));
+```
+
+The `faker.derive()` call clones the instance and re-initializes the seed of the clone with a generated value from the original.
+This decouples the generation of the list from generating a user.
+It does not matter how many properties you add to or remove from the `User` the following rows will not change.
+
+::: tip Note
+The following is only relevant, if you want to avoid changing your generated objects as much as possible:
+
+When adding one or more new properties, we recommend generating them last, because if you create a new property in the middle of your object, then the properties after that will still change (due to the extra seed consumption).
+When removing properties, you can continue calling the old method (or a dummy method) to consume the same amount of seed values.
+:::
+
+This also works for deeply nested complex objects:
+
+```ts
+function createLegalAgreement(faker: Faker) {
+  const derivedFaker = faker.derive();
+  return {
+    _id: derivedFaker.string.uuid(),
+    partyA: createRandomUser(derivedFaker),
+    partyB: createRandomUser(derivedFaker),
+  };
+}
+
+function createRandomUser(faker: Faker): User {
+  const derivedFaker = faker.derive();
+  return {
+    _id: derivedFaker.string.uuid(),
+    firstName: derivedFaker.person.firstName(),
+    lastName: derivedFaker.person.lastName(),
+    createdDate: derivedFaker.date.past(),
+    address: createRandomAddress(derivedFaker),
+  };
+}
+
+function createRandomAddress(faker: Faker): Address {
+  const derivedFaker = faker.derive();
+  return {
+    _id: derivedFaker.string.uuid(),
+    streetName: derivedFaker.location.street(),
+  };
+}
+```
+
+::: warning Warning
+Migrating your existing data generators will still change all data once, but after that they are independent.
+So we recommend writing your methods like this from the start.
+:::
+
+::: info Note
+Depending on your preferences and requirements you can design the methods either like this:
+
+```ts
+function createRandomXyz(faker: Faker): Xyz {
+  return {
+    _id: faker.string.uuid(),
+  };
+}
+
+createRandomXyz(faker.derive());
+createRandomXyz(faker.derive());
+createRandomXyz(faker.derive());
+```
+
+or this
+
+```ts
+function createRandomXyz(faker: Faker): Xyz {
+  const derivedFaker = faker.derive();
+  return {
+    _id: derivedFaker.string.uuid(),
+  };
+}
+
+createRandomXyz(faker);
+createRandomXyz(faker);
+createRandomXyz(faker);
+```
+
+The sole difference being more or less explicit about deriving a faker instance (writing more or less code).
+:::
+
+## Create identical complex objects
+
+If you want to create two identical objects, e.g. one to mutate and one to compare it to,
+then you can use `faker.clone()` to create a faker instance with the same settings and seed as the original.
+
+```ts
+const clonedFaker = faker.clone();
+const user1 = createRandomUser(faker);
+const user2 = createRandomUser(clonedFaker);
+expect(user1).toEqual(user2); ✅
+
+subscribeToNewsletter(user1);
+// Check that the user hasn't been modified
+expect(user1).toEqual(user2); ✅
+```
+
+::: info Note
+Calling `faker.clone()` is idempotent. So you can call it as often as you want, it doesn't have an impact on the original faker instance.
+:::

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -430,6 +430,21 @@ export class Faker extends SimpleFaker {
       'This method has been removed. Please use the constructor instead.'
     );
   }
+
+  clone(): Faker {
+    const instance = new Faker({
+      locale: this.rawDefinitions,
+      randomizer: this._randomizer.clone(),
+    });
+    instance.setDefaultRefDate(this._defaultRefDate);
+    return instance;
+  }
+
+  derive(): Faker {
+    const instance = this.clone();
+    instance.seed(this.number.int());
+    return instance;
+  }
 }
 
 export type FakerOptions = ConstructorParameters<typeof Faker>[0];

--- a/test/faker.spec.ts
+++ b/test/faker.spec.ts
@@ -71,12 +71,14 @@ describe('faker', () => {
 
   describe('randomizer', () => {
     it('should be possible to provide a custom Randomizer', () => {
+      const randomizer = {
+        next: () => 0,
+        seed: () => void 0,
+        clone: () => randomizer,
+      };
       const customFaker = new Faker({
         locale: {},
-        randomizer: {
-          next: () => 0,
-          seed: () => void 0,
-        },
+        randomizer,
       });
 
       expect(customFaker.number.int()).toBe(0);
@@ -122,6 +124,60 @@ describe('faker', () => {
 
       const actual = faker.animal.cat();
       expect(actual).toBe('Oriental');
+    });
+  });
+
+  describe('clone()', () => {
+    it('should create a clone that returns the same values as the original', () => {
+      const clone1 = faker.clone();
+      const clone2 = faker.clone();
+      const clone3 = clone1.clone();
+
+      expect(clone1).not.toBe(faker);
+      expect(clone2).not.toBe(faker);
+      expect(clone3).not.toBe(faker);
+      expect(clone1).not.toBe(clone2);
+      expect(clone1).not.toBe(clone3);
+      expect(clone2).not.toBe(clone3);
+
+      const value0 = faker.number.int();
+      expect(clone1.number.int()).toBe(value0);
+      expect(clone2.number.int()).toBe(value0);
+      expect(clone3.number.int()).toBe(value0);
+
+      const value1 = clone1.number.int();
+      expect(faker.number.int()).toBe(value1);
+      expect(clone2.number.int()).toBe(value1);
+      expect(clone3.number.int()).toBe(value1);
+
+      const value2 = clone2.number.int();
+      expect(clone1.number.int()).toBe(value2);
+      expect(faker.number.int()).toBe(value2);
+      expect(clone3.number.int()).toBe(value2);
+
+      const value3 = clone3.number.int();
+      expect(clone1.number.int()).toBe(value3);
+      expect(clone2.number.int()).toBe(value3);
+      expect(faker.number.int()).toBe(value3);
+    });
+  });
+
+  describe('derive()', () => {
+    it("should create a derived faker, that doesn't affect the original", () => {
+      const seed = faker.seed();
+      faker.number.int();
+      const value = faker.number.int();
+
+      faker.seed(seed);
+      const derived = faker.derive();
+
+      expect(derived).not.toBe(faker);
+
+      for (let i = 0; i < derived.number.int(100); i++) {
+        derived.number.int();
+      }
+
+      expect(faker.number.int()).toBe(value);
     });
   });
 

--- a/test/internal/mersenne.spec.ts
+++ b/test/internal/mersenne.spec.ts
@@ -133,4 +133,26 @@ describe('generateMersenne32Randomizer()', () => {
       });
     });
   });
+
+  describe('clone()', () => {
+    it('should return a new instance', () => {
+      const clone = randomizer.clone();
+
+      expect(clone).not.toBe(randomizer);
+    });
+
+    it('should return a new instance with the same state', () => {
+      const clone = randomizer.clone();
+
+      // Test that the clone is independent from the original at intervals
+      const originalValues = Array.from({ length: 1000 }, randomizer.next);
+      const clonedValues = Array.from({ length: 1000 }, clone.next);
+      expect(clonedValues).toEqual(originalValues);
+
+      // Test that the clone is independent from the original at each call
+      for (let i = 0; i < 1000; i++) {
+        expect(clone.next()).toBe(randomizer.next());
+      }
+    });
+  });
 });

--- a/test/simple-faker.spec.ts
+++ b/test/simple-faker.spec.ts
@@ -20,6 +20,23 @@ describe('simpleFaker', () => {
     }
   });
 
+  describe('randomizer', () => {
+    it('should be possible to provide a custom Randomizer', () => {
+      const randomizer = {
+        next: () => 0,
+        seed: () => void 0,
+        clone: () => randomizer,
+      };
+      const customFaker = new SimpleFaker({
+        randomizer,
+      });
+
+      expect(customFaker.number.int()).toBe(0);
+      expect(customFaker.number.int()).toBe(0);
+      expect(customFaker.number.int()).toBe(0);
+    });
+  });
+
   // This is only here for coverage
   // The actual test is in mersenne.spec.ts
   describe('seed()', () => {
@@ -57,6 +74,60 @@ describe('simpleFaker', () => {
 
       const actual = simpleFaker.string.uuid();
       expect(actual).toBe('95e97ae6-08ee-492f-9895-ec8be3410e88');
+    });
+  });
+
+  describe('clone()', () => {
+    it('should create a clone that returns the same values as the original', () => {
+      const clone1 = simpleFaker.clone();
+      const clone2 = simpleFaker.clone();
+      const clone3 = clone1.clone();
+
+      expect(clone1).not.toBe(simpleFaker);
+      expect(clone2).not.toBe(simpleFaker);
+      expect(clone3).not.toBe(simpleFaker);
+      expect(clone1).not.toBe(clone2);
+      expect(clone1).not.toBe(clone3);
+      expect(clone2).not.toBe(clone3);
+
+      const value0 = simpleFaker.number.int();
+      expect(clone1.number.int()).toBe(value0);
+      expect(clone2.number.int()).toBe(value0);
+      expect(clone3.number.int()).toBe(value0);
+
+      const value1 = clone1.number.int();
+      expect(simpleFaker.number.int()).toBe(value1);
+      expect(clone2.number.int()).toBe(value1);
+      expect(clone3.number.int()).toBe(value1);
+
+      const value2 = clone2.number.int();
+      expect(clone1.number.int()).toBe(value2);
+      expect(simpleFaker.number.int()).toBe(value2);
+      expect(clone3.number.int()).toBe(value2);
+
+      const value3 = clone3.number.int();
+      expect(clone1.number.int()).toBe(value3);
+      expect(clone2.number.int()).toBe(value3);
+      expect(simpleFaker.number.int()).toBe(value3);
+    });
+  });
+
+  describe('derive()', () => {
+    it("should create a derived faker, that doesn't affect the original", () => {
+      const seed = simpleFaker.seed();
+      simpleFaker.number.int();
+      const value = simpleFaker.number.int();
+
+      simpleFaker.seed(seed);
+      const derived = simpleFaker.derive();
+
+      expect(derived).not.toBe(simpleFaker);
+
+      for (let i = 0; i < derived.number.int(100); i++) {
+        derived.number.int();
+      }
+
+      expect(simpleFaker.number.int()).toBe(value);
     });
   });
 


### PR DESCRIPTION
Fixes #627

* #627

Required for:

* #1491

See also:

* #1413

----------

This PR introduces two new methods for faker.

* `faker.clone()`
* `faker.derive()`

## `clone()`

Can be used to generate repeated values or to allow generating the "last" value again.
This method does not consume seed values.

**Example**

````ts
faker.seed(42);
faker.clone().datatype.number(); // 8234
faker.clone().datatype.number(); // 8234
faker.datatype.number(); // 8234
````

`last()` was originally requested in #627

## `derive()`

Can be used to write methods that don't affect the rest of the generated data when changed.
This method consumes a single seed value in order to initialize the seed of the derived instance.

**Example**

````ts
function generatePerson(): Person {
  const derived = faker.derive();
  return {
    firstName: derived.person.firstName(),
    lastName: derived.person.lastName(),
    // You can add more attributes here without affecting the next person
    ...
  };
}

faker.seed(42);
generatePerson(); // { firstName: 'Devyn', lastName: 'Foo', ... }
generatePerson(); // { firstName: 'John', lastName: 'Bar', ... }
````

I evolved the `fork()` method into `derive()` while thinking about #1491 as it is incredible hard for our users to write extensible methods while retaining their original data. It basically makes `generatePerson` or any similar method an atomic operation regardless how many data are generated.

It can also be used to with nesting.

````ts
function generateMarriageCertificate(faker: Faker): MarriageCertificate {
  const derived = faker.derive();
  return {
    partner1: generatePerson(derived),
    partner2: generatePerson(derived),
    certifyingOffice: derived.location.city(),
  };
}

function generatePerson(faker: Faker): Person {
  const derived = faker.derive();
  return {
    firstName: derived.person.firstName(),
    lastName: derived.person.lastName(),
    // You can add more attributes here without affecting the next person
    ...
  };
}
````

## Alternatives

1) Add a `context` option to `clone()`, that mutates the seed (current seed + context -> new seed).
However, I think the consumption of a seed value is actually expected, so that partner/marriage certificate 1 and 2 are different.

2) Add a `seed` option to `clone` and use it like `faker.fork({seed: faker.datatype.number()})`. 
However that would just be a a more verbose version of the current `derive` method.

---

Food for thoughts: We could use the derive method in our code/methods to ensure each faker method call consumes only a single seed value. However this would probably (slightly) decrease performance.