### PR TITLE
fix(locale): remove invalid city patterns from pt_BR

### DIFF
--- a/src/locales/pt_BR/location/city.ts
+++ b/src/locales/pt_BR/location/city.ts
@@ -1,6 +1,4 @@
 export default [
-  '{{location.city_prefix}} {{person.firstName}}{{location.city_suffix}}',
-  '{{location.city_prefix}} {{person.firstName}}',
   '{{person.firstName}}{{location.city_suffix}}',
   '{{person.lastName}}{{location.city_suffix}}',
 ];


### PR DESCRIPTION
```
> allFakers.pt_BR.location.city()
// 'undefined Hugo'
```

This is because two of the patterns for `city` reference `city_prefix`, but this is empty for pt_PT
https://github.com/faker-js/faker/blob/next/src/locales/pt_BR/location/city_prefix.ts

Removed these patterns
