### PR TITLE
infra: add labels to feature issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: "\U0001F680 New feature proposal"
 description: Propose a new feature
-labels: ['s: pending triage'] # This will automatically assign the 's: pending triage' label
+labels: ['s: pending triage', 'c: feature', 's: waiting for user interest']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Add the `c: feature` and `s: waiting for user interest` labels to the feature request issue template.