### PR TITLE
chore: rename generics

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,13 @@ module.exports = defineConfig({
         leadingUnderscore: 'forbid',
         trailingUnderscore: 'forbid',
       },
+      {
+        format: ['PascalCase'],
+        selector: ['typeParameter'],
+        prefix: ['T'],
+        leadingUnderscore: 'forbid',
+        trailingUnderscore: 'forbid',
+      },
     ],
     '@typescript-eslint/no-inferrable-types': [
       'error',

--- a/scripts/apidoc/utils.ts
+++ b/scripts/apidoc/utils.ts
@@ -47,10 +47,10 @@ export function adjustUrls(description: string): string {
   return description.replace(/https:\/\/(next.)?fakerjs.dev\//g, '/');
 }
 
-export function mapByName<T extends { name: string }, V>(
-  input: T[],
-  valueExtractor: (item: T) => V
-): Record<string, V> {
+export function mapByName<TInput extends { name: string }, TValue>(
+  input: TInput[],
+  valueExtractor: (item: TInput) => TValue
+): Record<string, TValue> {
   return input.reduce(
     (acc, item) => ({ ...acc, [item.name]: valueExtractor(item) }),
     {}

--- a/scripts/generateLocales.ts
+++ b/scripts/generateLocales.ts
@@ -40,9 +40,10 @@ const pathDocsGuideLocalization = resolve(
 );
 
 // Workaround for nameOf<T>
-type PascalCase<S extends string> = S extends `${infer P1}_${infer P2}`
-  ? `${Capitalize<P1>}${PascalCase<P2>}`
-  : Capitalize<S>;
+type PascalCase<TName extends string> =
+  TName extends `${infer Prefix}_${infer Remainder}`
+    ? `${Capitalize<Prefix>}${PascalCase<Remainder>}`
+    : Capitalize<TName>;
 
 type DefinitionType = {
   [key in keyof LocaleDefinition]-?: PascalCase<`${key}Definition`>;

--- a/src/definitions/definitions.ts
+++ b/src/definitions/definitions.ts
@@ -22,8 +22,8 @@ import type { WordDefinition } from './word';
 /**
  * Wrapper type for all definition categories that will make all properties optional and allow extra properties.
  */
-export type LocaleEntry<T extends Record<string, unknown>> = {
-  [P in keyof T]?: T[P] | null;
+export type LocaleEntry<TCategoryDefinition extends Record<string, unknown>> = {
+  [P in keyof TCategoryDefinition]?: TCategoryDefinition[P] | null;
 } & Record<string, unknown>; // Unsupported & custom entries
 
 /**

--- a/src/locale-proxy.ts
+++ b/src/locale-proxy.ts
@@ -61,21 +61,21 @@ export function createLocaleProxy(locale: LocaleDefinition): LocaleProxy {
  * @param categoryData The module to create the proxy for.
  */
 function createCategoryProxy<
-  CategoryData extends Record<string | symbol, unknown>
+  TCategoryData extends Record<string | symbol, unknown>
 >(
   categoryName: string,
-  categoryData: CategoryData = {} as CategoryData
-): Required<CategoryData> {
+  categoryData: TCategoryData = {} as TCategoryData
+): Required<TCategoryData> {
   return new Proxy(categoryData, {
-    has(target: CategoryData, entryName: keyof CategoryData): boolean {
+    has(target: TCategoryData, entryName: keyof TCategoryData): boolean {
       const value = target[entryName];
       return value != null;
     },
 
     get(
-      target: CategoryData,
-      entryName: keyof CategoryData
-    ): CategoryData[keyof CategoryData] {
+      target: TCategoryData,
+      entryName: keyof TCategoryData
+    ): TCategoryData[keyof TCategoryData] {
       const value = target[entryName];
       if (typeof entryName === 'symbol' || entryName === 'nodeType') {
         return value;
@@ -97,5 +97,5 @@ function createCategoryProxy<
 
     set: throwReadOnlyError,
     deleteProperty: throwReadOnlyError,
-  }) as Required<CategoryData>;
+  }) as Required<TCategoryData>;
 }

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -732,7 +732,7 @@ export class HelpersModule {
   /**
    * Returns the result of the callback if the probability check was successful, otherwise `undefined`.
    *
-   * @template T The type of result of the given callback.
+   * @template TResult The type of result of the given callback.
    *
    * @param callback The callback to that will be invoked if the probability check was successful.
    * @param options The options to use. Defaults to `{}`.
@@ -745,8 +745,8 @@ export class HelpersModule {
    *
    * @since 6.3.0
    */
-  maybe<T>(
-    callback: () => T,
+  maybe<TResult>(
+    callback: () => TResult,
     options: {
       /**
        * The probability (`[0.00, 1.00]`) of the callback being invoked.
@@ -755,7 +755,7 @@ export class HelpersModule {
        */
       probability?: number;
     } = {}
-  ): T | undefined {
+  ): TResult | undefined {
     if (this.faker.datatype.boolean(options)) {
       return callback();
     }
@@ -965,7 +965,7 @@ export class HelpersModule {
    *
    * This does the same as `objectValue` except that it ignores (the values assigned to) the numeric keys added for TypeScript enums.
    *
-   * @template EnumType Type of generic enums, automatically inferred by TypeScript.
+   * @template T Type of generic enums, automatically inferred by TypeScript.
    *
    * @param enumObject Enum to pick the value from.
    *
@@ -981,11 +981,11 @@ export class HelpersModule {
    *
    * @since 8.0.0
    */
-  enumValue<EnumType extends Record<string | number, string | number>>(
-    enumObject: EnumType
-  ): EnumType[keyof EnumType] {
+  enumValue<T extends Record<string | number, string | number>>(
+    enumObject: T
+  ): T[keyof T] {
     // ignore numeric keys added by TypeScript
-    const keys: Array<keyof EnumType> = Object.keys(enumObject).filter((key) =>
+    const keys: Array<keyof T> = Object.keys(enumObject).filter((key) =>
       isNaN(Number(key))
     );
     const randomKey = this.arrayElement(keys);
@@ -1255,7 +1255,7 @@ export class HelpersModule {
    * Generates a unique result using the results of the given method.
    * Used unique entries will be stored internally and filtered from subsequent calls.
    *
-   * @template Method The type of the method to execute.
+   * @template TMethod The type of the method to execute.
    *
    * @param method The method used to generate the values.
    * @param args The arguments used to call the method.
@@ -1279,14 +1279,14 @@ export class HelpersModule {
    * More info can be found in issue [faker-js/faker #1785](https://github.com/faker-js/faker/issues/1785).
    */
   unique<
-    Method extends (
+    TMethod extends (
       // TODO @Shinigami92 2023-02-14: This `any` type can be fixed by anyone if they want to.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...parameters: any[]
     ) => RecordKey
   >(
-    method: Method,
-    args: Parameters<Method> = [] as Parameters<Method>,
+    method: TMethod,
+    args: Parameters<TMethod> = [] as Parameters<TMethod>,
     options: {
       /**
        * This parameter does nothing.
@@ -1333,7 +1333,7 @@ export class HelpersModule {
        */
       store?: Record<RecordKey, RecordKey>;
     } = {}
-  ): ReturnType<Method> {
+  ): ReturnType<TMethod> {
     deprecated({
       deprecated: 'faker.helpers.unique',
       proposed:
@@ -1362,7 +1362,7 @@ export class HelpersModule {
   /**
    * Generates an array containing values returned by the given method.
    *
-   * @template T The type of elements.
+   * @template TResult The type of elements.
    *
    * @param method The method used to generate the values.
    * @param options The optional options object.
@@ -1374,8 +1374,8 @@ export class HelpersModule {
    *
    * @since 8.0.0
    */
-  multiple<T>(
-    method: () => T,
+  multiple<TResult>(
+    method: () => TResult,
     options: {
       /**
        * The number or range of elements to generate.
@@ -1395,7 +1395,7 @@ export class HelpersModule {
             max: number;
           };
     } = {}
-  ): T[] {
+  ): TResult[] {
     const count = this.rangeToNumber(options.count ?? 3);
     if (count <= 0) {
       return [];

--- a/src/modules/helpers/unique.ts
+++ b/src/modules/helpers/unique.ts
@@ -57,7 +57,7 @@ Try adjusting maxTime or maxRetries parameters for faker.helpers.unique().`
  * Generates a unique result using the results of the given method.
  * Used unique entries will be stored internally and filtered from subsequent calls.
  *
- * @template Method The type of the method to execute.
+ * @template TMethod The type of the method to execute.
  *
  * @param method The method used to generate the values.
  * @param args The arguments used to call the method.
@@ -71,14 +71,14 @@ Try adjusting maxTime or maxRetries parameters for faker.helpers.unique().`
  * @param options.store The store of unique entries. Defaults to `GLOBAL_UNIQUE_STORE`.
  */
 export function exec<
-  Method extends (
+  TMethod extends (
     // TODO @Shinigami92 2023-02-14: This `any` type can be fixed by anyone if they want to.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...parameters: any[]
   ) => RecordKey
 >(
-  method: Method,
-  args: Parameters<Method>,
+  method: TMethod,
+  args: Parameters<TMethod>,
   options: {
     startTime?: number;
     maxTime?: number;
@@ -88,7 +88,7 @@ export function exec<
     compare?: (obj: Record<RecordKey, RecordKey>, key: RecordKey) => 0 | -1;
     store?: Record<RecordKey, RecordKey>;
   } = {}
-): ReturnType<Method> {
+): ReturnType<TMethod> {
   const now = new Date().getTime();
 
   const {
@@ -132,7 +132,7 @@ export function exec<
   }
 
   // Execute the provided method to find a potential satisfied value.
-  const result: ReturnType<Method> = method(...args) as ReturnType<Method>;
+  const result: ReturnType<TMethod> = method(...args) as ReturnType<TMethod>;
 
   // If the result has not been previously found, add it to the found array and return the value as it's unique.
   if (compare(store, result) === -1 && exclude.indexOf(result) === -1) {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,9 +3,9 @@
  *
  * @see https://github.com/microsoft/TypeScript/issues/29729#issuecomment-471566609
  */
-export type LiteralUnion<T extends U, U = string> =
-  | T
-  | (U & { zz_IGNORE_ME?: never });
+export type LiteralUnion<TSuggested extends TBase, TBase = string> =
+  | TSuggested
+  | (TBase & { zz_IGNORE_ME?: never });
 
 /**
  * A function that returns a value.
@@ -22,18 +22,18 @@ export type Callable = (
 /**
  * Type that represents a single method/function name of the given type.
  */
-export type MethodOf<ObjectType, Signature extends Callable = Callable> = {
-  [Key in keyof ObjectType]: ObjectType[Key] extends Signature
+export type MethodOf<TObjectType, TSignature extends Callable = Callable> = {
+  [Key in keyof TObjectType]: TObjectType[Key] extends TSignature
     ? Key extends string
       ? Key
       : never
     : never;
-}[keyof ObjectType];
+}[keyof TObjectType];
 
 /**
  * Type that represents all method/function names of the given type.
  */
 export type MethodsOf<
-  ObjectType,
-  Signature extends Callable = Callable
-> = ReadonlyArray<MethodOf<ObjectType, Signature>>;
+  TObjectType,
+  TSignature extends Callable = Callable
+> = ReadonlyArray<MethodOf<TObjectType, TSignature>>;

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -18,8 +18,8 @@ function isMethodOf(mod: string) {
   return (meth: string) => typeof fakerEN[mod][meth] === 'function';
 }
 
-type SkipConfig<Module> = Partial<
-  Record<keyof Module, '*' | ReadonlyArray<keyof typeof allLocales>>
+type SkipConfig<TModule> = Partial<
+  Record<keyof TModule, '*' | ReadonlyArray<keyof typeof allLocales>>
 >;
 
 const BROKEN_LOCALE_METHODS = {

--- a/test/scripts/apidoc/__snapshots__/signature.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/signature.spec.ts.snap
@@ -43,7 +43,7 @@ exports[`signature > analyzeSignature() > complexArrayParameter 1`] = `
   "returns": "T",
   "seeAlsos": [],
   "since": "",
-  "sourcePath": "test/scripts/apidoc/signature.example.ts#L356",
+  "sourcePath": "test/scripts/apidoc/signature.example.ts#L357",
   "throws": undefined,
 }
 `;

--- a/test/scripts/apidoc/signature.example.ts
+++ b/test/scripts/apidoc/signature.example.ts
@@ -349,6 +349,7 @@ export class SignatureTest {
    * Complex array parameter.
    *
    * @template T The type of the entries to pick from.
+   *
    * @param array Array to pick the value from.
    * @param array[].weight The weight of the value.
    * @param array[].value The value to pick.


### PR DESCRIPTION
<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->

This PR renamed generics to a convention suggested by one of the TypeScript experts @mattpocock based on the YouTube video: https://www.youtube.com/watch?v=qA65QjWCl60

~~Also based on this poll (https://main.elk.zone/mas.to/@jvhellemond@mastodon.social/110124086297164650) by @jvhellemond `entries` are renamed to `elements` when it is in the context of an array/set~~ _extracted into #2049_

_I only checked `src` folder_