### PR TITLE
fix(person): fix duplicate last names in full name generation

### DIFF
--- a/src/modules/person/index.ts
+++ b/src/modules/person/index.ts
@@ -183,8 +183,8 @@ export class PersonModule {
   ): string {
     const {
       sex = this.faker.helpers.arrayElement([Sex.Female, Sex.Male]),
-      firstName = this.firstName(sex),
-      lastName = this.lastName(sex),
+      firstName,
+      lastName,
     } = options;
 
     const fullNamePattern: string = this.faker.helpers.weightedArrayElement(
@@ -193,9 +193,9 @@ export class PersonModule {
 
     const fullName = this.faker.helpers.mustache(fullNamePattern, {
       'person.prefix': () => this.prefix(sex),
-      'person.firstName': () => firstName,
+      'person.firstName': () => firstName ?? this.firstName(sex),
       'person.middleName': () => this.middleName(sex),
-      'person.lastName': () => lastName,
+      'person.lastName': () => lastName ?? this.lastName(sex),
       'person.suffix': () => this.suffix(),
     });
     return fullName;

--- a/test/__snapshots__/person.spec.ts.snap
+++ b/test/__snapshots__/person.spec.ts.snap
@@ -6,15 +6,15 @@ exports[`person > 42 > firstName > noArgs 1`] = `"Garnet"`;
 
 exports[`person > 42 > firstName > with sex 1`] = `"Glen"`;
 
-exports[`person > 42 > fullName > noArgs 1`] = `"Sadie Wiegand"`;
+exports[`person > 42 > fullName > noArgs 1`] = `"Dr. Tina Reynolds"`;
 
 exports[`person > 42 > fullName > with all (sex) 1`] = `"John Doe"`;
 
-exports[`person > 42 > fullName > with firstName 1`] = `"John Schinner I"`;
+exports[`person > 42 > fullName > with firstName 1`] = `"Dr. John Deckow"`;
 
-exports[`person > 42 > fullName > with lastName 1`] = `"Sadie Doe I"`;
+exports[`person > 42 > fullName > with lastName 1`] = `"Dr. Tina Doe"`;
 
-exports[`person > 42 > fullName > with sex 1`] = `"Melanie Schinner I"`;
+exports[`person > 42 > fullName > with sex 1`] = `"Sadie Wiegand"`;
 
 exports[`person > 42 > gender 1`] = `"Gender nonconforming"`;
 
@@ -56,15 +56,15 @@ exports[`person > 1211 > firstName > noArgs 1`] = `"Tito"`;
 
 exports[`person > 1211 > firstName > with sex 1`] = `"Percy"`;
 
-exports[`person > 1211 > fullName > noArgs 1`] = `"Mr. Claude Trantow"`;
+exports[`person > 1211 > fullName > noArgs 1`] = `"Darrel Satterfield"`;
 
 exports[`person > 1211 > fullName > with all (sex) 1`] = `"John Doe IV"`;
 
-exports[`person > 1211 > fullName > with firstName 1`] = `"John Koelpin DDS"`;
+exports[`person > 1211 > fullName > with firstName 1`] = `"John Trantow"`;
 
-exports[`person > 1211 > fullName > with lastName 1`] = `"Claude Doe DDS"`;
+exports[`person > 1211 > fullName > with lastName 1`] = `"Darrel Doe"`;
 
-exports[`person > 1211 > fullName > with sex 1`] = `"Patti Koelpin DDS"`;
+exports[`person > 1211 > fullName > with sex 1`] = `"Joy Trantow DDS"`;
 
 exports[`person > 1211 > gender 1`] = `"Trigender"`;
 
@@ -106,15 +106,15 @@ exports[`person > 1337 > firstName > noArgs 1`] = `"Devyn"`;
 
 exports[`person > 1337 > firstName > with sex 1`] = `"Ray"`;
 
-exports[`person > 1337 > fullName > noArgs 1`] = `"Leona Cronin"`;
+exports[`person > 1337 > fullName > noArgs 1`] = `"Marilyn Effertz"`;
 
 exports[`person > 1337 > fullName > with all (sex) 1`] = `"John Doe"`;
 
-exports[`person > 1337 > fullName > with firstName 1`] = `"John MacGyver"`;
+exports[`person > 1337 > fullName > with firstName 1`] = `"John Cronin"`;
 
-exports[`person > 1337 > fullName > with lastName 1`] = `"Leona Doe"`;
+exports[`person > 1337 > fullName > with lastName 1`] = `"Marilyn Doe"`;
 
-exports[`person > 1337 > fullName > with sex 1`] = `"Esther MacGyver"`;
+exports[`person > 1337 > fullName > with sex 1`] = `"Leona Cronin"`;
 
 exports[`person > 1337 > gender 1`] = `"Demigender"`;
 


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->
Fixes #1817 

#### As Is
`faker.person.fullName` uses mustache templates from each locale to generate a full name. When the template contains multiple last names, the same last name is repeated. Same bug happens to multiple first names. This is because `firstName` and `lastName` are generated before the template replacement unlike `middleName` or `suffix` which are generated on demand.

#### To Be
Make `firstName` and `lastName` get generated on demand similar to `middleName`. Only fallback to `options.firstName` and `options.lastName` when those are supplied.

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->
