### PR TITLE
test: configure chai truncated threshold

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,3 @@
+import { chai } from 'vitest';
+
+chai.config.truncateThreshold = 10000;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ console.log('VITEST_SEQUENCE_SEED', VITEST_SEQUENCE_SEED);
 // https://vitejs.dev/config/
 export default defineConfig({
   test: {
+    setupFiles: ['test/setup.ts'],
     coverage: {
       all: true,
       reporter: ['clover', 'cobertura', 'lcov', 'text'],


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->

Based on https://github.com/vitest-dev/vitest/issues/2791

Set the threshold to a high value so expected values for e.g. toMatch will not get trimmed

This helps debugging failing tests