### PR TITLE
docs: update top section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,17 @@
   [![Chat on Discord](https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord)](https://chat.fakerjs.dev)
   [![Open Collective](https://img.shields.io/opencollective/backers/fakerjs)](https://opencollective.com/fakerjs#section-contributors)
   [![sponsor](https://img.shields.io/opencollective/all/fakerjs?label=sponsors)](https://opencollective.com/fakerjs)
-  
 </div>
 
 ## ⚡️ Try it Online
 
-[![](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://fakerjs.dev/new)
+[Open in StackBlitz](https://fakerjs.dev/new)
 
-[API Documentation](https://fakerjs.dev/guide/)
+## 📙 API Documentation
 
----
+[Guide - Getting started](https://fakerjs.dev/guide/)
 
-Please select the version of the documentation you are looking for.
+For detailed API documentation, please select the version of the documentation you are looking for.
 
 | Version |                         Github                         | Website                   |
 | :-----: | :----------------------------------------------------: | :------------------------ |


### PR DESCRIPTION
I find the top part of the README quite messy. The "Open in StackBlitz" button is too dominant and makes the link to "API documentation" (which is actually a link to the Getting Started Guide) hidden.

I moved things around a little and added some subheadings

## Before
<img width="749" alt="Screenshot 2023-03-01 at 19 11 10" src="https://user-images.githubusercontent.com/152770/222136064-f016f240-5732-47ab-94be-003ef5e04b73.png">


## After

<img width="771" alt="Screenshot 2023-03-01 at 19 10 53" src="https://user-images.githubusercontent.com/152770/222136053-9b3ac557-0bb9-41bb-877b-5932e67df05a.png">
