### PR TITLE
feat(string): add binary and octal random string generation

### DIFF
--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -121,9 +121,9 @@ export class NumberModule {
    * @param options.min Lower bound for generated number. Defaults to `0`.
    * @param options.max Upper bound for generated number. Defaults to `1`.
    *
-   * @see faker.string.binary() If you would like to generate a `binary string` with a given length (range).
-   *
    * @throws When options define `max < min`.
+   *
+   * @see faker.string.binary() If you would like to generate a `binary string` with a given length (range).
    *
    * @example
    * faker.number.binary() // '1'
@@ -152,9 +152,9 @@ export class NumberModule {
    * @param options.min Lower bound for generated number. Defaults to `0`.
    * @param options.max Upper bound for generated number. Defaults to `7`.
    *
-   * @see faker.string.octal() If you would like to generate an `octal string` with a given length (range).
-   *
    * @throws When options define `max < min`.
+   *
+   * @see faker.string.octal() If you would like to generate an `octal string` with a given length (range).
    *
    * @example
    * faker.number.octal() // '5'

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -121,6 +121,8 @@ export class NumberModule {
    * @param options.min Lower bound for generated number. Defaults to `0`.
    * @param options.max Upper bound for generated number. Defaults to `1`.
    *
+   * @see faker.string.binary() If you would like to generate a `binary string` with a given length (range).
+   *
    * @throws When options define `max < min`.
    *
    * @example
@@ -149,6 +151,8 @@ export class NumberModule {
    * @param options Maximum value or options object. Defaults to `{}`.
    * @param options.min Lower bound for generated number. Defaults to `0`.
    * @param options.max Upper bound for generated number. Defaults to `7`.
+   *
+   * @see faker.string.octal() If you would like to generate an `octal string` with a given length (range).
    *
    * @throws When options define `max < min`.
    *

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -256,8 +256,6 @@ export class StringModule {
    * faker.string.binary({ length: { min: 5, max: 10 } }) // '0b11101011'
    * faker.string.binary({ prefix: '0b' }) // '0b1'
    * faker.string.binary({ length: 10, prefix: 'bin_' }) // 'bin_1101011011'
-   * faker.string.binary({ prefix: '' }) // '1'
-   * faker.string.binary({ length: 10, prefix: '0b' }) // '0b1101011011'
    *
    * @since 8.0.0
    */
@@ -297,8 +295,6 @@ export class StringModule {
    * faker.string.octal({ length: { min: 5, max: 10 } }) // '0o15263214'
    * faker.string.octal({ prefix: '0o' }) // '0o7'
    * faker.string.octal({ length: 10, prefix: 'oct_' }) // 'oct_1542153414'
-   * faker.string.octal({ prefix: '' }) // '2'
-   * faker.string.octal({ length: 10, prefix: '0o' }) // '0o1526216210'
    *
    * @since 8.0.0
    */

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -242,6 +242,93 @@ export class StringModule {
   }
 
   /**
+   * Returns a [binary](https://en.wikipedia.org/wiki/Binary_number) string.
+   *
+   * @param options The optional options object.
+   * @param options.length The number or range of characters to generate after the prefix. Defaults to `1`.
+   * @param options.prefix Prefix for the generated number. Defaults to `'0x'`.
+   *
+   * @example
+   * faker.string.binary() // '0x1'
+   * faker.string.binary({ length: 10 }) // '0x1101011011'
+   * faker.string.binary({ length: { min: 5, max: 10 } }) // '0x11101011'
+   * faker.string.binary({ prefix: '0x' }) // '0x1'
+   * faker.string.binary({ length: 10, prefix: '#' }) // '#1101011011'
+   * faker.string.binary({ prefix: '' }) // '1'
+   * faker.string.binary({ length: 10, prefix: '0x' }) // '0x1101011011'
+   *
+   * @since 8.0.0
+   */
+  binary(
+    options: {
+      length?: number | { min: number; max: number };
+      prefix?: string;
+    } = {}
+  ): string {
+    const { prefix = '0x' } = options;
+    const length = this.faker.helpers.rangeToNumber(options.length ?? 1);
+    if (length <= 0) {
+      return prefix;
+    }
+
+    let binaryString = '';
+
+    for (let i = 0; i < length; i++) {
+      binaryString += this.faker.helpers.arrayElement(['0', '1']);
+    }
+
+    return `${prefix}${binaryString}`;
+  }
+
+  /**
+   * Returns an [octal](https://en.wikipedia.org/wiki/Octal) string.
+   *
+   * @param options The optional options object.
+   * @param options.length The number or range of characters to generate after the prefix. Defaults to `1`.
+   * @param options.prefix Prefix for the generated number. Defaults to `'0x'`.
+   *
+   * @example
+   * faker.string.octal() // '0x3'
+   * faker.string.octal({ length: 10 }) // '0x1526216210'
+   * faker.string.octal({ length: { min: 5, max: 10 } }) // '0x15263214'
+   * faker.string.octal({ prefix: '0x' }) // '0x7'
+   * faker.string.octal({ length: 10, prefix: '#' }) // '#1542153414'
+   * faker.string.octal({ prefix: '' }) // '2'
+   * faker.string.octal({ length: 10, prefix: '0x' }) // '0x1526216210'
+   *
+   * @since 8.0.0
+   */
+  octal(
+    options: {
+      length?: number | { min: number; max: number };
+      prefix?: string;
+    } = {}
+  ): string {
+    const { prefix = '0x' } = options;
+    const length = this.faker.helpers.rangeToNumber(options.length ?? 1);
+    if (length <= 0) {
+      return prefix;
+    }
+
+    let octalString = '';
+
+    for (let i = 0; i < length; i++) {
+      octalString += this.faker.helpers.arrayElement([
+        '0',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+      ]);
+    }
+
+    return `${prefix}${octalString}`;
+  }
+
+  /**
    * Returns a [hexadecimal](https://en.wikipedia.org/wiki/Hexadecimal) string.
    *
    * @param options The optional options object.

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -246,16 +246,16 @@ export class StringModule {
    *
    * @param options The optional options object.
    * @param options.length The number or range of characters to generate after the prefix. Defaults to `1`.
-   * @param options.prefix Prefix for the generated number. Defaults to `'0x'`.
+   * @param options.prefix Prefix for the generated number. Defaults to `'0b'`.
    *
    * @example
-   * faker.string.binary() // '0x1'
-   * faker.string.binary({ length: 10 }) // '0x1101011011'
-   * faker.string.binary({ length: { min: 5, max: 10 } }) // '0x11101011'
-   * faker.string.binary({ prefix: '0x' }) // '0x1'
+   * faker.string.binary() // '0b1'
+   * faker.string.binary({ length: 10 }) // '0b1101011011'
+   * faker.string.binary({ length: { min: 5, max: 10 } }) // '0b11101011'
+   * faker.string.binary({ prefix: '0b' }) // '0b1'
    * faker.string.binary({ length: 10, prefix: '#' }) // '#1101011011'
    * faker.string.binary({ prefix: '' }) // '1'
-   * faker.string.binary({ length: 10, prefix: '0x' }) // '0x1101011011'
+   * faker.string.binary({ length: 10, prefix: '0b' }) // '0b1101011011'
    *
    * @since 8.0.0
    */
@@ -265,7 +265,7 @@ export class StringModule {
       prefix?: string;
     } = {}
   ): string {
-    const { prefix = '0x' } = options;
+    const { prefix = '0b' } = options;
     const length = this.faker.helpers.rangeToNumber(options.length ?? 1);
     if (length <= 0) {
       return prefix;
@@ -285,16 +285,16 @@ export class StringModule {
    *
    * @param options The optional options object.
    * @param options.length The number or range of characters to generate after the prefix. Defaults to `1`.
-   * @param options.prefix Prefix for the generated number. Defaults to `'0x'`.
+   * @param options.prefix Prefix for the generated number. Defaults to `'0o'`.
    *
    * @example
-   * faker.string.octal() // '0x3'
-   * faker.string.octal({ length: 10 }) // '0x1526216210'
-   * faker.string.octal({ length: { min: 5, max: 10 } }) // '0x15263214'
-   * faker.string.octal({ prefix: '0x' }) // '0x7'
+   * faker.string.octal() // '0o3'
+   * faker.string.octal({ length: 10 }) // '0o1526216210'
+   * faker.string.octal({ length: { min: 5, max: 10 } }) // '0o15263214'
+   * faker.string.octal({ prefix: '0o' }) // '0o7'
    * faker.string.octal({ length: 10, prefix: '#' }) // '#1542153414'
    * faker.string.octal({ prefix: '' }) // '2'
-   * faker.string.octal({ length: 10, prefix: '0x' }) // '0x1526216210'
+   * faker.string.octal({ length: 10, prefix: '0o' }) // '0o1526216210'
    *
    * @since 8.0.0
    */
@@ -304,7 +304,7 @@ export class StringModule {
       prefix?: string;
     } = {}
   ): string {
-    const { prefix = '0x' } = options;
+    const { prefix = '0o' } = options;
     const length = this.faker.helpers.rangeToNumber(options.length ?? 1);
     if (length <= 0) {
       return prefix;

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -248,12 +248,14 @@ export class StringModule {
    * @param options.length The number or range of characters to generate after the prefix. Defaults to `1`.
    * @param options.prefix Prefix for the generated number. Defaults to `'0b'`.
    *
+   * @see faker.number.binary() If you would like to generate a `binary number` (within a range).
+   *
    * @example
    * faker.string.binary() // '0b1'
    * faker.string.binary({ length: 10 }) // '0b1101011011'
    * faker.string.binary({ length: { min: 5, max: 10 } }) // '0b11101011'
    * faker.string.binary({ prefix: '0b' }) // '0b1'
-   * faker.string.binary({ length: 10, prefix: '#' }) // '#1101011011'
+   * faker.string.binary({ length: 10, prefix: 'bin_' }) // 'bin_1101011011'
    * faker.string.binary({ prefix: '' }) // '1'
    * faker.string.binary({ length: 10, prefix: '0b' }) // '0b1101011011'
    *
@@ -287,12 +289,14 @@ export class StringModule {
    * @param options.length The number or range of characters to generate after the prefix. Defaults to `1`.
    * @param options.prefix Prefix for the generated number. Defaults to `'0o'`.
    *
+   * @see faker.number.octal() If you would like to generate an `octal number` (within a range).
+   *
    * @example
    * faker.string.octal() // '0o3'
    * faker.string.octal({ length: 10 }) // '0o1526216210'
    * faker.string.octal({ length: { min: 5, max: 10 } }) // '0o15263214'
    * faker.string.octal({ prefix: '0o' }) // '0o7'
-   * faker.string.octal({ length: 10, prefix: '#' }) // '#1542153414'
+   * faker.string.octal({ length: 10, prefix: 'oct_' }) // 'oct_1542153414'
    * faker.string.octal({ prefix: '' }) // '2'
    * faker.string.octal({ length: 10, prefix: '0o' }) // '0o1526216210'
    *

--- a/test/__snapshots__/string.spec.ts.snap
+++ b/test/__snapshots__/string.spec.ts.snap
@@ -52,6 +52,16 @@ exports[`string > 42 > alphanumeric > with length range 1`] = `"NWbJMBB9r963sR"`
 
 exports[`string > 42 > alphanumeric > with length, casing and exclude 1`] = `"cvy4kvh"`;
 
+exports[`string > 42 > binary > noArgs 1`] = `"0x0"`;
+
+exports[`string > 42 > binary > with custom prefix 1`] = `"bin_0"`;
+
+exports[`string > 42 > binary > with length 1`] = `"0x011011"`;
+
+exports[`string > 42 > binary > with length range 1`] = `"0x11011110000001"`;
+
+exports[`string > 42 > binary > with length, casing and empty prefix 1`] = `"0110111"`;
+
 exports[`string > 42 > hexadecimal > noArgs 1`] = `"0x8"`;
 
 exports[`string > 42 > hexadecimal > with casing = lower 1`] = `"0x8"`;
@@ -89,6 +99,16 @@ exports[`string > 42 > numeric > with length parameter 5`] = `"00978"`;
 exports[`string > 42 > numeric > with length range 1`] = `"79177551410048"`;
 
 exports[`string > 42 > numeric > with length, allowLeadingZeros and exclude 1`] = `"6890887"`;
+
+exports[`string > 42 > octal > noArgs 1`] = `"0x2"`;
+
+exports[`string > 42 > octal > with custom prefix 1`] = `"oct_2"`;
+
+exports[`string > 42 > octal > with length 1`] = `"0x267156"`;
+
+exports[`string > 42 > octal > with length range 1`] = `"0x67156441310036"`;
+
+exports[`string > 42 > octal > with length, casing and empty prefix 1`] = `"2671564"`;
 
 exports[`string > 42 > sample > noArgs 1`] = `"Cky2eiXX/J"`;
 
@@ -180,6 +200,16 @@ exports[`string > 1211 > alphanumeric > with length range 1`] = `"sTMd8Z2F9GdLql
 
 exports[`string > 1211 > alphanumeric > with length, casing and exclude 1`] = `"yexv53z"`;
 
+exports[`string > 1211 > binary > noArgs 1`] = `"0x1"`;
+
+exports[`string > 1211 > binary > with custom prefix 1`] = `"bin_1"`;
+
+exports[`string > 1211 > binary > with length 1`] = `"0x101100"`;
+
+exports[`string > 1211 > binary > with length range 1`] = `"0x01100101010100011101"`;
+
+exports[`string > 1211 > binary > with length, casing and empty prefix 1`] = `"1011001"`;
+
 exports[`string > 1211 > hexadecimal > noArgs 1`] = `"0xE"`;
 
 exports[`string > 1211 > hexadecimal > with casing = lower 1`] = `"0xe"`;
@@ -217,6 +247,16 @@ exports[`string > 1211 > numeric > with length parameter 5`] = `"76678"`;
 exports[`string > 1211 > numeric > with length range 1`] = `"48721906162743167807"`;
 
 exports[`string > 1211 > numeric > with length, allowLeadingZeros and exclude 1`] = `"9798609"`;
+
+exports[`string > 1211 > octal > noArgs 1`] = `"0x7"`;
+
+exports[`string > 1211 > octal > with custom prefix 1`] = `"oct_7"`;
+
+exports[`string > 1211 > octal > with length 1`] = `"0x737611"`;
+
+exports[`string > 1211 > octal > with length range 1`] = `"0x37611705151632155606"`;
+
+exports[`string > 1211 > octal > with length, casing and empty prefix 1`] = `"7376117"`;
 
 exports[`string > 1211 > sample > noArgs 1`] = `"wKti5-}$_/"`;
 
@@ -308,6 +348,16 @@ exports[`string > 1337 > alphanumeric > with length range 1`] = `"y9dhxs2jewAg"`
 
 exports[`string > 1337 > alphanumeric > with length, casing and exclude 1`] = `"ag45age"`;
 
+exports[`string > 1337 > binary > noArgs 1`] = `"0x0"`;
+
+exports[`string > 1337 > binary > with custom prefix 1`] = `"bin_0"`;
+
+exports[`string > 1337 > binary > with length 1`] = `"0x010001"`;
+
+exports[`string > 1337 > binary > with length range 1`] = `"0x100010000110"`;
+
+exports[`string > 1337 > binary > with length, casing and empty prefix 1`] = `"0100010"`;
+
 exports[`string > 1337 > hexadecimal > noArgs 1`] = `"0x5"`;
 
 exports[`string > 1337 > hexadecimal > with casing = lower 1`] = `"0x5"`;
@@ -345,6 +395,16 @@ exports[`string > 1337 > numeric > with length parameter 5`] = `"30631"`;
 exports[`string > 1337 > numeric > with length range 1`] = `"512254032552"`;
 
 exports[`string > 1337 > numeric > with length, allowLeadingZeros and exclude 1`] = `"6706677"`;
+
+exports[`string > 1337 > octal > noArgs 1`] = `"0x2"`;
+
+exports[`string > 1337 > octal > with custom prefix 1`] = `"oct_2"`;
+
+exports[`string > 1337 > octal > with length 1`] = `"0x241124"`;
+
+exports[`string > 1337 > octal > with length range 1`] = `"0x411243021442"`;
+
+exports[`string > 1337 > octal > with length, casing and empty prefix 1`] = `"2411243"`;
 
 exports[`string > 1337 > sample > noArgs 1`] = `"9U/4:SK$>6"`;
 

--- a/test/__snapshots__/string.spec.ts.snap
+++ b/test/__snapshots__/string.spec.ts.snap
@@ -52,15 +52,15 @@ exports[`string > 42 > alphanumeric > with length range 1`] = `"NWbJMBB9r963sR"`
 
 exports[`string > 42 > alphanumeric > with length, casing and exclude 1`] = `"cvy4kvh"`;
 
-exports[`string > 42 > binary > noArgs 1`] = `"0x0"`;
+exports[`string > 42 > binary > noArgs 1`] = `"0b0"`;
 
 exports[`string > 42 > binary > with custom prefix 1`] = `"bin_0"`;
 
-exports[`string > 42 > binary > with length 1`] = `"0x011011"`;
+exports[`string > 42 > binary > with length 1`] = `"0b011011"`;
 
 exports[`string > 42 > binary > with length and empty prefix 1`] = `"0110111"`;
 
-exports[`string > 42 > binary > with length range 1`] = `"0x11011110000001"`;
+exports[`string > 42 > binary > with length range 1`] = `"0b11011110000001"`;
 
 exports[`string > 42 > hexadecimal > noArgs 1`] = `"0x8"`;
 
@@ -100,15 +100,15 @@ exports[`string > 42 > numeric > with length range 1`] = `"79177551410048"`;
 
 exports[`string > 42 > numeric > with length, allowLeadingZeros and exclude 1`] = `"6890887"`;
 
-exports[`string > 42 > octal > noArgs 1`] = `"0x2"`;
+exports[`string > 42 > octal > noArgs 1`] = `"0o2"`;
 
 exports[`string > 42 > octal > with custom prefix 1`] = `"oct_2"`;
 
-exports[`string > 42 > octal > with length 1`] = `"0x267156"`;
+exports[`string > 42 > octal > with length 1`] = `"0o267156"`;
 
 exports[`string > 42 > octal > with length and empty prefix 1`] = `"2671564"`;
 
-exports[`string > 42 > octal > with length range 1`] = `"0x67156441310036"`;
+exports[`string > 42 > octal > with length range 1`] = `"0o67156441310036"`;
 
 exports[`string > 42 > sample > noArgs 1`] = `"Cky2eiXX/J"`;
 
@@ -200,15 +200,15 @@ exports[`string > 1211 > alphanumeric > with length range 1`] = `"sTMd8Z2F9GdLql
 
 exports[`string > 1211 > alphanumeric > with length, casing and exclude 1`] = `"yexv53z"`;
 
-exports[`string > 1211 > binary > noArgs 1`] = `"0x1"`;
+exports[`string > 1211 > binary > noArgs 1`] = `"0b1"`;
 
 exports[`string > 1211 > binary > with custom prefix 1`] = `"bin_1"`;
 
-exports[`string > 1211 > binary > with length 1`] = `"0x101100"`;
+exports[`string > 1211 > binary > with length 1`] = `"0b101100"`;
 
 exports[`string > 1211 > binary > with length and empty prefix 1`] = `"1011001"`;
 
-exports[`string > 1211 > binary > with length range 1`] = `"0x01100101010100011101"`;
+exports[`string > 1211 > binary > with length range 1`] = `"0b01100101010100011101"`;
 
 exports[`string > 1211 > hexadecimal > noArgs 1`] = `"0xE"`;
 
@@ -248,15 +248,15 @@ exports[`string > 1211 > numeric > with length range 1`] = `"4872190616274316780
 
 exports[`string > 1211 > numeric > with length, allowLeadingZeros and exclude 1`] = `"9798609"`;
 
-exports[`string > 1211 > octal > noArgs 1`] = `"0x7"`;
+exports[`string > 1211 > octal > noArgs 1`] = `"0o7"`;
 
 exports[`string > 1211 > octal > with custom prefix 1`] = `"oct_7"`;
 
-exports[`string > 1211 > octal > with length 1`] = `"0x737611"`;
+exports[`string > 1211 > octal > with length 1`] = `"0o737611"`;
 
 exports[`string > 1211 > octal > with length and empty prefix 1`] = `"7376117"`;
 
-exports[`string > 1211 > octal > with length range 1`] = `"0x37611705151632155606"`;
+exports[`string > 1211 > octal > with length range 1`] = `"0o37611705151632155606"`;
 
 exports[`string > 1211 > sample > noArgs 1`] = `"wKti5-}$_/"`;
 
@@ -348,15 +348,15 @@ exports[`string > 1337 > alphanumeric > with length range 1`] = `"y9dhxs2jewAg"`
 
 exports[`string > 1337 > alphanumeric > with length, casing and exclude 1`] = `"ag45age"`;
 
-exports[`string > 1337 > binary > noArgs 1`] = `"0x0"`;
+exports[`string > 1337 > binary > noArgs 1`] = `"0b0"`;
 
 exports[`string > 1337 > binary > with custom prefix 1`] = `"bin_0"`;
 
-exports[`string > 1337 > binary > with length 1`] = `"0x010001"`;
+exports[`string > 1337 > binary > with length 1`] = `"0b010001"`;
 
 exports[`string > 1337 > binary > with length and empty prefix 1`] = `"0100010"`;
 
-exports[`string > 1337 > binary > with length range 1`] = `"0x100010000110"`;
+exports[`string > 1337 > binary > with length range 1`] = `"0b100010000110"`;
 
 exports[`string > 1337 > hexadecimal > noArgs 1`] = `"0x5"`;
 
@@ -396,15 +396,15 @@ exports[`string > 1337 > numeric > with length range 1`] = `"512254032552"`;
 
 exports[`string > 1337 > numeric > with length, allowLeadingZeros and exclude 1`] = `"6706677"`;
 
-exports[`string > 1337 > octal > noArgs 1`] = `"0x2"`;
+exports[`string > 1337 > octal > noArgs 1`] = `"0o2"`;
 
 exports[`string > 1337 > octal > with custom prefix 1`] = `"oct_2"`;
 
-exports[`string > 1337 > octal > with length 1`] = `"0x241124"`;
+exports[`string > 1337 > octal > with length 1`] = `"0o241124"`;
 
 exports[`string > 1337 > octal > with length and empty prefix 1`] = `"2411243"`;
 
-exports[`string > 1337 > octal > with length range 1`] = `"0x411243021442"`;
+exports[`string > 1337 > octal > with length range 1`] = `"0o411243021442"`;
 
 exports[`string > 1337 > sample > noArgs 1`] = `"9U/4:SK$>6"`;
 

--- a/test/__snapshots__/string.spec.ts.snap
+++ b/test/__snapshots__/string.spec.ts.snap
@@ -58,9 +58,9 @@ exports[`string > 42 > binary > with custom prefix 1`] = `"bin_0"`;
 
 exports[`string > 42 > binary > with length 1`] = `"0x011011"`;
 
-exports[`string > 42 > binary > with length range 1`] = `"0x11011110000001"`;
+exports[`string > 42 > binary > with length and empty prefix 1`] = `"0110111"`;
 
-exports[`string > 42 > binary > with length, casing and empty prefix 1`] = `"0110111"`;
+exports[`string > 42 > binary > with length range 1`] = `"0x11011110000001"`;
 
 exports[`string > 42 > hexadecimal > noArgs 1`] = `"0x8"`;
 
@@ -106,9 +106,9 @@ exports[`string > 42 > octal > with custom prefix 1`] = `"oct_2"`;
 
 exports[`string > 42 > octal > with length 1`] = `"0x267156"`;
 
-exports[`string > 42 > octal > with length range 1`] = `"0x67156441310036"`;
+exports[`string > 42 > octal > with length and empty prefix 1`] = `"2671564"`;
 
-exports[`string > 42 > octal > with length, casing and empty prefix 1`] = `"2671564"`;
+exports[`string > 42 > octal > with length range 1`] = `"0x67156441310036"`;
 
 exports[`string > 42 > sample > noArgs 1`] = `"Cky2eiXX/J"`;
 
@@ -206,9 +206,9 @@ exports[`string > 1211 > binary > with custom prefix 1`] = `"bin_1"`;
 
 exports[`string > 1211 > binary > with length 1`] = `"0x101100"`;
 
-exports[`string > 1211 > binary > with length range 1`] = `"0x01100101010100011101"`;
+exports[`string > 1211 > binary > with length and empty prefix 1`] = `"1011001"`;
 
-exports[`string > 1211 > binary > with length, casing and empty prefix 1`] = `"1011001"`;
+exports[`string > 1211 > binary > with length range 1`] = `"0x01100101010100011101"`;
 
 exports[`string > 1211 > hexadecimal > noArgs 1`] = `"0xE"`;
 
@@ -254,9 +254,9 @@ exports[`string > 1211 > octal > with custom prefix 1`] = `"oct_7"`;
 
 exports[`string > 1211 > octal > with length 1`] = `"0x737611"`;
 
-exports[`string > 1211 > octal > with length range 1`] = `"0x37611705151632155606"`;
+exports[`string > 1211 > octal > with length and empty prefix 1`] = `"7376117"`;
 
-exports[`string > 1211 > octal > with length, casing and empty prefix 1`] = `"7376117"`;
+exports[`string > 1211 > octal > with length range 1`] = `"0x37611705151632155606"`;
 
 exports[`string > 1211 > sample > noArgs 1`] = `"wKti5-}$_/"`;
 
@@ -354,9 +354,9 @@ exports[`string > 1337 > binary > with custom prefix 1`] = `"bin_0"`;
 
 exports[`string > 1337 > binary > with length 1`] = `"0x010001"`;
 
-exports[`string > 1337 > binary > with length range 1`] = `"0x100010000110"`;
+exports[`string > 1337 > binary > with length and empty prefix 1`] = `"0100010"`;
 
-exports[`string > 1337 > binary > with length, casing and empty prefix 1`] = `"0100010"`;
+exports[`string > 1337 > binary > with length range 1`] = `"0x100010000110"`;
 
 exports[`string > 1337 > hexadecimal > noArgs 1`] = `"0x5"`;
 
@@ -402,9 +402,9 @@ exports[`string > 1337 > octal > with custom prefix 1`] = `"oct_2"`;
 
 exports[`string > 1337 > octal > with length 1`] = `"0x241124"`;
 
-exports[`string > 1337 > octal > with length range 1`] = `"0x411243021442"`;
+exports[`string > 1337 > octal > with length and empty prefix 1`] = `"2411243"`;
 
-exports[`string > 1337 > octal > with length, casing and empty prefix 1`] = `"2411243"`;
+exports[`string > 1337 > octal > with length range 1`] = `"0x411243021442"`;
 
 exports[`string > 1337 > sample > noArgs 1`] = `"9U/4:SK$>6"`;
 

--- a/test/string.spec.ts
+++ b/test/string.spec.ts
@@ -39,6 +39,28 @@ describe('string', () => {
         });
     });
 
+    t.describe('binary', (t) => {
+      t.it('noArgs')
+        .it('with length', { length: 6 })
+        .it('with length range', { length: { min: 10, max: 20 } })
+        .it('with custom prefix', { prefix: 'bin_' })
+        .it('with length, casing and empty prefix', {
+          length: 7,
+          prefix: '',
+        });
+    });
+
+    t.describe('octal', (t) => {
+      t.it('noArgs')
+        .it('with length', { length: 6 })
+        .it('with length range', { length: { min: 10, max: 20 } })
+        .it('with custom prefix', { prefix: 'oct_' })
+        .it('with length, casing and empty prefix', {
+          length: 7,
+          prefix: '',
+        });
+    });
+
     t.describe('hexadecimal', (t) => {
       t.it('noArgs')
         .it('with length', { length: 6 })
@@ -341,6 +363,84 @@ describe('string', () => {
 
           expect(() => faker.string.alphanumeric(input)).not.toThrow();
           expect(input.exclude).toEqual(['a', '0', '%']);
+        });
+      });
+
+      describe(`binary`, () => {
+        it('generates a single binary character when no additional argument was provided', () => {
+          const binary = faker.string.binary();
+          expect(binary).toMatch(/^0x[01]*$/i);
+          expect(binary).toHaveLength(3);
+        });
+
+        it('generates a random binary string with fixed length and no prefix', () => {
+          const binary = faker.string.binary({
+            length: 5,
+            prefix: '',
+          });
+          expect(binary).toMatch(/^[01]*$/i);
+          expect(binary).toHaveLength(5);
+        });
+
+        it.each([0, -1, -100])(
+          'should return the prefix when length is <= 0',
+          (length) => {
+            const binary = faker.string.binary({ length });
+
+            expect(binary).toBe('0x');
+          }
+        );
+
+        it('should return a binary string with a random amount of characters and no prefix', () => {
+          const binary = faker.string.binary({
+            length: { min: 10, max: 20 },
+            prefix: '',
+          });
+
+          expect(binary).toBeDefined();
+          expect(binary).toBeTypeOf('string');
+
+          expect(binary.length).toBeGreaterThanOrEqual(10);
+          expect(binary.length).toBeLessThanOrEqual(20);
+        });
+      });
+
+      describe(`octal`, () => {
+        it('generates single octal character when no additional argument was provided', () => {
+          const octal = faker.string.octal();
+          expect(octal).toMatch(/^0x[0-7]*$/i);
+          expect(octal).toHaveLength(3);
+        });
+
+        it('generates a random octal string with fixed length and no prefix', () => {
+          const octal = faker.string.octal({
+            length: 5,
+            prefix: '',
+          });
+          expect(octal).toMatch(/^[0-7]*$/i);
+          expect(octal).toHaveLength(5);
+        });
+
+        it.each([0, -1, -100])(
+          'should return the prefix when length is <= 0',
+          (length) => {
+            const octal = faker.string.octal({ length });
+
+            expect(octal).toBe('0x');
+          }
+        );
+
+        it('should return an octal string with a random amount of characters and no prefix', () => {
+          const octal = faker.string.octal({
+            length: { min: 10, max: 20 },
+            prefix: '',
+          });
+
+          expect(octal).toBeDefined();
+          expect(octal).toBeTypeOf('string');
+
+          expect(octal.length).toBeGreaterThanOrEqual(10);
+          expect(octal.length).toBeLessThanOrEqual(20);
         });
       });
 

--- a/test/string.spec.ts
+++ b/test/string.spec.ts
@@ -44,7 +44,7 @@ describe('string', () => {
         .it('with length', { length: 6 })
         .it('with length range', { length: { min: 10, max: 20 } })
         .it('with custom prefix', { prefix: 'bin_' })
-        .it('with length, casing and empty prefix', {
+        .it('with length and empty prefix', {
           length: 7,
           prefix: '',
         });
@@ -55,7 +55,7 @@ describe('string', () => {
         .it('with length', { length: 6 })
         .it('with length range', { length: { min: 10, max: 20 } })
         .it('with custom prefix', { prefix: 'oct_' })
-        .it('with length, casing and empty prefix', {
+        .it('with length and empty prefix', {
           length: 7,
           prefix: '',
         });

--- a/test/string.spec.ts
+++ b/test/string.spec.ts
@@ -369,7 +369,7 @@ describe('string', () => {
       describe(`binary`, () => {
         it('generates a single binary character when no additional argument was provided', () => {
           const binary = faker.string.binary();
-          expect(binary).toMatch(/^0x[01]$/i);
+          expect(binary).toMatch(/^0b[01]$/i);
           expect(binary).toHaveLength(3);
         });
 
@@ -387,7 +387,7 @@ describe('string', () => {
           (length) => {
             const binary = faker.string.binary({ length });
 
-            expect(binary).toBe('0x');
+            expect(binary).toBe('0b');
           }
         );
 
@@ -408,7 +408,7 @@ describe('string', () => {
       describe(`octal`, () => {
         it('generates single octal character when no additional argument was provided', () => {
           const octal = faker.string.octal();
-          expect(octal).toMatch(/^0x[0-7]$/i);
+          expect(octal).toMatch(/^0o[0-7]$/i);
           expect(octal).toHaveLength(3);
         });
 
@@ -426,7 +426,7 @@ describe('string', () => {
           (length) => {
             const octal = faker.string.octal({ length });
 
-            expect(octal).toBe('0x');
+            expect(octal).toBe('0o');
           }
         );
 

--- a/test/string.spec.ts
+++ b/test/string.spec.ts
@@ -369,7 +369,7 @@ describe('string', () => {
       describe(`binary`, () => {
         it('generates a single binary character when no additional argument was provided', () => {
           const binary = faker.string.binary();
-          expect(binary).toMatch(/^0x[01]*$/i);
+          expect(binary).toMatch(/^0x[01]$/i);
           expect(binary).toHaveLength(3);
         });
 
@@ -408,7 +408,7 @@ describe('string', () => {
       describe(`octal`, () => {
         it('generates single octal character when no additional argument was provided', () => {
           const octal = faker.string.octal();
-          expect(octal).toMatch(/^0x[0-7]*$/i);
+          expect(octal).toMatch(/^0x[0-7]$/i);
           expect(octal).toHaveLength(3);
         });
 


### PR DESCRIPTION
This PR implements binary and octal random string generation.

Issue: https://github.com/faker-js/faker/issues/184

PR that implements this feature in number module: https://github.com/faker-js/faker/pull/1708