### PR TITLE
chore: ignore lint warning

### DIFF
--- a/src/internal/bind-this-to-member-functions.ts
+++ b/src/internal/bind-this-to-member-functions.ts
@@ -11,6 +11,7 @@
  * const someMethod = someModule.someMethod;
  * someMethod(); // Works
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function bindThisToMemberFunctions<TClass extends { new (): any }>(
   instance: InstanceType<TClass>
 ): void {


### PR DESCRIPTION
Fixes the lint warning introduced in #2254.

- #2254

I didn't set the lint rule to error, because #2259 already does that (and other stuff) implicitly.

- #2259