### PR TITLE
fix: correct types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",
-  "types": "index.d.ts",
+  "types": "dist/types/index.d.ts",
   "typesVersions": {
     ">=4.0": {
       "*": [


### PR DESCRIPTION
<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->

fixing: https://publint.dev/@faker-js/faker@7.6.0

There is no `index.d.ts`
Everything is packaged into the dist folder
This might only affect users using TS + an old npm version that doesn't know the `exports` field