### PR TITLE
fix(number): values out of bounds

### DIFF
--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -43,12 +43,19 @@ export class NumberModule {
     }
 
     const { min = 0, max = min + 99999 } = options;
+    const effectiveMin = Math.ceil(min);
+    const effectiveMax = Math.floor(max);
 
-    if (max === min) {
-      return min;
+    if (effectiveMin === effectiveMax) {
+      return effectiveMin;
     }
 
-    if (max < min) {
+    if (effectiveMax < effectiveMin) {
+      if (max >= min) {
+        throw new FakerError(
+          `No integer value between ${min} and ${max} found.`
+        );
+      }
       throw new FakerError(`Max ${max} should be greater than min ${min}.`);
     }
 
@@ -56,7 +63,7 @@ export class NumberModule {
       // @ts-expect-error: access private member field
       this.faker._mersenne;
 
-    return mersenne.next({ min, max: max + 1 });
+    return mersenne.next({ min: effectiveMin, max: effectiveMax + 1 });
   }
 
   /**

--- a/test/__snapshots__/finance.spec.ts.snap
+++ b/test/__snapshots__/finance.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`finance > 42 > amount > with max 1`] = `"18.73"`;
 
 exports[`finance > 42 > amount > with min 1`] = `"380.79"`;
 
-exports[`finance > 42 > amount > with min and max and dec and symbol 1`] = `"$24.98160"`;
+exports[`finance > 42 > amount > with min and max and dec and symbol 1`] = `"$24.98161"`;
 
 exports[`finance > 42 > bic > noArgs 1`] = `"UYETSCLLG53"`;
 
@@ -146,7 +146,7 @@ exports[`finance > 1337 > amount > with max 1`] = `"13.10"`;
 
 exports[`finance > 1337 > amount > with min 1`] = `"269.40"`;
 
-exports[`finance > 1337 > amount > with min and max and dec and symbol 1`] = `"$20.48098"`;
+exports[`finance > 1337 > amount > with min and max and dec and symbol 1`] = `"$20.48099"`;
 
 exports[`finance > 1337 > bic > noArgs 1`] = `"OEFHLYG18IL"`;
 

--- a/test/__snapshots__/location.spec.ts.snap
+++ b/test/__snapshots__/location.spec.ts.snap
@@ -112,8 +112,8 @@ exports[`location > 1211 > longitude > noArgs 1`] = `154.2673`;
 
 exports[`location > 1211 > nearbyGPSCoordinate > near origin 1`] = `
 [
-  -0.02872051646443488,
-  0.05959053473372933,
+  -0.02872111236834616,
+  0.05959024752564801,
 ]
 `;
 

--- a/test/number.spec.ts
+++ b/test/number.spec.ts
@@ -130,15 +130,13 @@ describe('number', () => {
         }).toThrowError(`Max ${max} should be greater than min ${min}.`);
       });
 
-      // TODO @Shinigami92 2022-11-24: https://github.com/faker-js/faker/issues/1595
-      it.todo(
-        'should throw when there is no integer between min and max',
-        () => {
-          expect(() => {
-            faker.number.int({ min: 2.1, max: 2.9 });
-          }).toThrow();
-        }
-      );
+      it('should throw when there is no integer between min and max', () => {
+        expect(() => {
+          faker.number.int({ min: 2.1, max: 2.9 });
+        }).toThrow(
+          new FakerError(`No integer value between 2.1 and 2.9 found.`)
+        );
+      });
     });
 
     describe('float', () => {
@@ -193,8 +191,7 @@ describe('number', () => {
         expect(results).toEqual([0, 0.5, 1, 1.5]);
       });
 
-      // TODO @Shinigami92 2022-11-24: https://github.com/faker-js/faker/issues/1595
-      it.todo('provides numbers with a given precision of 0.4 steps', () => {
+      it('provides numbers with a given precision of 0.4 steps', () => {
         const results = Array.from(
           new Set(
             Array.from({ length: 50 }, () =>


### PR DESCRIPTION
Fixes: #1595

- #1595

This PR fixes the issue caused by number.int returning values out of bounds, if the given min and max aren't integers themselves.
This also causes number.float to return values out of bounds.

**Case 1:** `int({min: 2.1, max: 2.9})`

Previously -> 2 or 3
Now -> Error

**Case 2:** `int({min: 1.1, max: 2.9})`

Previously -> 1, 2 or 3
Now -> 2


