### PR TITLE
fix(locale): remove unrealistic fictional city patterns in ne, ro, tr

### DIFF
--- a/src/locales/ne/location/city_pattern.ts
+++ b/src/locales/ne/location/city_pattern.ts
@@ -1,7 +1,1 @@
-export default [
-  '{{location.city_prefix}} {{person.firstName}}{{location.city_suffix}}',
-  '{{location.city_prefix}} {{person.firstName}}',
-  '{{person.firstName}}{{location.city_suffix}}',
-  '{{person.lastName}}{{location.city_suffix}}',
-  '{{location.city_name}}',
-];
+export default ['{{location.city_name}}'];

--- a/src/locales/ro/location/city_pattern.ts
+++ b/src/locales/ro/location/city_pattern.ts
@@ -1,7 +1,1 @@
-export default [
-  '{{location.city_prefix}} {{person.firstName}}{{location.city_suffix}}',
-  '{{location.city_prefix}} {{person.firstName}}',
-  '{{person.firstName}}{{location.city_suffix}}',
-  '{{person.lastName}}{{location.city_suffix}}',
-  '{{location.city_name}}',
-];
+export default ['{{location.city_name}}'];

--- a/src/locales/tr/location/city_pattern.ts
+++ b/src/locales/tr/location/city_pattern.ts
@@ -1,7 +1,1 @@
-export default [
-  '{{location.city_prefix}} {{person.firstName}}{{location.city_suffix}}',
-  '{{location.city_prefix}} {{person.firstName}}',
-  '{{person.firstName}}{{location.city_suffix}}',
-  '{{person.lastName}}{{location.city_suffix}}',
-  '{{location.city_name}}',
-];
+export default ['{{location.city_name}}'];


### PR DESCRIPTION
Removes fictional patterns in three locales where location.city_name is available but there are no native city prefixes/suffixes available.

Avoids weird combinations of ne/ro/tr names with English prefixes/suffixes like

West Vladcester
Bökeshire
Manishacester
