### PR TITLE
test(system): add valid 0 for cron

### DIFF
--- a/test/system.spec.ts
+++ b/test/system.spec.ts
@@ -407,11 +407,11 @@ describe('system', () => {
           }
         );
 
-        it('should return non-standard cron expressions', () => {
+        it('should be able to return non-standard cron expressions', () => {
           const validResults = [...'0123456789'.split(''), '*', '@'];
           expect(
             faker.system.cron({ includeNonStandard: true })[0],
-            'generated cron, string should contain non-standard cron labels'
+            'generated cron, string should contain standard or non-standard cron labels'
           ).toSatisfy(
             (value) => !!validResults.find((result) => value === result)
           );

--- a/test/system.spec.ts
+++ b/test/system.spec.ts
@@ -408,7 +408,7 @@ describe('system', () => {
         );
 
         it('should return non-standard cron expressions', () => {
-          const validResults = ['1', '2', '3', '4', '5', '6', '*', '@'];
+          const validResults = ['0', '1', '2', '3', '4', '5', '6', '*', '@'];
           expect(
             faker.system.cron({ includeNonStandard: true })[0],
             'generated cron, string should contain non-standard cron labels'

--- a/test/system.spec.ts
+++ b/test/system.spec.ts
@@ -408,7 +408,7 @@ describe('system', () => {
         );
 
         it('should return non-standard cron expressions', () => {
-          const validResults = ['0', '1', '2', '3', '4', '5', '6', '*', '@'];
+          const validResults = [...'0123456789'.split(''), '*', '@'];
           expect(
             faker.system.cron({ includeNonStandard: true })[0],
             'generated cron, string should contain non-standard cron labels'


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->

While working on
- #1645 

it reports an failure for https://github.com/faker-js/faker/actions/runs/4025222101/jobs/6918173202#step:7:302

but `0` is a valid digit for cron