### PR TITLE
fix(person): avoid repeated double last name in some locales

### DIFF
--- a/src/locales/en_GH/person/name.ts
+++ b/src/locales/en_GH/person/name.ts
@@ -1,7 +1,7 @@
 export default [
   { value: '{{person.firstName}} {{person.lastName}}', weight: 1 },
   {
-    value: '{{person.firstName}} {{person.lastName}}-{{person.lastName}}',
+    value: '{{person.firstName}} {{person.lastName}}-{{person.lastName2}}',
     weight: 1,
   },
 ];

--- a/src/locales/es/person/name.ts
+++ b/src/locales/es/person/name.ts
@@ -1,11 +1,11 @@
 export default [
   {
     value:
-      '{{person.prefix}} {{person.firstName}} {{person.lastName}} {{person.lastName}}',
+      '{{person.prefix}} {{person.firstName}} {{person.lastName}} {{person.lastName2}}',
     weight: 1,
   },
   {
-    value: '{{person.firstName}} {{person.lastName}} {{person.lastName}}',
+    value: '{{person.firstName}} {{person.lastName}} {{person.lastName2}}',
     weight: 9,
   },
 ];

--- a/src/locales/es_MX/person/name.ts
+++ b/src/locales/es_MX/person/name.ts
@@ -1,20 +1,20 @@
 export default [
   {
     value:
-      '{{person.prefix}} {{person.firstName}} {{person.lastName}} {{person.lastName}}',
+      '{{person.prefix}} {{person.firstName}} {{person.lastName}} {{person.lastName2}}',
     weight: 1,
   },
   {
-    value: '{{person.firstName}} {{person.lastName}} de {{person.lastName}}',
+    value: '{{person.firstName}} {{person.lastName}} de {{person.lastName2}}',
     weight: 3,
   },
   {
     value:
-      '{{person.suffix}} {{person.firstName}} {{person.lastName}} {{person.lastName}}',
+      '{{person.suffix}} {{person.firstName}} {{person.lastName}} {{person.lastName2}}',
     weight: 1,
   },
   {
-    value: '{{person.firstName}} {{person.lastName}} {{person.lastName}}',
+    value: '{{person.firstName}} {{person.lastName}} {{person.lastName2}}',
     weight: 5,
   },
 ];

--- a/src/locales/lv/person/name.ts
+++ b/src/locales/lv/person/name.ts
@@ -14,7 +14,7 @@ export default [
     weight: 2,
   },
   {
-    value: '{{person.firstName}} {{person.lastName}}-{{person.lastName}}',
+    value: '{{person.firstName}} {{person.lastName}}-{{person.lastName2}}',
     weight: 2,
   },
 ];

--- a/src/locales/nb_NO/person/name.ts
+++ b/src/locales/nb_NO/person/name.ts
@@ -8,11 +8,11 @@ export default [
     weight: 1,
   },
   {
-    value: '{{person.firstName}} {{person.firstName}} {{person.lastName}}',
+    value: '{{person.firstName}} {{person.firstName}} {{person.lastName2}}',
     weight: 1,
   },
   {
-    value: '{{person.firstName}} {{person.lastName}} {{person.lastName}}',
+    value: '{{person.firstName}} {{person.lastName}} {{person.lastName2}}',
     weight: 1,
   },
   { value: '{{person.firstName}} {{person.lastName}}', weight: 8 },

--- a/src/locales/sv/person/name.ts
+++ b/src/locales/sv/person/name.ts
@@ -9,7 +9,7 @@ export default [
   },
   { value: '{{person.firstName}} {{person.lastName}}', weight: 8 },
   {
-    value: '{{person.firstName}} {{person.lastName}} {{person.lastName}}',
+    value: '{{person.firstName}} {{person.lastName}} {{person.lastName2}}',
     weight: 1,
   },
 ];

--- a/src/modules/person/index.ts
+++ b/src/modules/person/index.ts
@@ -190,12 +190,16 @@ export class PersonModule {
     const fullNamePattern: string = this.faker.helpers.weightedArrayElement(
       this.faker.definitions.person.name
     );
+    const lastName2 = fullNamePattern.includes('{{person.lastName2}}')
+      ? this.lastName(sex)
+      : '';
 
     const fullName = this.faker.helpers.mustache(fullNamePattern, {
       'person.prefix': () => this.prefix(sex),
       'person.firstName': () => firstName,
       'person.middleName': () => this.middleName(sex),
       'person.lastName': () => lastName,
+      'person.lastName2': () => lastName2,
       'person.suffix': () => this.suffix(),
     });
     return fullName;


### PR DESCRIPTION
fix #1817 

Since faker.mustache will always replace the same placeholder with the same name, tried introducing lastName2

If you have any better ideas for this let me know.

Note this affects #691 (the hyphenated patterns discussed there are already used in some locales)