### PR TITLE
docs: big api button

### DIFF
--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -13,3 +13,8 @@ table td ul li {
 .nav-bar-title .logo {
   min-height: 2rem;
 }
+
+.VPHero .action:not(:last-child) a.VPButton.alt {
+  border-color: var(--vp-button-brand-border) !important;
+  color: var(--vp-button-brand-border) !important;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,9 @@ hero:
     - theme: brand
       text: Get Started
       link: /guide/
+    - theme: brand
+      text: View API
+      link: /api/
     - theme: alt
       text: View on GitHub
       link: https://github.com/faker-js/faker

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ hero:
       text: Get Started
       link: /guide/
     - theme: alt
-      text: View API Index
+      text: Browse API
       link: /api/
     - theme: alt
       text: View on GitHub

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ hero:
     - theme: brand
       text: Get Started
       link: /guide/
-    - theme: brand
+    - theme: alt
       text: View API Index
       link: /api/
     - theme: alt

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ hero:
       text: Get Started
       link: /guide/
     - theme: brand
-      text: View API
+      text: View API Index
       link: /api/
     - theme: alt
       text: View on GitHub


### PR DESCRIPTION
When visiting the fakerjs.dev website I usually want to access the `API` overview page.
However the API button is only very small in the top-bar or via Guide->Api.
This PR adds a big colorful `View API` button to the center of the screen.

![grafik](https://user-images.githubusercontent.com/1579362/214167182-ae08761c-88d0-4e67-afb5-989af99e2da6.png)

Unfortunately, it isn't possible to use a different color than `Get Started` (and `View On Github`).