### PR TITLE
fix(test): fix imports for jsdocs example verification

### DIFF
--- a/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
+++ b/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
@@ -117,7 +117,9 @@ describe('verify JSDoc tags', () => {
             mkdirSync(dir, { recursive: true });
 
             const path = resolvePathToMethodFile(moduleName, methodName);
-            const imports = [...new Set(examples.match(/faker[^\.]*(?=\.)/g))];
+            const imports = [
+              ...new Set(examples.match(/(?<!\.)faker[^\.]*(?=\.)/g)),
+            ];
             writeFileSync(
               path,
               `import { ${imports.join(


### PR DESCRIPTION
Fixes an issue with our jsdoc example extraction and import guessing that causes rare issues:

````diff
- import { faker, fakerjs } from '../../../../../src';
+ import { faker } from '../../../../../src';

faker.internet.email() // 'Kassandra4@hotmail.com'
faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne63@yahoo.com'
faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe', provider: 'example.fakerjs.dev' }) // 'Jeanne_Doe88@example.fakerjs.dev'
faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe', provider: 'example.fakerjs.dev', allowSpecialCharacters: true }) // 'Jeanne%Doe88@example.fakerjs.dev'
````

`example.fakerjs.dev` incorrectly matched the pattern causing `fakerjs` to be imported and then when typedoc tries to analyze the file it will detect that the import is invalid.