### PR TITLE
feat(finance): Add ethereum checksummed address faking

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
     "vite": "~3.2.3",
     "vitepress": "1.0.0-alpha.28",
     "vitest": "~0.25.1",
-    "vue": "~3.2.45"
+    "vue": "~3.2.45",
+    "web3-utils": "^1.8.1"
   },
   "packageManager": "pnpm@7.15.0",
   "engines": {

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -350,13 +350,14 @@ export class FinanceModule {
    *
    * @example
    * faker.finance.ethereumAddress() // '0xf03dfeecbafc5147241cc4c4ca20b3c9dfd04c4a'
+   * faker.finance.ethereumAddress(options: { type: 'checksum' }) // '0xf03dFeeCbAFc5147241Cc4c4cA20b3c9Dfd04C4A'
    *
    * @since 5.0.0
    */
-  ethereumAddress(): string {
+  ethereumAddress(options: { type: 'non-checksum' | 'checksum' } = {}): string {
     const address = this.faker.string.hexadecimal({
       length: 40,
-      casing: 'lower',
+      casing: options.type === 'checksum' ? 'mixed' : 'lower',
     });
     return address;
   }

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -354,7 +354,7 @@ export class FinanceModule {
    *
    * @since 5.0.0
    */
-  ethereumAddress(options: { type: 'non-checksum' | 'checksum' } = {}): string {
+  ethereumAddress(options: { type?: 'non-checksum' | 'checksum' } = {}): string {
     const address = this.faker.string.hexadecimal({
       length: 40,
       casing: options.type === 'checksum' ? 'mixed' : 'lower',

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -1,3 +1,4 @@
+import web3 from 'web3-utils';
 import type { Faker } from '../..';
 import { FakerError } from '../../errors/faker-error';
 import iban from './iban';
@@ -348,17 +349,29 @@ export class FinanceModule {
   /**
    * Generates a random Ethereum address.
    *
+   * @param options Ethereum address options.
+   * @param options.type Output a checksummed or non-checksummed ( lowercase ) address.
+   *
    * @example
    * faker.finance.ethereumAddress() // '0xf03dfeecbafc5147241cc4c4ca20b3c9dfd04c4a'
    * faker.finance.ethereumAddress(options: { type: 'checksum' }) // '0xf03dFeeCbAFc5147241Cc4c4cA20b3c9Dfd04C4A'
    *
    * @since 5.0.0
    */
-  ethereumAddress(options: { type?: 'non-checksum' | 'checksum' } = {}): string {
+  ethereumAddress(
+    options: {
+      type?: 'non-checksum' | 'checksum';
+    } = {}
+  ): string {
     const address = this.faker.string.hexadecimal({
       length: 40,
-      casing: options.type === 'checksum' ? 'mixed' : 'lower',
+      casing: 'lower',
     });
+
+    if (options.type === 'checksum') {
+      return web3.toChecksumAddress(address);
+    }
+
     return address;
   }
 

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -1,5 +1,6 @@
 import isValidBtcAddress from 'validator/lib/isBtcAddress';
 import { afterEach, describe, expect, it } from 'vitest';
+import web3 from 'web3-utils';
 import { faker } from '../src';
 import { FakerError } from '../src/errors/faker-error';
 import ibanLib from '../src/modules/finance/iban';
@@ -447,10 +448,12 @@ describe('finance', () => {
         });
 
         it('should return a valid checksummed ethereum address', () => {
-          const ethereumAddress = faker.finance.ethereumAddress({ type: 'checksum' });
+          const ethereumAddress = faker.finance.ethereumAddress({
+            type: 'checksum',
+          });
 
           expect(ethereumAddress).toBeTypeOf('string');
-          expect(ethereumAddress).toMatch(/^(0x)(?=.*[A-Z])[0-9a-f]{40}$/);
+          expect(web3.checkAddressChecksum(ethereumAddress)).toBe(true);
         });
       });
 

--- a/test/finance.spec.ts
+++ b/test/finance.spec.ts
@@ -445,6 +445,13 @@ describe('finance', () => {
           expect(ethereumAddress).toBeTypeOf('string');
           expect(ethereumAddress).toMatch(/^(0x)[0-9a-f]{40}$/);
         });
+
+        it('should return a valid checksummed ethereum address', () => {
+          const ethereumAddress = faker.finance.ethereumAddress({ type: 'checksum' });
+
+          expect(ethereumAddress).toBeTypeOf('string');
+          expect(ethereumAddress).toMatch(/^(0x)(?=.*[A-Z])[0-9a-f]{40}$/);
+        });
       });
 
       describe('iban()', () => {


### PR DESCRIPTION
Closes https://github.com/faker-js/faker/issues/1567

Adds eth checksum as optional parameter with test to ensure that a "capital" letter isincluded which would indicate it's a checksum address

NOT READY FOR REVIEW