### PR TITLE
docs: remove duplicate description tags

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -75,13 +75,6 @@ const config = defineConfig({
     [
       'meta',
       {
-        name: 'description',
-        content: description,
-      },
-    ],
-    [
-      'meta',
-      {
         name: 'og:image',
         content: image,
       },


### PR DESCRIPTION
`description` is already passed through config, there is no need to pass it through `head` too.

![image](https://user-images.githubusercontent.com/40380293/199656543-00495f34-5ee6-43c6-bf70-2c4b59b9cb33.png)
