### PR TITLE
chore: fix missing defaultRefDate calls

### DIFF
--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -370,8 +370,8 @@ export class DateModule {
 
     const { from, to } = options;
 
-    const fromMs = toDate(from).getTime();
-    const toMs = toDate(to).getTime();
+    const fromMs = toDate(from, this.faker.defaultRefDate).getTime();
+    const toMs = toDate(to, this.faker.defaultRefDate).getTime();
     const dateOffset = this.faker.number.int(toMs - fromMs);
 
     return new Date(fromMs + dateOffset);
@@ -948,7 +948,7 @@ export class DateModule {
     } = {}
   ): Date {
     const mode = options.mode === 'age' ? 'age' : 'year';
-    const refDate = toDate(options.refDate);
+    const refDate = toDate(options.refDate, this.faker.defaultRefDate);
     const refYear = refDate.getUTCFullYear();
 
     // If no min or max is specified, generate a random date between (now - 80) years and (now - 18) years respectively

--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -11,8 +11,8 @@ import { deprecated } from '../../internal/deprecated';
  * @param fallback The fallback date to use if the passed date is not valid.
  */
 function toDate(
-  date?: string | Date | number,
-  fallback: () => Date = () => new Date()
+  date: string | Date | number | undefined,
+  fallback: () => Date
 ): Date {
   date = new Date(date);
   if (isNaN(date.valueOf())) {


### PR DESCRIPTION
It looks like I missed some `toDate` calls in #1757

(Found via `docs:diff` (#1755))