### PR TITLE
docs: document format of locale codes, allFakers and allLocales

### DIFF
--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -153,10 +153,21 @@ The same language may be spoken in different countries, with different patterns 
 
 Rarely, an additional variant may be needed to fully represent a accented version of the locale, or for languages which can be written in different scripts. This is appended after another underscore, for example `en_AU_ocker` (English in Australia in "Ocker" dialect) or `sr_RS_latin` (Serbian in Serbia in Latin script).
 
-You can access all prebuilt Faker instances or all locale definitions via an object where the locale codes are the keys:
+The recommended way to access Faker instances is by using one of the individual imports as shown above. If needed you can access all prebuilt Faker instances or all locale definitions via an object where the locale codes are the keys:
 
 ```ts
 import { allFakers, allLocales } from '@faker-js/faker';
 console.dir(allFakers['de_AT']); // the prebuilt Faker instance for de_AT
 console.dir(allLocales['de_AT']); // the raw locale definitions for de_AT
+```
+
+This could be useful if you want to enumerate all locales, for example:
+
+```ts
+import { allFakers } from '@faker-js/faker';
+for (let key of Object.keys(allFakers)) {
+  console.log(
+    `In locale ${key}, a sample name is ${allFakers[key].person.fullName()}`
+  );
+}
 ```

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -149,7 +149,7 @@ import { de, fakerDE } from '@faker-js/faker';
 
 Locales are named in a systematic way. The first two characters are a lowercase language code following the [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for example `ar` for Arabic or `en` for English. 
 
-The same language may be spoken in different countries, with different patterns for addresses, phone numbers etc. Optionally a two-letter uppercase country code can be added after an underscore, following the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), for example `en_US` represents English (United States) and `en_AU` represents English (Canada).
+The same language may be spoken in different countries, with different patterns for addresses, phone numbers etc. Optionally a two-letter uppercase country code can be added after an underscore, following the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), for example `en_US` represents English (United States) and `en_AU` represents English (Australia).
 
 Rarely, an additional variant may be needed to fully represent a accented version of the locale, or for languages which can be written in different scripts. This is appended after another underscore, for example `en_AU_ocker` (English in Australia in "Ocker" dialect) or `sr_RS_latin` (Serbian in Serbia in Latin script).
 

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -166,8 +166,12 @@ This could be useful if you want to enumerate all locales, for example:
 ```ts
 import { allFakers } from '@faker-js/faker';
 for (let key of Object.keys(allFakers)) {
-  console.log(
-    `In locale ${key}, a sample name is ${allFakers[key].person.fullName()}`
-  );
+  try {
+    console.log(
+      `In locale ${key}, a sample name is ${allFakers[key].person.fullName()}`
+    );
+  } catch (e) {
+    console.log(`In locale ${key}, an error occurred: ${e}`);
+  }
 }
 ```

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -151,7 +151,7 @@ Locales are named in a systematic way. The first two characters are a lowercase 
 
 The same language may be spoken in different countries, with different patterns for addresses, phone numbers etc. Optionally a two-letter uppercase country code can be added after an underscore, following the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), for example `en_US` represents English (United States) and `en_AU` represents English (Australia).
 
-Rarely, an additional variant may be needed to fully represent a accented version of the locale, or for languages which can be written in different scripts. This is appended after another underscore, for example `en_AU_ocker` (English in Australia in "Ocker" dialect) or `sr_RS_latin` (Serbian in Serbia in Latin script).
+Rarely, an additional variant may be needed to fully represent an accented variant of the locale, or for languages which can be written in different scripts. This is appended after another underscore, for example `en_AU_ocker` (English in Australia in "Ocker" dialect) or `sr_RS_latin` (Serbian in Serbia in Latin script).
 
 The recommended way to access Faker instances is by using one of the individual imports as shown above. If needed you can access all prebuilt Faker instances or all locale definitions via an object where the locale codes are the keys:
 

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -144,3 +144,19 @@ The `Locale` (data) and `Faker` columns refer to the respective `import` names:
 ```ts
 import { de, fakerDE } from '@faker-js/faker';
 ```
+
+## Locale codes
+
+Locales are named in a systematic way. The first two characters are a lowercase language code following the [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for example `ar` for Arabic or `en` for English. 
+
+The same language may be spoken in different countries, with different patterns for addresses, phone numbers etc. Optionally a two-letter uppercase country code can be added after an underscore, following the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), for example `en_US` represents English (United States) and `en_AU` represents English (Canada).
+
+Rarely, an additional variant may be needed to fully represent a accented version of the locale, or for languages which can be written in different scripts. This is appended after another underscore, for example `en_AU_ocker` (English in Australia in "Ocker" dialect) or `sr_RS_latin` (Serbian in Serbia in Latin script).
+
+You can access all prebuilt Faker instances or all locale definitions via an object where the locale codes are the keys:
+
+```ts
+import { allFakers, allLocales } from '@faker-js/faker';
+console.dir(allFakers["de_AT"]) // the prebuilt Faker instance for de_AT
+console.dir(allLocales["de_AT"]) // the raw locale definitions for de_AT
+```

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -147,7 +147,7 @@ import { de, fakerDE } from '@faker-js/faker';
 
 ## Locale codes
 
-Locales are named in a systematic way. The first two characters are a lowercase language code following the [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for example `ar` for Arabic or `en` for English. 
+Locales are named in a systematic way. The first two characters are a lowercase language code following the [ISO 639-1 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) for example `ar` for Arabic or `en` for English.
 
 The same language may be spoken in different countries, with different patterns for addresses, phone numbers etc. Optionally a two-letter uppercase country code can be added after an underscore, following the [ISO 3166-1 alpha-2 standard](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2), for example `en_US` represents English (United States) and `en_AU` represents English (Australia).
 
@@ -157,6 +157,6 @@ You can access all prebuilt Faker instances or all locale definitions via an obj
 
 ```ts
 import { allFakers, allLocales } from '@faker-js/faker';
-console.dir(allFakers["de_AT"]) // the prebuilt Faker instance for de_AT
-console.dir(allLocales["de_AT"]) // the raw locale definitions for de_AT
+console.dir(allFakers['de_AT']); // the prebuilt Faker instance for de_AT
+console.dir(allLocales['de_AT']); // the raw locale definitions for de_AT
 ```


### PR DESCRIPTION
extracted from #2025
fixes #1909
