### PR TITLE
feat(number): support precision on faker.number.int()

### DIFF
--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -67,15 +67,20 @@ export class NumberModule {
            * @default Number.MAX_SAFE_INTEGER
            */
           max?: number;
+          /**
+           * Precision of the generated number.
+           *
+           */
+          precision?: number;
         } = {}
   ): number {
     if (typeof options === 'number') {
       options = { max: options };
     }
 
-    const { min = 0, max = Number.MAX_SAFE_INTEGER } = options;
-    const effectiveMin = Math.ceil(min);
-    const effectiveMax = Math.floor(max);
+    const { min = 0, max = Number.MAX_SAFE_INTEGER, precision } = options;
+    let effectiveMin = Math.ceil(min);
+    let effectiveMax = Math.floor(max);
 
     if (effectiveMin === effectiveMax) {
       return effectiveMin;
@@ -91,11 +96,25 @@ export class NumberModule {
       throw new FakerError(`Max ${max} should be greater than min ${min}.`);
     }
 
+    let factor = 1;
+    if (precision !== undefined) {
+      if (precision <= 0) {
+        throw new FakerError(`Precision should be greater than 0.`);
+      }
+
+      factor = 1 / precision;
+      effectiveMin *= factor;
+      effectiveMax *= factor;
+    }
+
     const mersenne: Mersenne =
       // @ts-expect-error: access private member field
       this.faker._mersenne;
     const real = mersenne.next();
-    return Math.floor(real * (effectiveMax + 1 - effectiveMin) + effectiveMin);
+    return (
+      Math.floor(real * (effectiveMax + 1 - effectiveMin) + effectiveMin) /
+      factor
+    );
   }
 
   /**

--- a/test/number.spec.ts
+++ b/test/number.spec.ts
@@ -163,6 +163,10 @@ describe('number', () => {
           new FakerError(`No integer value between 2.1 and 2.9 found.`)
         );
       });
+
+      it('should round an int to precision', () => {
+        expect(faker.number.int({ min: 10, max: 100, precision: 10 })).toBe(50);
+      });
     });
 
     describe('float', () => {


### PR DESCRIPTION
Fixes #2186

In faker 7 I could specify
```
faker.datatype.number({ min: 30, max: 200, precision: 10 }) // 140, 90, 180, ...
faker.datatype.number({ min: 5000, max: 20000, precision: 100 }) // 5200, 18500, 12900,...
```

But with faker 8, the precision was removed from int.

```
faker.number.int({ min: 30, max: 200 })
```

### Suggested solution

Allow passing a precision to the int faker function

```
faker.number.int({ min: 30, max: 200, precision: 10 })
```
