### PR TITLE
docs(internet): password doesn't create crypto-secure PWs

### DIFF
--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -1293,7 +1293,8 @@ export class InternetModule {
   }
 
   /**
-   * Generates a random password.
+   * Generates a random password. Since the source of the randomness is not cryptographically secure,
+   * neither is this generator.
    *
    * @param options An options object. Defaults to `{}`.
    * @param options.length The length of the password to generate. Defaults to `15`.

--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -1293,8 +1293,8 @@ export class InternetModule {
   }
 
   /**
-   * Generates a random password. Since the source of the randomness is not cryptographically secure,
-   * neither is this generator.
+   * Generates a random password-like string. Do not use this method for generating actual passwords for users.
+   * Since the source of the randomness is not cryptographically secure, neither is this generator.
    *
    * @param options An options object. Defaults to `{}`.
    * @param options.length The length of the password to generate. Defaults to `15`.


### PR DESCRIPTION
Since this API uses faker.number, which itself is just using a Mersenne Twister implementation, these passwords are not safe for use in cryptographically-sensitive contexts.

<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->
