### PR TITLE
esm with tsup demonstration

### DIFF
--- a/test/locale-imports.spec.ts
+++ b/test/locale-imports.spec.ts
@@ -6,7 +6,7 @@ import { keys } from '../src/internal/keys';
 describe.each(keys(allLocales))('locale imports', (locale) => {
   it(`should be possible to directly require('@faker-js/faker/locale/${locale}')`, () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires, unicorn/prefer-module
-    const { faker } = require(`../dist/locale/${locale}`) as {
+    const { faker } = require(`../dist/locale/${locale}.cjs`) as {
       faker: Faker;
     };
 


### PR DESCRIPTION
This PR shows that with tsup + the esm migration all tests are passing

So this is the combination of

- #2261
- #2391

together with outputting .cjs files instead of .esm

---

I also tested with the playground and everything works fine :tada: 