### PR TITLE
docs: fix docs:dev api search completion navigation

### DIFF
--- a/docs/api/ApiIndex.vue
+++ b/docs/api/ApiIndex.vue
@@ -60,7 +60,7 @@ function apiSearchFocusHandler(event: KeyboardEvent): void {
     if (!item) return;
     const header = item.headers[0];
     if (!header) return;
-    window.location.href = item.link + '.html#' + slugify(header.anchor);
+    window.location.href = item.link + '#' + slugify(header.anchor);
   } else if (
     /^[a-z]$/.test(event.key) &&
     !event.altKey &&


### PR DESCRIPTION
This fixes an issue with `pnpm run docs:dev` that the api search complition navigates to `.html.html`.
This error doesn't seem to appear on our prod deployment/netlify automatically fixes these.