### PR TITLE
infra: try to fix e2e flakyness

### DIFF
--- a/cypress/e2e/api.cy.ts
+++ b/cypress/e2e/api.cy.ts
@@ -28,19 +28,29 @@ describe('API Test', () => {
     });
 
     it('should not have dead links', () => {
+      const checked = new Set<string>();
       cy.get('.api-group li').each(($el) => {
-        const text = $el.find('a').text();
-        const link = $el.find('a').attr('href');
+        const anchor = $el.find('a');
+        const text = anchor.text();
+        const link = anchor.attr('href').split('#')[0];
+        if (checked.has(link)) {
+          return;
+        }
+
+        checked.add(link);
 
         cy.request({
           method: 'HEAD',
           url: `/api/${link}`,
           failOnStatusCode: false,
-        }).should(({ status }) => {
-          expect(status, `${text} to have a working link: /api/${link}`).to.eq(
-            200
-          );
-        });
+        })
+          .should(({ status }) => {
+            expect(
+              status,
+              `${text} to have a working link: /api/${link}`
+            ).to.eq(200);
+          })
+          .end();
       });
     });
   });

--- a/cypress/e2e/api.cy.ts
+++ b/cypress/e2e/api.cy.ts
@@ -32,10 +32,14 @@ describe('API Test', () => {
         const text = $el.find('a').text();
         const link = $el.find('a').attr('href');
 
-        cy.request(`/api/${link}`).should((response) => {
-          expect(response.status).to.eq(200);
-          expect(response.body).to.include(text);
-          expect(response.body).to.not.include('PAGE NOT FOUND');
+        cy.request({
+          method: 'HEAD',
+          url: `/api/${link}`,
+          failOnStatusCode: false,
+        }).should(({ status }) => {
+          expect(status, `${text} to have a working link: /api/${link}`).to.eq(
+            200
+          );
         });
       });
     });

--- a/cypress/e2e/api.cy.ts
+++ b/cypress/e2e/api.cy.ts
@@ -23,7 +23,9 @@ describe('API Test', () => {
 
     it('should include at least 1 element in each module', () => {
       cy.get('.api-group').each(($el) => {
-        cy.wrap($el).get('li a[href]').should('have.length.above', 0);
+        cy.wrap($el).within(() => {
+          cy.get('li a[href]').should('have.length.above', 0);
+        });
       });
     });
 


### PR DESCRIPTION
Tries to fix:

- #1943 

 Improvements:

- Make HEAD requests instead of GET
- (Potentially) avoid retries due to non 2xx response codes
- Check every url only once (ignoring #part) 270 requests (one per method) -> 15(?) (one per module)
- Don't search the entire page for module methods, only search that module section (bug)