### PR TITLE
test: replace deprecated method call

### DIFF
--- a/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
+++ b/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import validator from 'validator';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -26,7 +26,7 @@ const tempDir = resolve(__dirname, 'temp');
 
 afterAll(() => {
   // Remove temp folder
-  rmdirSync(tempDir, { recursive: true });
+  rmSync(tempDir, { recursive: true });
 });
 
 describe('verify JSDoc tags', () => {


### PR DESCRIPTION
`rmdirSync` is deprecated.

> (node:1909) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead