### PR TITLE
docs: fix see also for non faker.x references

### DIFF
--- a/docs/.vitepress/components/api-docs/method.vue
+++ b/docs/.vitepress/components/api-docs/method.vue
@@ -44,7 +44,7 @@ function seeAlsoToUrl(see: string): string {
             :href="seeAlsoToUrl(seeAlso)"
             v-html="seeAlso"
           />
-          <template v-else v-html="seeAlso" />
+          <div v-else v-html="seeAlso" />
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Found in https://github.com/faker-js/faker/pull/1790#discussion_r1090060316

In vue `<template>` tags aren't rendered. So we have to use div instead.

Thanks to @Shinigami92 for helping to fix this issue.

