### PR TITLE
infra: ignore .pnpm-store

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.pnpm-store/
 coverage/
 dist/
 test/scripts/apidoc/temp/


### PR DESCRIPTION
<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->

When using corepack and having a local `.pnpm-store/` folder, prettier wants to format the content
This prevents prettier from doing that