### PR TITLE
changed deprecated faker.datatype.uuid() to faker.string.uuid() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const { faker } = require('@faker-js/faker');
 
 export function createRandomUser(): User {
   return {
-    userId: faker.datatype.uuid(),
+    userId: faker.string.uuid(),
     username: faker.internet.userName(),
     email: faker.internet.email(),
     avatar: faker.image.avatar(),


### PR DESCRIPTION
added a single change to the readme, where datatype is changed , and it is set as deprecated [Link](https://fakerjs.dev/api/datatype.html#uuid)
<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->
