### PR TITLE
fix(currency): modernise currency list for 2023

### DIFF
--- a/src/locales/en/finance/currency.ts
+++ b/src/locales/en/finance/currency.ts
@@ -160,11 +160,6 @@ export default [
     symbol: '₱',
   },
   {
-    name: 'Cuban Peso Convertible',
-    code: 'CUC',
-    symbol: '$',
-  },
-  {
     name: 'Cape Verde Escudo',
     code: 'CVE',
     symbol: '',
@@ -192,11 +187,6 @@ export default [
   {
     name: 'Algerian Dinar',
     code: 'DZD',
-    symbol: '',
-  },
-  {
-    name: 'Kroon',
-    code: 'EEK',
     symbol: '',
   },
   {
@@ -278,11 +268,6 @@ export default [
     name: 'Lempira',
     code: 'HNL',
     symbol: 'L',
-  },
-  {
-    name: 'Croatian Kuna',
-    code: 'HRK',
-    symbol: 'kn',
   },
   {
     name: 'Gourde',
@@ -410,16 +395,6 @@ export default [
     symbol: '$',
   },
   {
-    name: 'Lithuanian Litas',
-    code: 'LTL',
-    symbol: 'Lt',
-  },
-  {
-    name: 'Latvian Lats',
-    code: 'LVL',
-    symbol: 'Ls',
-  },
-  {
     name: 'Libyan Dinar',
     code: 'LYD',
     symbol: '',
@@ -461,7 +436,7 @@ export default [
   },
   {
     name: 'Ouguiya',
-    code: 'MRO',
+    code: 'MRU',
     symbol: '',
   },
   {
@@ -621,7 +596,7 @@ export default [
   },
   {
     name: 'Leone',
-    code: 'SLL',
+    code: 'SLE',
     symbol: '',
   },
   {
@@ -635,14 +610,14 @@ export default [
     symbol: '$',
   },
   {
+    name: 'South Sudanese pound',
+    code: 'SSP',
+    symbol: '',
+  },
+  {
     name: 'Dobra',
     code: 'STN',
     symbol: 'Db',
-  },
-  {
-    name: 'El Salvador Colon',
-    code: 'SVC',
-    symbol: '₡',
   },
   {
     name: 'Syrian Pound',
@@ -750,49 +725,9 @@ export default [
     symbol: '',
   },
   {
-    name: 'Silver',
-    code: 'XAG',
-    symbol: '',
-  },
-  {
-    name: 'Gold',
-    code: 'XAU',
-    symbol: '',
-  },
-  {
-    name: 'Bond Markets Units European Composite Unit (EURCO)',
-    code: 'XBA',
-    symbol: '',
-  },
-  {
-    name: 'European Monetary Unit (E.M.U.-6)',
-    code: 'XBB',
-    symbol: '',
-  },
-  {
-    name: 'European Unit of Account 9(E.U.A.-9)',
-    code: 'XBC',
-    symbol: '',
-  },
-  {
-    name: 'European Unit of Account 17(E.U.A.-17)',
-    code: 'XBD',
-    symbol: '',
-  },
-  {
     name: 'East Caribbean Dollar',
     code: 'XCD',
     symbol: '$',
-  },
-  {
-    name: 'SDR',
-    code: 'XDR',
-    symbol: '',
-  },
-  {
-    name: 'UIC-Franc',
-    code: 'XFU',
-    symbol: '',
   },
   {
     name: 'CFA Franc BCEAO',
@@ -800,23 +735,8 @@ export default [
     symbol: '',
   },
   {
-    name: 'Palladium',
-    code: 'XPD',
-    symbol: '',
-  },
-  {
     name: 'CFP Franc',
     code: 'XPF',
-    symbol: '',
-  },
-  {
-    name: 'Platinum',
-    code: 'XPT',
-    symbol: '',
-  },
-  {
-    name: 'Codes specifically reserved for testing purposes',
-    code: 'XTS',
     symbol: '',
   },
   {

--- a/test/__snapshots__/finance.spec.ts.snap
+++ b/test/__snapshots__/finance.spec.ts.snap
@@ -46,17 +46,17 @@ exports[`finance > 42 > creditCardNumber > with issuer option 1`] = `"4791775514
 
 exports[`finance > 42 > currency 1`] = `
 {
-  "code": "IQD",
-  "name": "Iraqi Dinar",
-  "symbol": "",
+  "code": "ILS",
+  "name": "New Israeli Sheqel",
+  "symbol": "₪",
 }
 `;
 
-exports[`finance > 42 > currencyCode 1`] = `"IQD"`;
+exports[`finance > 42 > currencyCode 1`] = `"ILS"`;
 
-exports[`finance > 42 > currencyName 1`] = `"Iraqi Dinar"`;
+exports[`finance > 42 > currencyName 1`] = `"New Israeli Sheqel"`;
 
-exports[`finance > 42 > currencySymbol 1`] = `"₱"`;
+exports[`finance > 42 > currencySymbol 1`] = `"₪"`;
 
 exports[`finance > 42 > ethereumAddress 1`] = `"0x8be4abdd39321ad7d3fe01ffce404f4d6db0906b"`;
 
@@ -96,7 +96,7 @@ exports[`finance > 42 > pin > with length option 1`] = `"3791775514"`;
 
 exports[`finance > 42 > routingNumber 1`] = `"379177554"`;
 
-exports[`finance > 42 > transactionDescription 1`] = `"invoice transaction at Wiegand, Deckow and Reynolds using card ending with ***(...8361) for SDG 374.54 in account ***55141004"`;
+exports[`finance > 42 > transactionDescription 1`] = `"invoice transaction at Wiegand, Deckow and Reynolds using card ending with ***(...8361) for RSD 374.54 in account ***55141004"`;
 
 exports[`finance > 42 > transactionType 1`] = `"withdrawal"`;
 
@@ -146,17 +146,17 @@ exports[`finance > 1211 > creditCardNumber > with issuer option 1`] = `"4487-219
 
 exports[`finance > 1211 > currency 1`] = `
 {
-  "code": "XDR",
-  "name": "SDR",
+  "code": "VUV",
+  "name": "Vatu",
   "symbol": "",
 }
 `;
 
-exports[`finance > 1211 > currencyCode 1`] = `"XDR"`;
+exports[`finance > 1211 > currencyCode 1`] = `"VUV"`;
 
-exports[`finance > 1211 > currencyName 1`] = `"SDR"`;
+exports[`finance > 1211 > currencyName 1`] = `"Vatu"`;
 
-exports[`finance > 1211 > currencySymbol 1`] = `"₭"`;
+exports[`finance > 1211 > currencySymbol 1`] = `"₩"`;
 
 exports[`finance > 1211 > ethereumAddress 1`] = `"0xeadb42f0e3f4a973fab0aeefce96dfcf49cd438d"`;
 
@@ -196,7 +196,7 @@ exports[`finance > 1211 > pin > with length option 1`] = `"9487219061"`;
 
 exports[`finance > 1211 > routingNumber 1`] = `"948721904"`;
 
-exports[`finance > 1211 > transactionDescription 1`] = `"deposit transaction at Trantow - Satterfield using card ending with ***(...4316) for STN 928.52 in account ***19061627"`;
+exports[`finance > 1211 > transactionDescription 1`] = `"deposit transaction at Trantow - Satterfield using card ending with ***(...4316) for SDG 928.52 in account ***19061627"`;
 
 exports[`finance > 1211 > transactionType 1`] = `"invoice"`;
 
@@ -246,15 +246,15 @@ exports[`finance > 1337 > creditCardNumber > with issuer option 1`] = `"45122540
 
 exports[`finance > 1337 > currency 1`] = `
 {
-  "code": "FJD",
-  "name": "Fiji Dollar",
-  "symbol": "$",
+  "code": "ETB",
+  "name": "Ethiopian Birr",
+  "symbol": "",
 }
 `;
 
-exports[`finance > 1337 > currencyCode 1`] = `"FJD"`;
+exports[`finance > 1337 > currencyCode 1`] = `"ETB"`;
 
-exports[`finance > 1337 > currencyName 1`] = `"Fiji Dollar"`;
+exports[`finance > 1337 > currencyName 1`] = `"Ethiopian Birr"`;
 
 exports[`finance > 1337 > currencySymbol 1`] = `"$"`;
 
@@ -296,6 +296,6 @@ exports[`finance > 1337 > pin > with length option 1`] = `"2512254032"`;
 
 exports[`finance > 1337 > routingNumber 1`] = `"251225401"`;
 
-exports[`finance > 1337 > transactionDescription 1`] = `"withdrawal transaction at Cronin - Effertz using card ending with ***(...3927) for GTQ 262.02 in account ***54032552"`;
+exports[`finance > 1337 > transactionDescription 1`] = `"withdrawal transaction at Cronin - Effertz using card ending with ***(...3927) for GIP 262.02 in account ***54032552"`;
 
 exports[`finance > 1337 > transactionType 1`] = `"withdrawal"`;

--- a/test/__snapshots__/random.spec.ts.snap
+++ b/test/__snapshots__/random.spec.ts.snap
@@ -42,7 +42,7 @@ exports[`random > 1211 > words > noArgs 1`] = `"invoice Cyclocross assail"`;
 
 exports[`random > 1211 > words > with length 1`] = `"gah strictly Rustic assail Manager"`;
 
-exports[`random > 1211 > words > with length range 1`] = `"invoice Cyclocross assail Manager New"`;
+exports[`random > 1211 > words > with length range 1`] = `"invoice Cyclocross assail Manager Gourde"`;
 
 exports[`random > 1337 > alpha > noArgs 1`] = `"n"`;
 


### PR DESCRIPTION
fix #1879 

Removals
- CUC (Cuban Peso Convertible, phased out 2021)
- EEK (Estonian kroon, replaced by EUR in 2010)
- HKR (Croatian Kuna, replace by EUR in 2023)
- LTL (Lithuanian litas, replaced by EUR in 2015)
- LVL (Latvian lats, replaced by EUR in 2013)
- SVC (El Savador colon, replaced by USD in 2001)
- XAG, XAU, XPD, XPT - precious metals
- XTS - testing code
- XBA, XBB, XBC, XBD - bond market units
- XDR - special drawing rights
- XFU - special settlement currency withdrawn 1990

Changes
- MRO (Mauritanian ouguiya, replaced by MRU in 2018)
- SLL (Sierra Leonean leone, replaced by SLE in 2022)

Additions
- SSP (South Sudanese pound, introduced 2011)
