### PR TITLE
test: use basic reporter

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       reporter: ['clover', 'cobertura', 'lcov', 'text'],
       include: ['src'],
     },
+    reporters: 'basic',
     onConsoleLog(log, type) {
       if (
         type === 'stderr' &&


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->

closes #1635 

This fixes running tests locally
The previous default reporter cleared the console log everytime when to much is going on in the console
But this results in issues with to many tests and it hangs
So this new reporter do what would be done when `CI=true` would be configured and will not clear the screen anymore
IMO this is even a better UX