### PR TITLE
feat: datatype.number and number `not` parameter introduced

### DIFF
--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -22,9 +22,12 @@ export class DatatypeModule {
    * @param options Maximum value or options object.
    * @param options.min Lower bound for generated number. Defaults to `0`.
    * @param options.max Upper bound for generated number. Defaults to `min + 99999`.
+   * @param options.not A number that the generated number cannot be equal to. Defaults to `undefined`.
    * @param options.precision Precision of the generated number. Defaults to `1`.
    *
    * @throws When options define `max < min`.
+   * @throws When options define `max === min === Math.round(not)`.
+   * @throws When tries too many times to generate a number not equal to `options.not`.
    *
    * @see faker.number.int() for the default precision of `1`
    * @see faker.number.float() for a custom precision
@@ -42,7 +45,9 @@ export class DatatypeModule {
    * @deprecated Use `faker.number.int()` or `faker.number.float()` instead.
    */
   number(
-    options: number | { min?: number; max?: number; precision?: number } = 99999
+    options:
+      | number
+      | { min?: number; max?: number; not?: number; precision?: number } = 99999
   ): number {
     deprecated({
       deprecated: 'faker.datatype.number()',
@@ -55,9 +60,9 @@ export class DatatypeModule {
       options = { max: options };
     }
 
-    const { min = 0, max = min + 99999, precision = 1 } = options;
+    const { min = 0, max = min + 99999, not, precision = 1 } = options;
 
-    return this.faker.number.float({ min, max, precision });
+    return this.faker.number.float({ min, max, precision, not });
   }
 
   /**
@@ -66,6 +71,7 @@ export class DatatypeModule {
    * @param options Precision or options object.
    * @param options.min Lower bound for generated number. Defaults to `0`.
    * @param options.max Upper bound for generated number. Defaults to `99999`.
+   * @param options.not A number that the generated number cannot be equal to. Defaults to `undefined`.
    * @param options.precision Precision of the generated number. Defaults to `0.01`.
    *
    * @see faker.number.float()
@@ -83,7 +89,9 @@ export class DatatypeModule {
    * @deprecated Use `faker.number.float()` instead.
    */
   float(
-    options: number | { min?: number; max?: number; precision?: number } = {}
+    options:
+      | number
+      | { min?: number; max?: number; not?: number; precision?: number } = {}
   ): number {
     deprecated({
       deprecated: 'faker.datatype.float()',
@@ -98,9 +106,9 @@ export class DatatypeModule {
       };
     }
 
-    const { min = 0, max = min + 99999, precision = 0.01 } = options;
+    const { min = 0, max = min + 99999, not, precision = 0.01 } = options;
 
-    return this.faker.number.float({ min, max, precision });
+    return this.faker.number.float({ min, max, not, precision });
   }
 
   /**

--- a/test/__snapshots__/datatype.spec.ts.snap
+++ b/test/__snapshots__/datatype.spec.ts.snap
@@ -83,6 +83,12 @@ exports[`datatype > 42 > float > with min and max 1`] = `-0.43`;
 
 exports[`datatype > 42 > float > with min, max and precision 1`] = `-0.4261`;
 
+exports[`datatype > 42 > float > with min, max, and not 1`] = `-0.43`;
+
+exports[`datatype > 42 > float > with min, max, not, and precision 1`] = `-0.4261`;
+
+exports[`datatype > 42 > float > with not 1`] = `37453.64`;
+
 exports[`datatype > 42 > hexadecimal > noArgs 1`] = `"0x8"`;
 
 exports[`datatype > 42 > hexadecimal > with casing 1`] = `"0x8"`;
@@ -114,6 +120,12 @@ exports[`datatype > 42 > number > with min 1`] = `37412`;
 exports[`datatype > 42 > number > with min and max 1`] = `-1`;
 
 exports[`datatype > 42 > number > with min, max and precision 1`] = `-0.43`;
+
+exports[`datatype > 42 > number > with min, max, and not 1`] = `-1`;
+
+exports[`datatype > 42 > number > with min, max, not, and precision 1`] = `-0.43`;
+
+exports[`datatype > 42 > number > with not 1`] = `37454`;
 
 exports[`datatype > 42 > string > noArgs 1`] = `"Cky2eiXX/J"`;
 
@@ -213,6 +225,12 @@ exports[`datatype > 1211 > float > with min and max 1`] = `61.07`;
 
 exports[`datatype > 1211 > float > with min, max and precision 1`] = `61.0658`;
 
+exports[`datatype > 1211 > float > with min, max, and not 1`] = `61.07`;
+
+exports[`datatype > 1211 > float > with min, max, not, and precision 1`] = `61.0658`;
+
+exports[`datatype > 1211 > float > with not 1`] = `92851.09`;
+
 exports[`datatype > 1211 > hexadecimal > noArgs 1`] = `"0xE"`;
 
 exports[`datatype > 1211 > hexadecimal > with casing 1`] = `"0xe"`;
@@ -244,6 +262,12 @@ exports[`datatype > 1211 > number > with min 1`] = `92810`;
 exports[`datatype > 1211 > number > with min and max 1`] = `61`;
 
 exports[`datatype > 1211 > number > with min, max and precision 1`] = `61.07`;
+
+exports[`datatype > 1211 > number > with min, max, and not 1`] = `61`;
+
+exports[`datatype > 1211 > number > with min, max, not, and precision 1`] = `61.07`;
+
+exports[`datatype > 1211 > number > with not 1`] = `92852`;
 
 exports[`datatype > 1211 > string > noArgs 1`] = `"wKti5-}$_/"`;
 
@@ -341,6 +365,12 @@ exports[`datatype > 1337 > float > with min and max 1`] = `-12.92`;
 
 exports[`datatype > 1337 > float > with min, max and precision 1`] = `-12.9153`;
 
+exports[`datatype > 1337 > float > with min, max, and not 1`] = `-12.92`;
+
+exports[`datatype > 1337 > float > with min, max, not, and precision 1`] = `-12.9153`;
+
+exports[`datatype > 1337 > float > with not 1`] = `26202.2`;
+
 exports[`datatype > 1337 > hexadecimal > noArgs 1`] = `"0x5"`;
 
 exports[`datatype > 1337 > hexadecimal > with casing 1`] = `"0x5"`;
@@ -372,6 +402,12 @@ exports[`datatype > 1337 > number > with min 1`] = `26160`;
 exports[`datatype > 1337 > number > with min and max 1`] = `-13`;
 
 exports[`datatype > 1337 > number > with min, max and precision 1`] = `-12.92`;
+
+exports[`datatype > 1337 > number > with min, max, and not 1`] = `-13`;
+
+exports[`datatype > 1337 > number > with min, max, not, and precision 1`] = `-12.92`;
+
+exports[`datatype > 1337 > number > with not 1`] = `26202`;
 
 exports[`datatype > 1337 > string > noArgs 1`] = `"9U/4:SK$>6"`;
 

--- a/test/__snapshots__/number.spec.ts.snap
+++ b/test/__snapshots__/number.spec.ts.snap
@@ -22,15 +22,37 @@ exports[`number > 42 > float > with min and max 1`] = `-0.43`;
 
 exports[`number > 42 > float > with min, max and precision 1`] = `-0.4261`;
 
+exports[`number > 42 > float > with min, max, and not 1`] = `-0.43`;
+
+exports[`number > 42 > float > with min, max, not, and precision 1`] = `-0.4261`;
+
+exports[`number > 42 > float > with not 1`] = `0.37`;
+
 exports[`number > 42 > float > with plain number 1`] = `1.5`;
 
 exports[`number > 42 > hex > noArgs 1`] = `"5"`;
+
+exports[`number > 42 > hex > with max 1`] = `"4"`;
+
+exports[`number > 42 > hex > with min 1`] = `"5"`;
+
+exports[`number > 42 > hex > with min and max 1`] = `"4"`;
+
+exports[`number > 42 > hex > with not 1`] = `"5"`;
 
 exports[`number > 42 > hex > with options 1`] = `"4"`;
 
 exports[`number > 42 > hex > with value 1`] = `"0"`;
 
 exports[`number > 42 > int > noArgs 1`] = `3373557438480384`;
+
+exports[`number > 42 > int > with max 1`] = `4`;
+
+exports[`number > 42 > int > with min 1`] = `3373557438480384`;
+
+exports[`number > 42 > int > with min and max 1`] = `4`;
+
+exports[`number > 42 > int > with not 1`] = `3373557438480384`;
 
 exports[`number > 42 > int > with options 1`] = `4`;
 
@@ -58,15 +80,37 @@ exports[`number > 1211 > float > with min and max 1`] = `61.07`;
 
 exports[`number > 1211 > float > with min, max and precision 1`] = `61.0658`;
 
+exports[`number > 1211 > float > with min, max, and not 1`] = `61.07`;
+
+exports[`number > 1211 > float > with min, max, not, and precision 1`] = `61.0658`;
+
+exports[`number > 1211 > float > with not 1`] = `0.93`;
+
 exports[`number > 1211 > float > with plain number 1`] = `3.72`;
 
 exports[`number > 1211 > hex > noArgs 1`] = `"e"`;
+
+exports[`number > 1211 > hex > with max 1`] = `"a"`;
+
+exports[`number > 1211 > hex > with min 1`] = `"e"`;
+
+exports[`number > 1211 > hex > with min and max 1`] = `"a"`;
+
+exports[`number > 1211 > hex > with not 1`] = `"e"`;
 
 exports[`number > 1211 > hex > with options 1`] = `"a"`;
 
 exports[`number > 1211 > hex > with value 1`] = `"1"`;
 
 exports[`number > 1211 > int > noArgs 1`] = `8363366036799488`;
+
+exports[`number > 1211 > int > with max 1`] = `10`;
+
+exports[`number > 1211 > int > with min 1`] = `8363366036799488`;
+
+exports[`number > 1211 > int > with min and max 1`] = `10`;
+
+exports[`number > 1211 > int > with not 1`] = `8363366036799488`;
 
 exports[`number > 1211 > int > with options 1`] = `10`;
 
@@ -94,15 +138,37 @@ exports[`number > 1337 > float > with min and max 1`] = `-12.92`;
 
 exports[`number > 1337 > float > with min, max and precision 1`] = `-12.9153`;
 
+exports[`number > 1337 > float > with min, max, and not 1`] = `-12.92`;
+
+exports[`number > 1337 > float > with min, max, not, and precision 1`] = `-12.9153`;
+
+exports[`number > 1337 > float > with not 1`] = `0.26`;
+
 exports[`number > 1337 > float > with plain number 1`] = `1.05`;
 
 exports[`number > 1337 > hex > noArgs 1`] = `"4"`;
+
+exports[`number > 1337 > hex > with max 1`] = `"2"`;
+
+exports[`number > 1337 > hex > with min 1`] = `"4"`;
+
+exports[`number > 1337 > hex > with min and max 1`] = `"2"`;
+
+exports[`number > 1337 > hex > with not 1`] = `"4"`;
 
 exports[`number > 1337 > hex > with options 1`] = `"2"`;
 
 exports[`number > 1337 > hex > with value 1`] = `"0"`;
 
 exports[`number > 1337 > int > noArgs 1`] = `2360108468142080`;
+
+exports[`number > 1337 > int > with max 1`] = `2`;
+
+exports[`number > 1337 > int > with min 1`] = `2360108468142080`;
+
+exports[`number > 1337 > int > with min and max 1`] = `2`;
+
+exports[`number > 1337 > int > with not 1`] = `2360108468142080`;
 
 exports[`number > 1337 > int > with options 1`] = `2`;
 

--- a/test/datatype.spec.ts
+++ b/test/datatype.spec.ts
@@ -11,13 +11,25 @@ describe('datatype', () => {
         .itRepeated('repeated', 5, 6)
         .it('with min', { min: -42 })
         .it('with max', { max: 69 })
+        .it('with not', { not: 7 })
         .it('with min and max', {
           min: -42,
           max: 69,
         })
+        .it('with min, max, and not', {
+          min: -42,
+          max: 69,
+          not: 7,
+        })
         .it('with min, max and precision', {
           min: -42,
           max: 69,
+          precision: 0.01,
+        })
+        .it('with min, max, not, and precision', {
+          min: -42,
+          max: 69,
+          not: 7,
           precision: 0.01,
         });
     });
@@ -27,10 +39,18 @@ describe('datatype', () => {
         .itRepeated('repeated', 6)
         .it('with min', { min: -42 })
         .it('with max', { max: 69 })
+        .it('with not', { not: 7 })
         .it('with min and max', { min: -42, max: 69 })
+        .it('with min, max, and not', { min: -42, max: 69, not: 7 })
         .it('with min, max and precision', {
           min: -42,
           max: 69,
+          precision: 0.0001,
+        })
+        .it('with min, max, not, and precision', {
+          min: -42,
+          max: 69,
+          not: 7,
           precision: 0.0001,
         });
     });

--- a/test/number.spec.ts
+++ b/test/number.spec.ts
@@ -15,17 +15,29 @@ describe('number', () => {
     )((t) => {
       t.it('noArgs')
         .it('with value', 1)
-        .it('with options', { min: 0, max: 10 });
+        .it('with min', { min: 0 })
+        .it('with max', { max: 10 })
+        .it('with not', { not: 7 })
+        .it('with min and max', { min: 0, max: 10 })
+        .it('with options', { min: 0, max: 10, not: 7 });
     });
 
     t.describe('float', (t) => {
       t.it('with plain number', 4)
         .it('with min', { min: -42 })
         .it('with max', { max: 69 })
+        .it('with not', { not: 7 })
         .it('with min and max', { min: -42, max: 69 })
+        .it('with min, max, and not', { min: -42, max: 69, not: 7 })
         .it('with min, max and precision', {
           min: -42,
           max: 69,
+          precision: 0.0001,
+        })
+        .it('with min, max, not, and precision', {
+          min: -42,
+          max: 69,
+          not: 7,
           precision: 0.0001,
         });
     });


### PR DESCRIPTION
Introduced `not` parameter for `int` and `float` number generators.

See: https://discord.com/channels/929487054990110771/929487054990110777/1058484035875258419

I had a recurring need to generate numbers with a provided parameter to signify what number I did _not_ want generated.

To prevent endless loops in rare cases with limited runway between min and max parameters, I included a try count with a maximum of hardcoded 100 tries if the number generated is the number _`not`_ wanted. If this were to occur, and error will be thrown as documented.