### PR TITLE
chore: unify todos

### DIFF
--- a/scripts/generateLocales.ts
+++ b/scripts/generateLocales.ts
@@ -126,7 +126,7 @@ function generateLocaleFile(locale: string): void {
     }
   }
 
-  // TODO christopher 2023-03-07: Remove 'en' fallback in a separate PR
+  // TODO @Shinigami92 2023-03-07: Remove 'en' fallback in a separate PR
   if (locales[locales.length - 1] !== 'en' && locale !== 'base') {
     locales.push('en');
   }

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -1251,7 +1251,7 @@ export class HelpersModule {
    */
   unique<
     Method extends (
-      // TODO christopher 2023-02-14: This `any` type can be fixed by anyone if they want to.
+      // TODO @Shinigami92 2023-02-14: This `any` type can be fixed by anyone if they want to.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...parameters: any[]
     ) => RecordKey

--- a/src/modules/helpers/unique.ts
+++ b/src/modules/helpers/unique.ts
@@ -83,7 +83,7 @@ Try adjusting maxTime or maxRetries parameters for faker.helpers.unique().`
  */
 export function exec<
   Method extends (
-    // TODO christopher 2023-02-14: This `any` type can be fixed by anyone if they want to.
+    // TODO @Shinigami92 2023-02-14: This `any` type can be fixed by anyone if they want to.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ...parameters: any[]
   ) => RecordKey

--- a/src/modules/image/providers/lorempicsum.ts
+++ b/src/modules/image/providers/lorempicsum.ts
@@ -101,7 +101,7 @@ export class LoremPicsum {
       since: '8.0',
       until: '9.0',
     });
-    // TODO ST-DDT 2022-03-11: This method does the same as image url, maybe generate a seed, if it is missig?
+    // TODO @ST-DDT 2022-03-11: This method does the same as image url, maybe generate a seed, if it is missing?
     return this.imageUrl(width, height, grayscale, blur, seed);
   }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -14,7 +14,7 @@ export type LiteralUnion<T extends U, U = string> =
  * These would fail when invoked since they are invoked without the `new` keyword.
  */
 export type Callable = (
-  // TODO christopher 2023-02-14: This `any` type can be fixed by anyone if they want to.
+  // TODO @Shinigami92 2023-02-14: This `any` type can be fixed by anyone if they want to.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ...args: any[]
 ) => unknown;

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -22,7 +22,7 @@ type SkipConfig<Module> = Partial<
 >;
 
 const BROKEN_LOCALE_METHODS = {
-  // TODO ST-DDT 2022-03-28: these are TODOs (usually broken locale files)
+  // TODO @ST-DDT 2022-03-28: these are TODOs (usually broken locale files)
   company: {
     suffixes: ['az'],
     companySuffix: ['az'],
@@ -118,7 +118,7 @@ describe('functional tests', () => {
         describe(module, () => {
           modules[module].forEach((meth) => {
             const testAssertion = () => {
-              // TODO ST-DDT 2022-03-28: Use random seed once there are no more failures
+              // TODO @ST-DDT 2022-03-28: Use random seed once there are no more failures
               faker.seed(1);
               const result = faker[module][meth]();
 
@@ -133,7 +133,7 @@ describe('functional tests', () => {
             if (isWorkingLocaleForMethod(module, meth, locale)) {
               it(`${meth}()`, testAssertion);
             } else {
-              // TODO ST-DDT 2022-03-28: Remove once there are no more failures
+              // TODO @ST-DDT 2022-03-28: Remove once there are no more failures
               // We expect a failure here to ensure we remove the exclusions when fixed
               it.fails(`${meth}()`, testAssertion);
             }
@@ -156,7 +156,7 @@ describe('faker.helpers.fake functional tests', () => {
         describe(module, () => {
           modules[module].forEach((meth) => {
             const testAssertion = () => {
-              // TODO ST-DDT 2022-03-28: Use random seed once there are no more failures
+              // TODO @ST-DDT 2022-03-28: Use random seed once there are no more failures
               faker.seed(1);
               const result = faker.helpers.fake(`{{${module}.${meth}}}`);
 
@@ -169,7 +169,7 @@ describe('faker.helpers.fake functional tests', () => {
             if (isWorkingLocaleForMethod(module, meth, locale)) {
               it(`${meth}()`, testAssertion);
             } else {
-              // TODO ST-DDT 2022-03-28: Remove once there are no more failures
+              // TODO @ST-DDT 2022-03-28: Remove once there are no more failures
               // We expect a failure here to ensure we remove the exclusions when fixed
               it.fails(`${meth}()`, testAssertion);
             }


### PR DESCRIPTION
<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->

this just unifies the TODOs to follow all the same pattern

hint: you can use user snippets in VSCode to add a short suggestion for this like e.g.:

```jsonc
{
  // Place your global snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
  // Placeholders with the same ids are connected.
  // Example:
  // "Print to console": {
  //     "scope": "javascript,typescript",
  //     "prefix": "log",
  //     "body": [
  //         "console.log('$1');",
  //         "$2"
  //     ],
  //     "description": "Log output to console"
  // }
  "todo-c": {
    "prefix": "todo-c",
    "body": "$LINE_COMMENT TODO christopher $CURRENT_YEAR-$CURRENT_MONTH-$CURRENT_DATE: $1"
  },
  "todo-s": {
    "prefix": "todo-s",
    "body": "$LINE_COMMENT TODO @Shinigami92 $CURRENT_YEAR-$CURRENT_MONTH-$CURRENT_DATE: $1"
  }
}
```