### PR TITLE
docs: add contributing link from html docs back to github

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -44,6 +44,10 @@ function extendSideNav(current: SidebarItem): SidebarItem[] {
           text: 'Team',
           link: '/about/team',
         },
+        {
+          text: 'Contributing',
+          link: '/about/contributing',
+        },
       ],
     },
   ];
@@ -155,6 +159,10 @@ const config = defineConfig({
             text: 'Team',
             link: '/about/team',
           },
+          {
+            text: 'Contributing',
+            link: '/about/contributing',
+          },
         ],
       },
       {
@@ -229,6 +237,10 @@ const config = defineConfig({
           {
             text: 'Team',
             link: '/about/team',
+          },
+          {
+            text: 'Contributing',
+            link: '/about/contributing',
           },
         ],
       }),

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -1,0 +1,7 @@
+---
+editLink: false
+---
+
+# Contributing
+
+We welcome new contributors! For more information see the [Contributing](https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md) file on Github. All contributors are expected to follow the [Code of Conduct](https://github.com/faker-js/faker/blob/next/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
fix #2139

<img width="377" alt="Screenshot 2023-05-10 at 17 47 17" src="https://github.com/faker-js/faker/assets/152770/1bdcf0a1-c367-4924-be60-9f755956cb20">

<img width="861" alt="Screenshot 2023-05-10 at 17 48 40" src="https://github.com/faker-js/faker/assets/152770/df03148a-cd58-48c4-be8b-e89191dbd154">



