### PR TITLE
fix(location): Czech postcode format

### DIFF
--- a/src/locales/cs_CZ/location/postcode.ts
+++ b/src/locales/cs_CZ/location/postcode.ts
@@ -1,1 +1,1 @@
-export default ['#####', '### ##', '###-##'];
+export default ['#####', '### ##'];


### PR DESCRIPTION
<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->

Postcode for Czechia contains 5 numbers, these numbers are usually divided into one group or two groups which are _3 numbers_, _space_ and _2 numbers_.

Format with dash is not common and never used. 
[Wiki reference about ZIP format](https://cs.wikipedia.org/wiki/Po%C5%A1tovn%C3%AD_sm%C4%9Brovac%C3%AD_%C4%8D%C3%ADslo#Form.C3.A1t_a_v.C3.BDznam_PS.C4.8C)
