### PR TITLE
feat(helpers): new method `objectEntry`

### DIFF
--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -798,14 +798,14 @@ export class HelpersModule {
   }
 
   /**
-   * Returns a random [key, value] pair from given object or `undefined` if no key could be found.
+   * Returns a random [key, value] pair from given object or throws an Error if no key could be found.
    *
    * @template T The type of the object to select from.
    *
    * @param object The object to be used.
    *
    * @example
-   * faker.helpers.objectEntry({ myProperty: 'myValue' }) // ['myProperty', 'value']
+   * faker.helpers.objectEntry({ prop1: 'value1', prop2: 'value2' }) // ['prop1', 'value1']
    *
    * @since 8.0.0
    */
@@ -813,7 +813,7 @@ export class HelpersModule {
     object: T
   ): [keyof T, T[keyof T]] {
     const key = this.faker.helpers.objectKey(object);
-    return key ? [key, object[key]] : undefined;
+    return [key, object[key]];
   }
 
   /**

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -764,11 +764,13 @@ export class HelpersModule {
   }
 
   /**
-   * Returns a random key from given object or `undefined` if no key could be found.
+   * Returns a random key from given object.
    *
    * @template T The type of the object to select from.
    *
    * @param object The object to be used.
+   *
+   * @throws If the given object is empty.
    *
    * @example
    * faker.helpers.objectKey({ myProperty: 'myValue' }) // 'myProperty'
@@ -781,11 +783,13 @@ export class HelpersModule {
   }
 
   /**
-   * Returns a random value from given object or `undefined` if no key could be found.
+   * Returns a random value from given object.
    *
    * @template T The type of object to select from.
    *
    * @param object The object to be used.
+   *
+   * @throws If the given object is empty.
    *
    * @example
    * faker.helpers.objectValue({ myProperty: 'myValue' }) // 'myValue'
@@ -798,11 +802,13 @@ export class HelpersModule {
   }
 
   /**
-   * Returns a random [key, value] pair from given object or throws an Error if no key could be found.
+   * Returns a random `[key, value]` pair from the given object.
    *
    * @template T The type of the object to select from.
    *
    * @param object The object to be used.
+   *
+   * @throws If the given object is empty.
    *
    * @example
    * faker.helpers.objectEntry({ prop1: 'value1', prop2: 'value2' }) // ['prop1', 'value1']

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -798,6 +798,25 @@ export class HelpersModule {
   }
 
   /**
+   * Returns a random [key, value] pair from given object or `undefined` if no key could be found.
+   *
+   * @template T The type of the object to select from.
+   *
+   * @param object The object to be used.
+   *
+   * @example
+   * faker.helpers.objectEntry({ myProperty: 'myValue' }) // ['myProperty', 'value']
+   *
+   * @since 8.0.0
+   */
+  objectEntry<T extends Record<string, unknown>>(
+    object: T
+  ): [keyof T, T[keyof T]] {
+    const key = this.faker.helpers.objectKey(object);
+    return key ? [key, object[key]] : undefined;
+  }
+
+  /**
    * Returns random element from the given array.
    *
    * @template T The type of the elements to pick from.
@@ -912,15 +931,15 @@ export class HelpersModule {
     count?:
       | number
       | {
-          /**
-           * The minimum number of elements to pick.
-           */
-          min: number;
-          /**
-           * The maximum number of elements to pick.
-           */
-          max: number;
-        }
+        /**
+         * The minimum number of elements to pick.
+         */
+        min: number;
+        /**
+         * The maximum number of elements to pick.
+         */
+        max: number;
+      }
   ): T[] {
     // TODO @xDivisionByZerox 2023-04-20: Remove in v9
     if (array == null) {
@@ -1234,15 +1253,15 @@ export class HelpersModule {
     numberOrRange:
       | number
       | {
-          /**
-           * The minimum value for the range.
-           */
-          min: number;
-          /**
-           * The maximum value for the range.
-           */
-          max: number;
-        }
+        /**
+         * The minimum value for the range.
+         */
+        min: number;
+        /**
+         * The maximum value for the range.
+         */
+        max: number;
+      }
   ): number {
     if (typeof numberOrRange === 'number') {
       return numberOrRange;
@@ -1383,17 +1402,17 @@ export class HelpersModule {
        * @default 3
        */
       count?:
-        | number
-        | {
-            /**
-             * The minimum value for the range.
-             */
-            min: number;
-            /**
-             * The maximum value for the range.
-             */
-            max: number;
-          };
+      | number
+      | {
+        /**
+         * The minimum value for the range.
+         */
+        min: number;
+        /**
+         * The maximum value for the range.
+         */
+        max: number;
+      };
     } = {}
   ): T[] {
     const count = this.rangeToNumber(options.count ?? 3);

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -931,15 +931,15 @@ export class HelpersModule {
     count?:
       | number
       | {
-        /**
-         * The minimum number of elements to pick.
-         */
-        min: number;
-        /**
-         * The maximum number of elements to pick.
-         */
-        max: number;
-      }
+          /**
+           * The minimum number of elements to pick.
+           */
+          min: number;
+          /**
+           * The maximum number of elements to pick.
+           */
+          max: number;
+        }
   ): T[] {
     // TODO @xDivisionByZerox 2023-04-20: Remove in v9
     if (array == null) {
@@ -1253,15 +1253,15 @@ export class HelpersModule {
     numberOrRange:
       | number
       | {
-        /**
-         * The minimum value for the range.
-         */
-        min: number;
-        /**
-         * The maximum value for the range.
-         */
-        max: number;
-      }
+          /**
+           * The minimum value for the range.
+           */
+          min: number;
+          /**
+           * The maximum value for the range.
+           */
+          max: number;
+        }
   ): number {
     if (typeof numberOrRange === 'number') {
       return numberOrRange;
@@ -1402,17 +1402,17 @@ export class HelpersModule {
        * @default 3
        */
       count?:
-      | number
-      | {
-        /**
-         * The minimum value for the range.
-         */
-        min: number;
-        /**
-         * The maximum value for the range.
-         */
-        max: number;
-      };
+        | number
+        | {
+            /**
+             * The minimum value for the range.
+             */
+            min: number;
+            /**
+             * The maximum value for the range.
+             */
+            max: number;
+          };
     } = {}
   ): T[] {
     const count = this.rangeToNumber(options.count ?? 3);

--- a/test/__snapshots__/helpers.spec.ts.snap
+++ b/test/__snapshots__/helpers.spec.ts.snap
@@ -110,6 +110,13 @@ exports[`helpers > 42 > mustache > template with method 1`] = `"Hello John!"`;
 
 exports[`helpers > 42 > mustache > template with string 1`] = `"Hello John!"`;
 
+exports[`helpers > 42 > objectEntry > simple 1`] = `
+[
+  "b",
+  2,
+]
+`;
+
 exports[`helpers > 42 > objectKey > simple 1`] = `"b"`;
 
 exports[`helpers > 42 > objectValue > simple 1`] = `2`;
@@ -343,6 +350,13 @@ exports[`helpers > 1211 > mustache > template with method 1`] = `"Hello John!"`;
 
 exports[`helpers > 1211 > mustache > template with string 1`] = `"Hello John!"`;
 
+exports[`helpers > 1211 > objectEntry > simple 1`] = `
+[
+  "c",
+  3,
+]
+`;
+
 exports[`helpers > 1211 > objectKey > simple 1`] = `"c"`;
 
 exports[`helpers > 1211 > objectValue > simple 1`] = `3`;
@@ -557,6 +571,13 @@ exports[`helpers > 1337 > multiple > with only method 1`] = `
 exports[`helpers > 1337 > mustache > template with method 1`] = `"Hello John!"`;
 
 exports[`helpers > 1337 > mustache > template with string 1`] = `"Hello John!"`;
+
+exports[`helpers > 1337 > objectEntry > simple 1`] = `
+[
+  "a",
+  1,
+]
+`;
 
 exports[`helpers > 1337 > objectKey > simple 1`] = `"a"`;
 

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -946,12 +946,11 @@ describe('helpers', () => {
             you: 'my',
             friend: '!',
           };
-          const actual = faker.helpers.objectEntry(testObject);
-          console.log(actual);
+          const [key, value] = faker.helpers.objectEntry(testObject);
 
-          expect(Object.keys(testObject)).toContain(actual[0]);
-          expect(Object.values(testObject)).toContain(actual[1]);
-          expect(testObject[actual[0]]).toContain(actual[1]);
+          expect(Object.keys(testObject)).toContain(key);
+          expect(Object.values(testObject)).toContain(value);
+          expect(testObject[key]).toEqual(value);
         });
 
         it('should throw if given object is empty', () => {

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -157,6 +157,10 @@ describe('helpers', () => {
       t.it('simple', { a: 1, b: 2, c: 3 });
     });
 
+    t.describe('objectEntry', (t) => {
+      t.it('simple', { a: 1, b: 2, c: 3 });
+    });
+
     t.describe('fake', (t) => {
       t.it('with empty string', '')
         .it('with a static template', 'my test string')
@@ -930,6 +934,28 @@ describe('helpers', () => {
 
         it('should throw if given object is empty', () => {
           expect(() => faker.helpers.objectValue({})).toThrowError(
+            new FakerError('Cannot get value from empty dataset.')
+          );
+        });
+      });
+
+      describe('objectEntry', () => {
+        it('should return a random key, value pair', () => {
+          const testObject = {
+            hello: 'to',
+            you: 'my',
+            friend: '!',
+          };
+          const actual = faker.helpers.objectEntry(testObject);
+          console.log(actual);
+
+          expect(Object.keys(testObject)).toContain(actual[0]);
+          expect(Object.values(testObject)).toContain(actual[1]);
+          expect(testObject[actual[0]]).toContain(actual[1]);
+        });
+
+        it('should throw if given object is empty', () => {
+          expect(() => faker.helpers.objectEntry({})).toThrowError(
             new FakerError('Cannot get value from empty dataset.')
           );
         });


### PR DESCRIPTION
For issue #1764, added a new helper method named `faker.helpers.objectEntry` that will return a random key-value pair from the given object.

Changes made:
- Added a new method `faker.helpers.objectEntry`
- Added tests and updated snapshots 
