### PR TITLE
chore: turn on padding-line-between-statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,23 +34,6 @@ module.exports = defineConfig({
     '@typescript-eslint/ban-ts-comment': 'warn',
     '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'error',
-    '@typescript-eslint/no-inferrable-types': [
-      'error',
-      { ignoreParameters: true },
-    ],
-    '@typescript-eslint/no-unsafe-argument': 'warn',
-    '@typescript-eslint/no-unsafe-assignment': 'off',
-    '@typescript-eslint/no-unsafe-call': 'off',
-    '@typescript-eslint/no-unsafe-member-access': 'off',
-    '@typescript-eslint/no-unsafe-return': 'warn',
-    '@typescript-eslint/restrict-template-expressions': [
-      'error',
-      {
-        allowNumber: true,
-        allowBoolean: true,
-      },
-    ],
-    '@typescript-eslint/unbound-method': 'off',
     '@typescript-eslint/naming-convention': [
       'error',
       {
@@ -60,6 +43,24 @@ module.exports = defineConfig({
         trailingUnderscore: 'forbid',
       },
     ],
+    '@typescript-eslint/no-inferrable-types': [
+      'error',
+      { ignoreParameters: true },
+    ],
+    '@typescript-eslint/no-unsafe-argument': 'warn',
+    '@typescript-eslint/no-unsafe-assignment': 'off',
+    '@typescript-eslint/no-unsafe-call': 'off',
+    '@typescript-eslint/no-unsafe-member-access': 'off',
+    '@typescript-eslint/no-unsafe-return': 'warn',
+    '@typescript-eslint/padding-line-between-statements': [
+      'error',
+      { blankLine: 'always', prev: 'block-like', next: '*' },
+    ],
+    '@typescript-eslint/restrict-template-expressions': [
+      'error',
+      { allowNumber: true, allowBoolean: true },
+    ],
+    '@typescript-eslint/unbound-method': 'off',
   },
   overrides: [
     {

--- a/scripts/apidoc/apiDocsWriter.ts
+++ b/scripts/apidoc/apiDocsWriter.ts
@@ -161,6 +161,7 @@ export function writeApiSearchIndex(project: ProjectReflection): void {
           },
         ];
       }
+
       return apiSection;
     })
     .sort((a, b) => a.text.localeCompare(b.text));

--- a/scripts/apidoc/moduleMethods.ts
+++ b/scripts/apidoc/moduleMethods.ts
@@ -46,6 +46,7 @@ export function extractModuleName(module: DeclarationReflection): string {
   } else if (name === 'NameModule') {
     return 'Person';
   }
+
   return name.replace(/Module$/, '');
 }
 

--- a/scripts/apidoc/parameterDefaults.ts
+++ b/scripts/apidoc/parameterDefaults.ts
@@ -52,6 +52,7 @@ function cleanParameterDefault(value?: string): string | undefined {
   if (value == null) {
     return undefined;
   }
+
   // Strip type casts: "'foobar' as unknown as T" => "'foobar'"
   return value.replace(/ as unknown as [A-Za-z<>]+/, '');
 }
@@ -124,6 +125,7 @@ function patchSignatureParameterDefaults(
   if (signatureParameters.length !== parameterDefaults.length) {
     throw new Error('Unexpected parameter length mismatch');
   }
+
   signatureParameters.forEach(
     (param, index) =>
       (param.defaultValue = parameterDefaults[index] || param.defaultValue)

--- a/scripts/apidoc/signature.ts
+++ b/scripts/apidoc/signature.ts
@@ -136,6 +136,7 @@ export function analyzeSignature(
   if (signatureTypeParameters.length !== 0) {
     signatureTypeParametersString = `<${signatureTypeParameters.join(', ')}>`;
   }
+
   const signatureParametersString = signatureParameters.join(', ');
 
   let examples: string;
@@ -144,6 +145,7 @@ export function analyzeSignature(
   } else {
     examples = `faker.${methodName}${signatureTypeParametersString}(${signatureParametersString}): ${signature.type?.toString()}\n`;
   }
+
   faker.seed(0);
   if (moduleName) {
     try {
@@ -222,6 +224,7 @@ function analyzeParameterOptions(
   if (!parameterType) {
     return [];
   }
+
   if (parameterType.type === 'union') {
     return parameterType.types.flatMap((type) =>
       analyzeParameterOptions(name, type)
@@ -253,6 +256,7 @@ function typeToText(type_?: Type, short = false): string {
   if (!type_) {
     return '?';
   }
+
   const type = type_ as SomeType;
   switch (type.type) {
     case 'array':
@@ -275,6 +279,7 @@ function typeToText(type_?: Type, short = false): string {
           .map((t) => typeToText(t, short))
           .join(', ')}>`;
       }
+
     case 'reflection':
       return declarationTypeToText(type.declaration, short);
     case 'indexedAccess':
@@ -327,6 +332,7 @@ function signatureTypeToText(signature?: SignatureReflection): string {
   if (!signature) {
     return '(???) => ?';
   }
+
   return `(${signature.parameters
     ?.map((p) => `${p.name}: ${typeToText(p.type)}`)
     .join(', ')}) => ${typeToText(signature.type)}`;
@@ -342,18 +348,22 @@ function extractDefaultFromComment(comment?: Comment): string | undefined {
   if (!comment) {
     return;
   }
+
   const summary = comment.summary;
   const text = joinTagParts(summary).trim();
   if (!text) {
     return;
   }
+
   const result = /^(.*)[ \n]Defaults to `([^`]+)`\.(.*)$/s.exec(text);
   if (!result) {
     return;
   }
+
   if (result[3].trim()) {
     throw new Error(`Found description text after the default value:\n${text}`);
   }
+
   summary.splice(summary.length - 2, 2);
   const lastSummaryPart = summary[summary.length - 1];
   lastSummaryPart.text = lastSummaryPart.text.replace(/[ \n]Defaults to $/, '');

--- a/scripts/apidoc/utils.ts
+++ b/scripts/apidoc/utils.ts
@@ -117,6 +117,7 @@ export function extractSeeAlsos(signature?: SignatureReflection): string[] {
     if (content.length === 1) {
       return joinTagContent(tag);
     }
+
     return tag.content
       .filter((_, index) => index % 3 === 1) // ['-', 'content', '\n']
       .map((part) => part.text);

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -12,6 +12,7 @@ const target = ['ES2019', 'node14.17'];
 if (existsSync(localeDir)) {
   rmSync(localeDir, { recursive: true, force: true });
 }
+
 mkdirSync(localeDir);
 for (const locale of Object.keys(locales)) {
   writeFileSync(

--- a/scripts/generateLocales.ts
+++ b/scripts/generateLocales.ts
@@ -82,6 +82,7 @@ function removeIndexTs(files: string[]): string[] {
   if (index !== -1) {
     files.splice(index, 1);
   }
+
   return files;
 }
 
@@ -152,6 +153,7 @@ function tryLoadLocalesMainIndexFile(pathModules: string): LocaleDefinition {
       console.error(`Failed to load ${pathModules} or manually parse it.`, e);
     }
   }
+
   return localeDef;
 }
 
@@ -177,6 +179,7 @@ function generateLocalesIndexFile(
       )}';`
     );
   }
+
   content.push(
     ...modules.map((m) => `import ${escapeImport(m)} from './${m}';`)
   );

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -62,6 +62,7 @@ export class Faker {
         `Locale ${locale} is not supported. You might want to add the requested locale first to \`faker.locales\`.`
       );
     }
+
     this._locale = locale;
   }
 
@@ -75,6 +76,7 @@ export class Faker {
         `Locale ${localeFallback} is not supported. You might want to add the requested locale first to \`faker.locales\`.`
       );
     }
+
     this._localeFallback = localeFallback;
   }
 

--- a/src/internal/mersenne/twister.ts
+++ b/src/internal/mersenne/twister.ts
@@ -129,6 +129,7 @@ export default class MersenneTwister19937 {
         sum = this.addition32(sum, this.unsigned32(n2 << i));
       }
     }
+
     return sum;
   }
 
@@ -194,10 +195,12 @@ export default class MersenneTwister19937 {
         this.mt[0] = this.mt[this.N - 1];
         i = 1;
       }
+
       if (j >= keyLength) {
         j = 0;
       }
     }
+
     for (k = this.N - 1; k; k--) {
       // mt[i] = (mt[i] ^ ((mt[i-1] ^ (mt[i-1] >> 30)) * 1566083941)) - i
       this.mt[i] = this.subtraction32(
@@ -218,6 +221,7 @@ export default class MersenneTwister19937 {
         i = 1;
       }
     }
+
     this.mt[0] = 0x80000000; // MSB is 1; assuring non-zero initial array
   }
 

--- a/src/modules/animal/index.ts
+++ b/src/modules/animal/index.ts
@@ -10,6 +10,7 @@ export class AnimalModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -58,9 +58,11 @@ function formatHexColor(
       hexColor = hexColor.toLowerCase();
       break;
   }
+
   if (options?.prefix) {
     hexColor = options.prefix + hexColor;
   }
+
   return hexColor;
 }
 
@@ -78,6 +80,7 @@ function toBinary(values: number[]): string {
       const bytes = new Uint8Array(buffer);
       return toBinary(Array.from(bytes)).split(' ').join('');
     }
+
     return (value >>> 0).toString(2).padStart(8, '0');
   });
   return binary.join(' ');
@@ -161,6 +164,7 @@ export class ColorModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -320,11 +324,13 @@ export class ColorModule {
       color = formatHexColor(color, options);
       return color;
     }
+
     color = Array.from({ length: 3 }, () => this.faker.number.int(255));
     if (includeAlpha) {
       color.push(this.faker.number.float());
       cssFunction = 'rgba';
     }
+
     return toColorFormat(color, format, cssFunction);
   }
 
@@ -460,6 +466,7 @@ export class ColorModule {
     for (let i = 0; i < (options?.includeAlpha ? 3 : 2); i++) {
       hsl.push(this.faker.number.float());
     }
+
     return toColorFormat(
       hsl,
       options?.format || 'decimal',
@@ -537,6 +544,7 @@ export class ColorModule {
     for (let i = 0; i < 2; i++) {
       hsl.push(this.faker.number.float());
     }
+
     return toColorFormat(hsl, options?.format || 'decimal', 'hwb');
   }
 
@@ -598,6 +606,7 @@ export class ColorModule {
         this.faker.number.float({ min: -100, max: 100, precision: 0.0001 })
       );
     }
+
     return toColorFormat(lab, options?.format || 'decimal', 'lab');
   }
 
@@ -669,6 +678,7 @@ export class ColorModule {
     for (let i = 0; i < 2; i++) {
       lch.push(this.faker.number.float({ max: 230, precision: 0.1 }));
     }
+
     return toColorFormat(lch, options?.format || 'decimal', 'lch');
   }
 
@@ -742,6 +752,7 @@ export class ColorModule {
     if (options?.format === 'css' && !options?.space) {
       options = { ...options, space: 'sRGB' };
     }
+
     const color = Array.from({ length: 3 }, () =>
       this.faker.number.float({ precision: 0.0001 })
     );

--- a/src/modules/commerce/index.ts
+++ b/src/modules/commerce/index.ts
@@ -10,6 +10,7 @@ export class CommerceModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/company/index.ts
+++ b/src/modules/company/index.ts
@@ -10,6 +10,7 @@ export class CompanyModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/database/index.ts
+++ b/src/modules/database/index.ts
@@ -10,6 +10,7 @@ export class DatabaseModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -11,6 +11,7 @@ export class DatatypeModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -211,14 +212,17 @@ export class DatatypeModule {
         probability: options,
       };
     }
+
     const { probability = 0.5 } = options;
     if (probability <= 0) {
       return false;
     }
+
     if (probability >= 1) {
       // This check is required to avoid returning false when float() returns 1
       return true;
     }
+
     return this.faker.number.float() < probability;
   }
 

--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -28,6 +28,7 @@ export class DateModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/finance/iban.ts
+++ b/src/modules/finance/iban.ts
@@ -1401,6 +1401,7 @@ const iban: Iban = {
     for (let i = 0; i < digitStr.length; i++) {
       m = (m * 10 + +digitStr[i]) % 97;
     }
+
     return m;
   },
   pattern10: ['01', '02', '03', '04', '05', '06', '07', '08', '09'],

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -12,6 +12,7 @@ export class FinanceModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -34,6 +35,7 @@ export class FinanceModule {
     for (let i = 0; i < length; i++) {
       template += '#';
     }
+
     length = null;
     return this.faker.helpers.replaceSymbolWithNumber(template);
   }
@@ -219,6 +221,7 @@ export class FinanceModule {
         this.faker.definitions.finance.currency
       )['symbol'];
     }
+
     return symbol;
   }
 
@@ -292,6 +295,7 @@ export class FinanceModule {
       const formats = this.faker.helpers.objectValue(localeFormat); // There could be multiple formats
       format = this.faker.helpers.arrayElement(formats);
     }
+
     format = format.replace(/\//g, '');
     return this.faker.helpers.replaceCreditCardSymbols(format);
   }
@@ -338,6 +342,7 @@ export class FinanceModule {
     if (length < 1) {
       throw new FakerError('minimum length is 1');
     }
+
     return this.faker.string.numeric({ length, allowLeadingZeros: true });
   }
 
@@ -409,10 +414,13 @@ export class FinanceModule {
             s += this.faker.number.int(9);
           }
         }
+
         c--;
       }
+
       s = s.substring(0, count);
     }
+
     let checksum: string | number =
       98 - iban.mod97(iban.toDigitString(`${s}${ibanFormat.country}00`));
 

--- a/src/modules/git/index.ts
+++ b/src/modules/git/index.ts
@@ -28,6 +28,7 @@ export class GitModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/hacker/index.ts
+++ b/src/modules/hacker/index.ts
@@ -10,6 +10,7 @@ export class HackerModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -14,6 +14,7 @@ export class HelpersModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -65,6 +66,7 @@ export class HelpersModule {
         str += string.charAt(i);
       }
     }
+
     return str;
   }
 
@@ -130,6 +132,7 @@ export class HelpersModule {
         str += string.charAt(i);
       }
     }
+
     return str;
   }
 
@@ -199,6 +202,7 @@ export class HelpersModule {
         max = min;
         min = tmp;
       }
+
       repetitions = this.faker.number.int({ min, max });
       string =
         string.slice(0, token.index) +
@@ -206,6 +210,7 @@ export class HelpersModule {
         string.slice(token.index + token[0].length);
       token = string.match(RANGE_REP_REG);
     }
+
     // Deal with repeat `{num}`
     token = string.match(REP_REG);
     while (token != null) {
@@ -229,12 +234,14 @@ export class HelpersModule {
         max = min;
         min = tmp;
       }
+
       string =
         string.slice(0, token.index) +
         this.faker.number.int({ min, max }).toString() +
         string.slice(token.index + token[0].length);
       token = string.match(RANGE_REG);
     }
+
     return string;
   }
 
@@ -320,6 +327,7 @@ export class HelpersModule {
       const array = Array.from(set);
       return this.shuffle(array).splice(0, length);
     }
+
     const set = new Set<T>();
     try {
       if (typeof source === 'function') {
@@ -330,6 +338,7 @@ export class HelpersModule {
     } catch {
       // Ignore
     }
+
     return Array.from(set);
   }
 
@@ -356,6 +365,7 @@ export class HelpersModule {
     if (str == null) {
       return '';
     }
+
     for (const p in data) {
       const re = new RegExp(`{{${p}}}`, 'g');
       const value = data[p];
@@ -365,6 +375,7 @@ export class HelpersModule {
         str = str.replace(re, value);
       }
     }
+
     return str;
   }
 
@@ -390,6 +401,7 @@ export class HelpersModule {
     if (this.faker.datatype.boolean(options)) {
       return callback();
     }
+
     return undefined;
   }
 
@@ -738,6 +750,7 @@ export class HelpersModule {
     if (typeof numberOrRange === 'number') {
       return numberOrRange;
     }
+
     return this.faker.number.int(numberOrRange);
   }
 

--- a/src/modules/helpers/luhn-check.ts
+++ b/src/modules/helpers/luhn-check.ts
@@ -35,8 +35,10 @@ function luhnChecksum(str: string): number {
         n = (n % 10) + 1;
       }
     }
+
     sum += n;
     alternate = !alternate;
   }
+
   return sum % 10;
 }

--- a/src/modules/helpers/unique.ts
+++ b/src/modules/helpers/unique.ts
@@ -28,6 +28,7 @@ function defaultCompare(
   if (obj[key] === undefined) {
     return -1;
   }
+
   return 0;
 }
 

--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -30,6 +30,7 @@ export class ImageModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
 

--- a/src/modules/image/providers/placeholder.ts
+++ b/src/modules/image/providers/placeholder.ts
@@ -13,6 +13,7 @@ export class Placeholder {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -33,6 +33,7 @@ export class InternetModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -173,10 +174,12 @@ export class InternetModule {
         if (charMapping[char]) {
           return charMapping[char];
         }
+
         if (char.charCodeAt(0) < 0x80) {
           // Keep ASCII characters
           return char;
         }
+
         // Final fallback return the Unicode char code value for Chinese, Japanese, Korean etc, base-36 encoded
         return char.charCodeAt(0).toString(36);
       })
@@ -224,6 +227,7 @@ export class InternetModule {
         ])}${lastName}${this.faker.number.int(99)}`;
         break;
     }
+
     result = result.toString().replace(/'/g, '');
     result = result.replace(/ /g, '');
     return result;
@@ -493,6 +497,7 @@ export class InternetModule {
         mac += validSep;
       }
     }
+
     return mac;
   }
 
@@ -536,6 +541,7 @@ export class InternetModule {
       if (prefix.length >= length) {
         return prefix;
       }
+
       if (memorable) {
         if (prefix.match(consonant)) {
           pattern = vowel;
@@ -543,16 +549,20 @@ export class InternetModule {
           pattern = consonant;
         }
       }
+
       const n = this.faker.number.int(94) + 33;
       let char = String.fromCharCode(n);
       if (memorable) {
         char = char.toLowerCase();
       }
+
       if (!char.match(pattern)) {
         return _password(length, memorable, pattern, prefix);
       }
+
       return _password(length, memorable, pattern, prefix + char);
     };
+
     return _password(len, memorable, pattern, prefix);
   }
 

--- a/src/modules/internet/user-agent.ts
+++ b/src/modules/internet/user-agent.ts
@@ -70,6 +70,7 @@ export function generate(faker: Faker): string {
         if (rand >= min && rand <= max) {
           break;
         }
+
         min = min + obj[key];
       }
     }
@@ -219,6 +220,7 @@ export function generate(faker: Faker): string {
     for (let x = 0; x < dots; x++) {
       return_val += `.${faker.string.numeric({ allowLeadingZeros: true })}`;
     }
+
     return return_val;
   };
 

--- a/src/modules/location/index.ts
+++ b/src/modules/location/index.ts
@@ -10,6 +10,7 @@ export class LocationModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -39,6 +40,7 @@ export class LocationModule {
         format = this.faker.helpers.arrayElement(localeFormat);
       }
     }
+
     return this.faker.helpers.replaceSymbols(format);
   }
 
@@ -62,6 +64,7 @@ export class LocationModule {
     if (zipRange) {
       return String(this.faker.number.int(zipRange));
     }
+
     return this.zipCode();
   }
 
@@ -309,6 +312,7 @@ export class LocationModule {
         this.faker.definitions.location.direction
       );
     }
+
     return this.faker.helpers.arrayElement(
       this.faker.definitions.location.direction_abbr
     );
@@ -333,6 +337,7 @@ export class LocationModule {
         this.faker.definitions.location.direction.slice(0, 4)
       );
     }
+
     return this.faker.helpers.arrayElement(
       this.faker.definitions.location.direction_abbr.slice(0, 4)
     );
@@ -357,6 +362,7 @@ export class LocationModule {
         this.faker.definitions.location.direction.slice(4, 8)
       );
     }
+
     return this.faker.helpers.arrayElement(
       this.faker.definitions.location.direction_abbr.slice(4, 8)
     );
@@ -419,6 +425,7 @@ export class LocationModule {
       newCoordinate[0] = Math.sign(newCoordinate[0]) * 180 - newCoordinate[0];
       newCoordinate[1] += 180;
     }
+
     // Box longitude [-180°, 180°]
     newCoordinate[1] = (((newCoordinate[1] % 360) + 540) % 360) - 180;
 

--- a/src/modules/lorem/index.ts
+++ b/src/modules/lorem/index.ts
@@ -11,6 +11,7 @@ export class LoremModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/music/index.ts
+++ b/src/modules/music/index.ts
@@ -10,6 +10,7 @@ export class MusicModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -12,6 +12,7 @@ export class NumberModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -56,6 +57,7 @@ export class NumberModule {
           `No integer value between ${min} and ${max} found.`
         );
       }
+
       throw new FakerError(`Max ${max} should be greater than min ${min}.`);
     }
 

--- a/src/modules/person/index.ts
+++ b/src/modules/person/index.ts
@@ -65,6 +65,7 @@ export class PersonModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/phone/index.ts
+++ b/src/modules/phone/index.ts
@@ -10,6 +10,7 @@ export class PhoneModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/random/index.ts
+++ b/src/modules/random/index.ts
@@ -18,6 +18,7 @@ export class RandomModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -206,6 +207,7 @@ export class RandomModule {
     if (typeof options === 'number') {
       return this.faker.string.alpha(options);
     }
+
     return this.faker.string.alpha({
       length: options.count,
       casing: options.casing,

--- a/src/modules/science/index.ts
+++ b/src/modules/science/index.ts
@@ -39,6 +39,7 @@ export class ScienceModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -91,6 +91,7 @@ export class StringModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -440,6 +441,7 @@ export class StringModule {
       const value = placeholder === 'x' ? random : (random & 0x3) | 0x8;
       return value.toString(16);
     };
+
     return RFC4122_TEMPLATE.replace(/[xy]/g, replacePlaceholders);
   }
 

--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -42,6 +42,7 @@ export class SystemModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/vehicle/index.ts
+++ b/src/modules/vehicle/index.ts
@@ -10,6 +10,7 @@ export class VehicleModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }

--- a/src/modules/word/index.ts
+++ b/src/modules/word/index.ts
@@ -12,6 +12,7 @@ export class WordModule {
       if (name === 'constructor' || typeof this[name] !== 'function') {
         continue;
       }
+
       this[name] = this[name].bind(this);
     }
   }
@@ -392,6 +393,7 @@ export class WordModule {
     if (typeof options === 'number') {
       options = { count: options };
     }
+
     const { count = { min: 1, max: 3 } } = options;
 
     return this.faker.helpers

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -63,6 +63,7 @@ function modulesList(): { [module: string]: string[] } {
       } else {
         console.log(`Skipping ${mod} - No testable methods`);
       }
+
       return result;
     }, {});
 

--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -346,6 +346,7 @@ describe('date', () => {
             for (let i = 1; i < dates.length; i++) {
               expect(dates[i]).greaterThan(dates[i - 1]);
             }
+
             expect(dates[dates.length - 1]).lessThan(to);
           }
         );

--- a/test/support/seededRuns.ts
+++ b/test/support/seededRuns.ts
@@ -219,6 +219,7 @@ class TestGenerator<
     for (const method of methods) {
       this.it(method);
     }
+
     return this;
   }
 
@@ -244,6 +245,7 @@ class TestGenerator<
       ).toBeFalsy();
       variantNames.add(name);
     };
+
     const tester: MethodTester<Module[MethodName]> = {
       it(name: string, ...args: Parameters<Module[MethodName]>) {
         expectVariantNotTested(name);
@@ -279,6 +281,7 @@ class TestGenerator<
       for (const method of methods) {
         this.describe(method, factory);
       }
+
       return this;
     };
   }


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->

related to #1686 

---

For now I only turned on `{ blankLine: 'always', prev: 'block-like', next: '*' }`
This will add blank lines after blocks like `if`, `for` and `switch`
Then I executed `pnpm eslint . --fix`

I also sorted the `@typesscript-eslint/*` rules alphabetically

@faker-js/maintainers @faker-js/members Please let me know if you like this PR and if I should proceed or if we should merge this now and configure every further more strictness in separate PRs so the PR diff doesn't explode

I would like to additionally configure:
- `case` in switch blocks
- maybe a blank line before each `block-like` if somehow possible
- ...