### PR TITLE
docs: fix param check

### DIFF
--- a/scripts/apidoc/signature.ts
+++ b/scripts/apidoc/signature.ts
@@ -243,7 +243,7 @@ function analyzeParameterOptions(
       description: mdToHtml(
         toBlock(
           property.comment ??
-            (property.type as ReflectionType)?.declaration.signatures?.[0]
+            (property.type as ReflectionType)?.declaration?.signatures?.[0]
               .comment
         )
       ),

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -396,6 +396,7 @@ export class HelpersModule {
   /**
    * Returns a random key from given object or `undefined` if no key could be found.
    *
+   * @template T The type of the object to select from.
    * @param object The object to be used.
    *
    * @example
@@ -411,6 +412,7 @@ export class HelpersModule {
   /**
    * Returns a random value from given object or `undefined` if no key could be found.
    *
+   * @template T The type of object to select from.
    * @param object The object to be used.
    *
    * @example
@@ -788,6 +790,7 @@ export class HelpersModule {
   /**
    * Generates an array containing values returned by the given method.
    *
+   * @template T The type of elements.
    * @param method The method used to generate the values.
    * @param options The optional options object.
    * @param options.count The number or range of elements to generate. Defaults to `3`.


### PR DESCRIPTION
Fix #1685 

- #1685 

I changed the script so it no longer fails for missing nested descriptions. 
Instead, I added a test that checks that the generated api-docs have proper descriptions for all params.