### PR TITLE
chore: remove disturbing image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The API covers the following modules:
 | Git      | `faker.git.commitMessage()`                   | feat: add products list page                                                                       |
 | Hacker   | `faker.hacker.phrase()`                       | Try to reboot the SQL bus, maybe it will bypass the virtual application!                           |
 | Helpers  | `faker.helpers.arrayElement(['a', 'b', 'c'])` | b                                                                                                  |
-| Image    | `faker.image.cats()`                          | https://loremflickr.com/640/480/cats <img src="https://loremflickr.com/640/480/cats" height="100"> |
+| Image    | `faker.image.url()`                           | https://picsum.photos/id/165/640/480 <img src="https://picsum.photos/id/165/640/480" height="100"> |
 | Internet | `faker.internet.domainName()`                 | muddy-neuropathologist.net                                                                         |
 | Location | `faker.location.city()`                       | Lake Raoulfort                                                                                     |
 | Lorem    | `faker.lorem.paragraph()`                     | Porro nulla id vero perspiciatis nulla nihil. ...                                                  |


### PR DESCRIPTION
The image shown on the [README](https://github.com/faker-js/faker/blob/95d0765caaf882c87064cbbeae5399a2582b7f9d/README.md#-modules) is disturbing and needs to be removed ASAP.

<details>
<summary>Screenshot (Click to show)</summary>

![grafik](https://user-images.githubusercontent.com/1579362/214709470-aeb6b83a-fa25-4295-8ed4-2da415aceace.png)

</details>

The image is static and no longer random.
~~I assume this is intentional from loremflickr to prevent the usage on github.~~ 
Correction: Github Image Cache + Bad Luck
Reproducible in Firefox (normal, mobile and private mode), Chrome.

I also consider removing loremflickr from our image providers entirely, since having that image in a presentation with a customer is an absolute no go 🙅 .