### PR TITLE
fix: revert types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",
-  "types": "dist/types/index.d.ts",
+  "types": "index.d.ts",
   "typesVersions": {
     ">=4.0": {
       "*": [


### PR DESCRIPTION
This reverts commit 956a15fff5c3714485e8e612df62034a5f78c0c5.

<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->

This had broken the whole package!

---

@bluwy

- If we remove the field it is not working
- If we change the field to something else it is also not working
- Only `"types": "index.d.ts"` is working here

Do you know anything about that? Why did publint reported this as invalid? Or even: what is going on here?