### PR TITLE
infra: remove typedoc-plugin-missing-exports dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "standard-version": "~9.5.0",
     "tsx": "~3.12.6",
     "typedoc": "~0.24.1",
-    "typedoc-plugin-missing-exports": "~1.0.0",
     "typescript": "~4.9.5",
     "validator": "~13.9.0",
     "vite": "~4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ devDependencies:
   typedoc:
     specifier: ~0.24.1
     version: 0.24.1(typescript@4.9.5)
-  typedoc-plugin-missing-exports:
-    specifier: ~1.0.0
-    version: 1.0.0(typedoc@0.24.1)
   typescript:
     specifier: ~4.9.5
     version: 4.9.5
@@ -4842,14 +4839,6 @@ packages:
 
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
-    dev: true
-
-  /typedoc-plugin-missing-exports@1.0.0(typedoc@0.24.1):
-    resolution: {integrity: sha512-7s6znXnuAj1eD9KYPyzVzR1lBF5nwAY8IKccP5sdoO9crG4lpd16RoFpLsh2PccJM+I2NASpr0+/NMka6ThwVA==}
-    peerDependencies:
-      typedoc: 0.22.x || 0.23.x
-    dependencies:
-      typedoc: 0.24.1(typescript@4.9.5)
     dev: true
 
   /typedoc@0.24.1(typescript@4.9.5):

--- a/test/scripts/apidoc/__snapshots__/signature.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/signature.spec.ts.snap
@@ -43,7 +43,7 @@ exports[`signature > analyzeSignature() > complexArrayParameter 1`] = `
   "returns": "T",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L343",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L346",
 }
 `;
 
@@ -67,7 +67,7 @@ exports[`signature > analyzeSignature() > defaultBooleanParamMethod 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L101",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L104",
 }
 `;
 
@@ -115,7 +115,7 @@ exports[`signature > analyzeSignature() > functionParamMethod 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L121",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L124",
 }
 `;
 
@@ -174,7 +174,7 @@ exports[`signature > analyzeSignature() > literalUnionParamMethod 1`] = `
   "returns": "string",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L155",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L158",
 }
 `;
 
@@ -193,7 +193,7 @@ exports[`signature > analyzeSignature() > methodWithDeprecated 1`] = `
     "test.apidoc.methodWithExample()",
   ],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L273",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L276",
 }
 `;
 
@@ -244,7 +244,7 @@ exports[`signature > analyzeSignature() > methodWithDeprecatedOption 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L285",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L288",
 }
 `;
 
@@ -261,7 +261,7 @@ exports[`signature > analyzeSignature() > methodWithExample 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L262",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L265",
 }
 `;
 
@@ -280,7 +280,7 @@ exports[`signature > analyzeSignature() > methodWithMultipleSeeMarkers 1`] = `
     "test.apidoc.methodWithDeprecated()",
   ],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L312",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L315",
 }
 `;
 
@@ -299,7 +299,7 @@ exports[`signature > analyzeSignature() > methodWithMultipleSeeMarkersAndBacktic
     "test.apidoc.methodWithDeprecated() with parameter <code>bar</code> and <code>baz</code>.",
   ],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L322",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L325",
 }
 `;
 
@@ -315,7 +315,7 @@ exports[`signature > analyzeSignature() > methodWithSinceMarker 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "1.0.0",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L331",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L334",
 }
 `;
 
@@ -353,7 +353,7 @@ exports[`signature > analyzeSignature() > multiParamMethod 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L112",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L115",
 }
 `;
 
@@ -369,7 +369,7 @@ exports[`signature > analyzeSignature() > noParamMethod 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L74",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L77",
 }
 `;
 
@@ -393,7 +393,7 @@ exports[`signature > analyzeSignature() > optionalStringParamMethod 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L92",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L95",
 }
 `;
 
@@ -460,7 +460,7 @@ It also has a more complex description.</p>
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L212",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L215",
 }
 `;
 
@@ -498,7 +498,7 @@ exports[`signature > analyzeSignature() > optionsInterfaceParamMethodWithDefault
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L248",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L251",
 }
 `;
 
@@ -563,7 +563,7 @@ exports[`signature > analyzeSignature() > optionsParamMethod 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L182",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L185",
 }
 `;
 
@@ -601,7 +601,7 @@ exports[`signature > analyzeSignature() > optionsTypeParamMethodWithDefaults 1`]
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L230",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L233",
 }
 `;
 
@@ -625,7 +625,7 @@ exports[`signature > analyzeSignature() > requiredNumberParamMethod 1`] = `
   "returns": "number",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L83",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L86",
 }
 `;
 
@@ -635,9 +635,9 @@ exports[`signature > analyzeSignature() > stringUnionParamMethod 1`] = `
   "description": "<p>Test with string union.</p>
 ",
   "examples": "<div class=\\"language-ts\\"><button title=\\"Copy Code\\" class=\\"copy\\"></button><span class=\\"lang\\">ts</span><pre v-pre class=\\"shiki material-theme-palenight\\"><code><span class=\\"line\\"><span style=\\"color:#82AAFF\\">stringUnionParamMethod</span><span style=\\"color:#A6ACCD\\">(value: </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">a</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">|</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">b</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#89DDFF\\">,</span><span style=\\"color:#A6ACCD\\"> options</span><span style=\\"color:#89DDFF\\">?:</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">{</span></span>
-<span class=\\"line\\"><span style=\\"color:#A6ACCD\\">  </span><span style=\\"color:#F07178\\">casing</span><span style=\\"color:#89DDFF\\">:</span><span style=\\"color:#A6ACCD\\"> Casing</span><span style=\\"color:#89DDFF\\">,</span></span>
+<span class=\\"line\\"><span style=\\"color:#A6ACCD\\">  </span><span style=\\"color:#F07178\\">casing</span><span style=\\"color:#89DDFF\\">:</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">lower</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">|</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">mixed</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">|</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">upper</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#89DDFF\\">,</span></span>
 <span class=\\"line\\"><span style=\\"color:#A6ACCD\\">  </span><span style=\\"color:#F07178\\">excludes</span><span style=\\"color:#89DDFF\\">:</span><span style=\\"color:#A6ACCD\\"> readonly AlphaNumericChar[]</span><span style=\\"color:#89DDFF\\">,</span></span>
-<span class=\\"line\\"><span style=\\"color:#A6ACCD\\">  </span><span style=\\"color:#F07178\\">format</span><span style=\\"color:#89DDFF\\">:</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">hex</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">|</span><span style=\\"color:#A6ACCD\\"> ColorFormat</span></span>
+<span class=\\"line\\"><span style=\\"color:#A6ACCD\\">  </span><span style=\\"color:#F07178\\">format</span><span style=\\"color:#89DDFF\\">:</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">binary</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">|</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">css</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">|</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">decimal</span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">|</span><span style=\\"color:#A6ACCD\\"> </span><span style=\\"color:#89DDFF\\">'</span><span style=\\"color:#C3E88D\\">hex</span><span style=\\"color:#89DDFF\\">'</span></span>
 <span class=\\"line\\"><span style=\\"color:#89DDFF\\">}</span><span style=\\"color:#A6ACCD\\">): string</span></span></code></pre>
 </div>",
   "name": "stringUnionParamMethod",
@@ -661,7 +661,7 @@ exports[`signature > analyzeSignature() > stringUnionParamMethod 1`] = `
       "description": "<p>The casing parameter.</p>
 ",
       "name": "options.casing?",
-      "type": "Casing",
+      "type": "'lower' | 'mixed' | 'upper'",
     },
     {
       "default": undefined,
@@ -675,12 +675,12 @@ exports[`signature > analyzeSignature() > stringUnionParamMethod 1`] = `
       "description": "<p>The format parameter.</p>
 ",
       "name": "options.format?",
-      "type": "'hex' | ColorFormat",
+      "type": "'binary' | 'css' | 'decimal' | 'hex'",
     },
   ],
   "returns": "string",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L134",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L137",
 }
 `;

--- a/test/scripts/apidoc/signature.example.ts
+++ b/test/scripts/apidoc/signature.example.ts
@@ -1,6 +1,9 @@
 import type { Casing, ColorFormat } from '../../../src';
 import type { AlphaNumericChar } from '../../../src/modules/string';
 import type { LiteralUnion } from '../../../src/utils/types';
+// explicitly export types so they show up in the docs as decomposed types
+export type { NumberColorFormat, StringColorFormat } from '../../../src';
+export { Casing, ColorFormat, AlphaNumericChar, LiteralUnion };
 
 /**
  * Parameter options type with default from signature.


### PR DESCRIPTION
The `typedoc-plugin-missing-exports` is both

- incompatible with the current version of `typedoc`
- and obsolete since, we (should) export all the types anyway.

See also

- https://github.com/Gerrit0/typedoc-plugin-missing-exports/issues/19