### PR TITLE
test: fix system fileExt assumption

### DIFF
--- a/test/system.spec.ts
+++ b/test/system.spec.ts
@@ -198,10 +198,8 @@ describe('system', () => {
         it('should return file ext', () => {
           const fileExt = faker.system.fileExt();
 
-          expect(
-            fileExt.length,
-            'generated fileExt should start with ."'
-          ).toBeGreaterThan(1);
+          expect(fileExt).toBeTypeOf('string');
+          expect(fileExt).not.toBe('');
         });
 
         it('should return file ext based on mimeType', () => {


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->

While working on
- #1645 

I found this test
the fileExt doesn't prefix the ext with a point
the test assumption was wrong