### PR TITLE
fix: strongly type ethereum address with a `0x${string}` type

### DIFF
--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -353,11 +353,12 @@ export class FinanceModule {
    *
    * @since 5.0.0
    */
-  ethereumAddress(): string {
+  ethereumAddress(): `0x${string}` {
     const address = this.faker.string.hexadecimal({
       length: 40,
       casing: 'lower',
     });
+
     return address;
   }
 

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -78,6 +78,7 @@ export type NumericChar =
 
 export type AlphaChar = LowerAlphaChar | UpperAlphaChar;
 export type AlphaNumericChar = AlphaChar | NumericChar;
+export type StringLiteral<T> = T extends `${string & T}` ? T : string;
 
 const SAMPLE_MAX_LENGTH = Math.pow(2, 20);
 
@@ -257,14 +258,18 @@ export class StringModule {
    *
    * @since 8.0.0
    */
-  hexadecimal(
+  hexadecimal<T = '0x'>(
     options: {
       length?: number;
       casing?: Casing;
-      prefix?: string;
+      prefix?: StringLiteral<T>;
     } = {}
-  ): string {
-    const { length = 1, casing = 'mixed', prefix = '0x' } = options;
+  ): `${StringLiteral<T>}${string}` {
+    const {
+      length = 1,
+      casing = 'mixed',
+      prefix = '0x' as StringLiteral<T>,
+    } = options;
 
     let wholeString = '';
 
@@ -295,11 +300,8 @@ export class StringModule {
       ]);
     }
 
-    if (casing === 'upper') {
-      wholeString = wholeString.toUpperCase();
-    } else if (casing === 'lower') {
-      wholeString = wholeString.toLowerCase();
-    }
+    wholeString =
+      wholeString[casing === 'upper' ? 'toUpperCase' : 'toLowerCase']();
 
     return `${prefix}${wholeString}`;
   }

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -300,8 +300,11 @@ export class StringModule {
       ]);
     }
 
-    wholeString =
-      wholeString[casing === 'upper' ? 'toUpperCase' : 'toLowerCase']();
+    if (casing === 'upper') {
+      wholeString = wholeString.toUpperCase();
+    } else if (casing === 'lower') {
+      wholeString = wholeString.toLowerCase();
+    }
 
     return `${prefix}${wholeString}`;
   }


### PR DESCRIPTION
Hello!

In our application we would like to strongly type token addresses for ethereum, and instead of type `string` we would like to provide a type that guarantees us with the format 0x${string} throughout our applications

We currently typecast the value that faker.finance.ethereumAddress() provides us to it, that works perfectly fine but it seems like a nice addition to have a stronger type for this coming from faker.

Lmk if you would like to see any changes.