### PR TITLE
docs: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ versions.json
 
 # Dist
 /dist
+/docs/.vitepress/cache
 /docs/.vitepress/dist
 /docs/api/typedoc.json
 /lib


### PR DESCRIPTION
When I run `pnpm run docs:build` files show up as not checked in.
This PR adds the vitepress cache folder to the gitignore.