### PR TITLE
test(date): add birthdate error test

### DIFF
--- a/test/date.spec.ts
+++ b/test/date.spec.ts
@@ -558,6 +558,19 @@ describe('date', () => {
             new Date().getUTCFullYear() - min
           );
         });
+
+        it('should throw an error when the min > max year', () => {
+          const min = 2000;
+          const max = 1990;
+
+          expect(() =>
+            faker.date.birthdate({ min, max, mode: 'year' })
+          ).toThrow(
+            new FakerError(
+              `Max 662515200000 should be larger then min 946771200000.`
+            )
+          );
+        });
       });
 
       describe('deprecated', () => {


### PR DESCRIPTION
<!-- Please first read https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/verify-semantic-pull-requests/CONTRIBUTING.md#committing -->

Adds a birthdate test that throws an error when the min is larger than the max year.