### PR TITLE
chore: consistent jsdocs tag formatting

### DIFF
--- a/src/faker.ts
+++ b/src/faker.ts
@@ -46,7 +46,6 @@ import { mergeLocales } from './utils/merge-locales';
  *
  * faker.person.firstName(); // 'John'
  * faker.person.lastName(); // 'Doe'
- *
  * @example
  * import { Faker, es } from '@faker-js/faker';
  * // const { Faker, es } = require('@faker-js/faker');
@@ -347,6 +346,7 @@ export class Faker {
    * by logging the result and explicitly setting it if needed.
    *
    * @param seed The seed to use. Defaults to a random number.
+   *
    * @returns The seed that was set.
    *
    * @see [Reproducible Results](https://next.fakerjs.dev/guide/usage.html#reproducible-results)
@@ -381,6 +381,7 @@ export class Faker {
    * by logging the result and explicitly setting it if needed.
    *
    * @param seedArray The seed array to use.
+   *
    * @returns The seed array that was set.
    *
    * @see [Reproducible Results](https://next.fakerjs.dev/guide/usage.html#reproducible-results)
@@ -415,6 +416,7 @@ export class Faker {
    * by logging the result and explicitly setting it if needed.
    *
    * @param seed The seed or seed array to use.
+   *
    * @returns The seed that was set.
    *
    * @see [Reproducible Results](https://next.fakerjs.dev/guide/usage.html#reproducible-results)

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -839,6 +839,7 @@ export class FinanceModule {
    * Generates a random PIN number.
    *
    * @param length The length of the PIN to generate. Defaults to `4`.
+   *
    * @throws Will throw an error if length is less than 1.
    *
    * @example
@@ -853,6 +854,7 @@ export class FinanceModule {
    *
    * @param options An options object. Defaults to `{}`.
    * @param options.length The length of the PIN to generate. Defaults to `4`.
+   *
    * @throws Will throw an error if length is less than 1.
    *
    * @example
@@ -874,6 +876,7 @@ export class FinanceModule {
    *
    * @param options An options object or the length of the PIN. Defaults to `{}`.
    * @param options.length The length of the PIN to generate. Defaults to `4`.
+   *
    * @throws Will throw an error if length is less than 1.
    *
    * @example
@@ -900,6 +903,7 @@ export class FinanceModule {
    *
    * @param options An options object or the length of the PIN. Defaults to `{}`.
    * @param options.length The length of the PIN to generate. Defaults to `4`.
+   *
    * @throws Will throw an error if length is less than 1.
    *
    * @example
@@ -957,6 +961,7 @@ export class FinanceModule {
    *
    * @param formatted Return a formatted version of the generated IBAN. Defaults to `false`.
    * @param countryCode The country code from which you want to generate an IBAN, if none is provided a random country will be used.
+   *
    * @throws Will throw an error if the passed country code is not supported.
    *
    * @example
@@ -973,6 +978,7 @@ export class FinanceModule {
    * @param options An options object. Defaults to `{}`.
    * @param options.formatted Return a formatted version of the generated IBAN. Defaults to `false`.
    * @param options.countryCode The country code from which you want to generate an IBAN, if none is provided a random country will be used.
+   *
    * @throws Will throw an error if the passed country code is not supported.
    *
    * @example

--- a/src/modules/git/index.ts
+++ b/src/modules/git/index.ts
@@ -62,7 +62,6 @@ export class GitModule {
    * @param options.eol Choose the end of line character to use. Defaults to 'CRLF'.
    * 'LF' = '\n',
    * 'CRLF' = '\r\n'
-   *
    * @param options.refDate The date to use as reference point for the commit. Defaults to `new Date()`.
    *
    * @example

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -555,6 +555,7 @@ export class HelpersModule {
    * Takes an array and randomizes it in place then returns it.
    *
    * @template T The type of the elements to shuffle.
+   *
    * @param list The array to shuffle.
    * @param options The options to use when shuffling.
    * @param options.inplace Whether to shuffle the array in place or return a new array. Defaults to `false`.
@@ -579,6 +580,7 @@ export class HelpersModule {
    * Returns a randomized version of the array.
    *
    * @template T The type of the elements to shuffle.
+   *
    * @param list The array to shuffle.
    * @param options The options to use when shuffling.
    * @param options.inplace Whether to shuffle the array in place or return a new array. Defaults to `false`.
@@ -604,6 +606,7 @@ export class HelpersModule {
    * Returns a randomized version of the array.
    *
    * @template T The type of the elements to shuffle.
+   *
    * @param list The array to shuffle.
    * @param options The options to use when shuffling.
    * @param options.inplace Whether to shuffle the array in place or return a new array. Defaults to `false`.
@@ -647,6 +650,7 @@ export class HelpersModule {
    * This method does not store the unique state between invocations.
    *
    * @template T The type of the elements.
+   *
    * @param source The strings to choose from or a function that generates a string.
    * @param length The number of elements to generate.
    *
@@ -721,6 +725,7 @@ export class HelpersModule {
    * Returns the result of the callback if the probability check was successful, otherwise `undefined`.
    *
    * @template T The type of result of the given callback.
+   *
    * @param callback The callback to that will be invoked if the probability check was successful.
    * @param options The options to use. Defaults to `{}`.
    * @param options.probability The probability (`[0.00, 1.00]`) of the callback being invoked. Defaults to `0.5`.
@@ -754,6 +759,7 @@ export class HelpersModule {
    * Returns a random key from given object or `undefined` if no key could be found.
    *
    * @template T The type of the object to select from.
+   *
    * @param object The object to be used.
    *
    * @example
@@ -770,6 +776,7 @@ export class HelpersModule {
    * Returns a random value from given object or `undefined` if no key could be found.
    *
    * @template T The type of object to select from.
+   *
    * @param object The object to be used.
    *
    * @example
@@ -786,6 +793,7 @@ export class HelpersModule {
    * Returns random element from the given array.
    *
    * @template T The type of the elements to pick from.
+   *
    * @param array Array to pick the value from.
    *
    * @example
@@ -813,6 +821,7 @@ export class HelpersModule {
    * For example, if there are two values A and B, with weights 1 and 2 respectively, then the probability of picking A is 1/3 and the probability of picking B is 2/3.
    *
    * @template T The type of the elements to pick from.
+   *
    * @param array Array to pick the value from.
    * @param array[].weight The weight of the value.
    * @param array[].value The value to pick.
@@ -868,6 +877,7 @@ export class HelpersModule {
    * Returns a subset with random elements of the given array in random order.
    *
    * @template T The type of the elements to pick from.
+   *
    * @param array Array to pick the value from.
    * @param count Number or range of elements to pick.
    *    When not provided, random number of elements will be picked.
@@ -934,6 +944,7 @@ export class HelpersModule {
    * This does the same as `objectValue` except that it ignores (the values assigned to) the numeric keys added for TypeScript enums.
    *
    * @template EnumType Type of generic enums, automatically inferred by TypeScript.
+   *
    * @param enumObject Enum to pick the value from.
    *
    * @example
@@ -1228,6 +1239,7 @@ export class HelpersModule {
    * Used unique entries will be stored internally and filtered from subsequent calls.
    *
    * @template Method The type of the method to execute.
+   *
    * @param method The method used to generate the values.
    * @param args The arguments used to call the method.
    * @param options The optional options used to configure this method.
@@ -1327,6 +1339,7 @@ export class HelpersModule {
    * Generates an array containing values returned by the given method.
    *
    * @template T The type of elements.
+   *
    * @param method The method used to generate the values.
    * @param options The optional options object.
    * @param options.count The number or range of elements to generate. Defaults to `3`.

--- a/src/modules/helpers/unique.ts
+++ b/src/modules/helpers/unique.ts
@@ -70,6 +70,7 @@ Try adjusting maxTime or maxRetries parameters for faker.helpers.unique().`
  * Used unique entries will be stored internally and filtered from subsequent calls.
  *
  * @template Method The type of the method to execute.
+ *
  * @param method The method used to generate the values.
  * @param args The arguments used to call the method.
  * @param options The optional options used to configure this method.

--- a/src/modules/person/index.ts
+++ b/src/modules/person/index.ts
@@ -17,6 +17,7 @@ export type SexType = `${Sex}`;
  * @param param2.generic Non-sex definitions.
  * @param param2.female Female definitions.
  * @param param2.male Male definitions.
+ *
  * @returns Definition based on given sex.
  */
 function selectDefinition<T>(

--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -102,6 +102,7 @@ export class SystemModule {
    * Returns a random file name with a given extension or a commonly used extension.
    *
    * @param ext Extension. Empty string is considered to be not set.
+   *
    * @example
    * faker.system.commonFileName() // 'dollar.jpg'
    * faker.system.commonFileName('txt') // 'global_borders_wyoming.txt'

--- a/src/utils/merge-locales.ts
+++ b/src/utils/merge-locales.ts
@@ -7,6 +7,7 @@ import type { LocaleDefinition } from '..';
  * Mutating the category entries in the returned locale will also mutate the entries in the respective source locale.
  *
  * @param locales The locales to merge.
+ *
  * @returns The newly merged locale.
  *
  * @example


### PR DESCRIPTION
Formatted the code to have:
- exactly one newline between different tags
- exactly zero trailing newlines between same tags

I'm not sure whether there should be a newline between `@template` and `@param`, but we have (at least) one place in the code where `@internal` jumps between the two.

Assumed tag sequence:

````ts
        'jsdoc/sort-tags': [
          'error',
          {
            tagSequence: [
              { tags: ['template'] },
              { tags: ['internal'] },
              { tags: ['param'] },
              { tags: ['returns'] },
              { tags: ['throws'] },
              { tags: ['see'] },
              { tags: ['example'] },
              { tags: ['since'] },
              { tags: ['default'] },
              { tags: ['deprecated'] },
            ],
          },
        ],
````

Requires: https://github.com/gajus/eslint-plugin-jsdoc/pull/1017 to work (slightly buggy ATM).