### PR TITLE
docs: show examples for modules

### DIFF
--- a/scripts/apidoc/apiDocsWriter.ts
+++ b/scripts/apidoc/apiDocsWriter.ts
@@ -37,8 +37,8 @@ editLink: false
  * @param moduleName The name of the module to write the docs for.
  * @param lowerModuleName The lowercase name of the module.
  * @param comment The module comments.
- * @param deprecated The deprecation message.
  * @param examples The example code.
+ * @param deprecated The deprecation message.
  * @param methods The methods of the module.
  */
 export async function writeApiDocsModule(

--- a/scripts/apidoc/apiDocsWriter.ts
+++ b/scripts/apidoc/apiDocsWriter.ts
@@ -38,14 +38,14 @@ editLink: false
  * @param lowerModuleName The lowercase name of the module.
  * @param comment The module comments.
  * @param deprecated The deprecation message.
- * @param example The example code.
+ * @param examples The example code.
  * @param methods The methods of the module.
  */
 export async function writeApiDocsModule(
   moduleName: string,
   lowerModuleName: string,
   comment: string,
-  example: string | undefined,
+  examples: string | undefined,
   deprecated: string | undefined,
   methods: Method[]
 ): Promise<ModuleSummary> {
@@ -53,7 +53,7 @@ export async function writeApiDocsModule(
     moduleName,
     lowerModuleName,
     comment,
-    example,
+    examples,
     deprecated,
     methods
   );
@@ -86,7 +86,7 @@ export async function writeApiDocsModule(
  * @param moduleName The name of the module to write the docs for.
  * @param lowerModuleName The lowercase name of the module.
  * @param comment The module comments.
- * @param example The example code.
+ * @param examples The example code.
  * @param deprecated The deprecation message.
  * @param methods The methods of the module.
  */
@@ -94,7 +94,7 @@ async function writeApiDocsModulePage(
   moduleName: string,
   lowerModuleName: string,
   comment: string,
-  example: string | undefined,
+  examples: string | undefined,
   deprecated: string | undefined,
   methods: Method[]
 ): Promise<void> {
@@ -124,7 +124,7 @@ async function writeApiDocsModulePage(
 
   ${comment}
 
-  ${example == null ? '' : `<div class="examples">${example}</div>`}
+  ${examples == null ? '' : `<div class="examples">${examples}</div>`}
 
   :::
 

--- a/scripts/apidoc/apiDocsWriter.ts
+++ b/scripts/apidoc/apiDocsWriter.ts
@@ -38,12 +38,14 @@ editLink: false
  * @param lowerModuleName The lowercase name of the module.
  * @param comment The module comments.
  * @param deprecated The deprecation message.
+ * @param example The example code.
  * @param methods The methods of the module.
  */
 export async function writeApiDocsModule(
   moduleName: string,
   lowerModuleName: string,
   comment: string,
+  example: string | undefined,
   deprecated: string | undefined,
   methods: Method[]
 ): Promise<ModuleSummary> {
@@ -51,6 +53,7 @@ export async function writeApiDocsModule(
     moduleName,
     lowerModuleName,
     comment,
+    example,
     deprecated,
     methods
   );
@@ -83,12 +86,15 @@ export async function writeApiDocsModule(
  * @param moduleName The name of the module to write the docs for.
  * @param lowerModuleName The lowercase name of the module.
  * @param comment The module comments.
+ * @param example The example code.
+ * @param deprecated The deprecation message.
  * @param methods The methods of the module.
  */
 async function writeApiDocsModulePage(
   moduleName: string,
   lowerModuleName: string,
   comment: string,
+  example: string | undefined,
   deprecated: string | undefined,
   methods: Method[]
 ): Promise<void> {
@@ -117,6 +123,8 @@ async function writeApiDocsModulePage(
   }
 
   ${comment}
+
+  ${example == null ? '' : `<div class="examples">${example}</div>`}
 
   :::
 

--- a/scripts/apidoc/fakerClass.ts
+++ b/scripts/apidoc/fakerClass.ts
@@ -29,7 +29,7 @@ async function processClass(
 
   console.log(`Processing ${name} class`);
 
-  const { comment, deprecated } = analyzeModule(fakerClass);
+  const { comment, deprecated, example } = analyzeModule(fakerClass);
   const methods: Method[] = [];
 
   console.debug(`- constructor`);
@@ -43,6 +43,7 @@ async function processClass(
     name,
     moduleFieldName,
     comment,
+    example,
     deprecated,
     methods
   );

--- a/scripts/apidoc/fakerClass.ts
+++ b/scripts/apidoc/fakerClass.ts
@@ -29,7 +29,7 @@ async function processClass(
 
   console.log(`Processing ${name} class`);
 
-  const { comment, deprecated, example } = analyzeModule(fakerClass);
+  const { comment, deprecated, examples } = analyzeModule(fakerClass);
   const methods: Method[] = [];
 
   console.debug(`- constructor`);
@@ -43,7 +43,7 @@ async function processClass(
     name,
     moduleFieldName,
     comment,
-    example,
+    examples,
     deprecated,
     methods
   );

--- a/scripts/apidoc/fakerUtilities.ts
+++ b/scripts/apidoc/fakerUtilities.ts
@@ -28,5 +28,12 @@ async function processUtilities(
     )
   );
 
-  return writeApiDocsModule('Utilities', 'utils', comment, undefined, methods);
+  return writeApiDocsModule(
+    'Utilities',
+    'utils',
+    comment,
+    undefined,
+    undefined,
+    methods
+  );
 }

--- a/scripts/apidoc/markdown.ts
+++ b/scripts/apidoc/markdown.ts
@@ -46,6 +46,16 @@ function comparableSanitizedHtml(html: string): string {
 }
 
 /**
+ * Converts a Typescript code block to an HTML string and sanitizes it.
+ * @param code The code to convert.
+ * @returns The converted HTML string.
+ */
+export function codeToHtml(code: string): string {
+  const delimiter = '```';
+  return mdToHtml(`${delimiter}ts\n${code}\n${delimiter}`);
+}
+
+/**
  * Converts Markdown to an HTML string and sanitizes it.
  * @param md The markdown to convert.
  * @param inline Whether to render the markdown as inline, without a wrapping `<p>` tag. Defaults to `false`.

--- a/scripts/apidoc/moduleMethods.ts
+++ b/scripts/apidoc/moduleMethods.ts
@@ -10,9 +10,9 @@ import { analyzeSignature } from './signature';
 import {
   extractDeprecated,
   extractDescription,
+  extractJoinedRawExamples,
   extractModuleFieldName,
   extractModuleName,
-  extractRawExamples,
   selectApiMethodSignatures,
   selectApiModules,
 } from './typedoc';
@@ -70,12 +70,11 @@ export function analyzeModule(module: DeclarationReflection): {
   deprecated: string | undefined;
   examples: string | undefined;
 } {
-  const exampleTags = extractRawExamples(module);
-  let examples;
-  if (exampleTags.length > 0) {
-    const code = '```';
-    examples = mdToHtml(`${code}ts\n${exampleTags.join('\n').trim()}${code}\n`);
-  }
+  const examplesRaw = extractJoinedRawExamples(module);
+  const code = '```';
+  const examples = examplesRaw
+    ? mdToHtml(`${code}ts\n${examplesRaw}${code}\n`)
+    : undefined;
 
   return {
     comment: adjustUrls(extractDescription(module)),

--- a/scripts/apidoc/moduleMethods.ts
+++ b/scripts/apidoc/moduleMethods.ts
@@ -5,6 +5,7 @@ import type {
 } from 'typedoc';
 import type { Method } from '../../docs/.vitepress/components/api-docs/method';
 import { writeApiDocsModule } from './apiDocsWriter';
+import { codeToHtml } from './markdown';
 import { analyzeSignature } from './signature';
 import {
   extractDeprecated,

--- a/scripts/apidoc/moduleMethods.ts
+++ b/scripts/apidoc/moduleMethods.ts
@@ -43,7 +43,7 @@ async function processModule(
   const moduleName = extractModuleName(module);
   console.log(`Processing Module ${moduleName}`);
   const moduleFieldName = extractModuleFieldName(module);
-  const { comment, deprecated, example } = analyzeModule(module);
+  const { comment, deprecated, examples } = analyzeModule(module);
   const methods = await processModuleMethods(
     module,
     `faker.${moduleFieldName}.`
@@ -68,19 +68,19 @@ async function processModule(
 export function analyzeModule(module: DeclarationReflection): {
   comment: string;
   deprecated: string | undefined;
-  example: string | undefined;
+  examples: string | undefined;
 } {
   const exampleTags = extractRawExamples(module);
-  let example;
+  let examples;
   if (exampleTags.length > 0) {
     const code = '```';
-    example = mdToHtml(`${code}ts\n${exampleTags.join('\n').trim()}${code}\n`);
+    examples = mdToHtml(`${code}ts\n${exampleTags.join('\n').trim()}${code}\n`);
   }
 
   return {
     comment: adjustUrls(extractDescription(module)),
     deprecated: extractDeprecated(module),
-    example,
+    examples,
   };
 }
 

--- a/scripts/apidoc/moduleMethods.ts
+++ b/scripts/apidoc/moduleMethods.ts
@@ -53,7 +53,7 @@ async function processModule(
     moduleName,
     moduleFieldName,
     comment,
-    example,
+    examples,
     deprecated,
     methods
   );

--- a/scripts/apidoc/moduleMethods.ts
+++ b/scripts/apidoc/moduleMethods.ts
@@ -5,7 +5,6 @@ import type {
 } from 'typedoc';
 import type { Method } from '../../docs/.vitepress/components/api-docs/method';
 import { writeApiDocsModule } from './apiDocsWriter';
-import { mdToHtml } from './markdown';
 import { analyzeSignature } from './signature';
 import {
   extractDeprecated,
@@ -71,10 +70,7 @@ export function analyzeModule(module: DeclarationReflection): {
   examples: string | undefined;
 } {
   const examplesRaw = extractJoinedRawExamples(module);
-  const code = '```';
-  const examples = examplesRaw
-    ? mdToHtml(`${code}ts\n${examplesRaw}${code}\n`)
-    : undefined;
+  const examples = examplesRaw ? codeToHtml(examplesRaw) : undefined;
 
   return {
     comment: adjustUrls(extractDescription(module)),

--- a/scripts/apidoc/signature.ts
+++ b/scripts/apidoc/signature.ts
@@ -18,8 +18,8 @@ import { mdToHtml } from './markdown';
 import {
   extractDeprecated,
   extractDescription,
+  extractJoinedRawExamples,
   extractRawDefault,
-  extractRawExamples,
   extractSeeAlsos,
   extractSince,
   extractSourcePath,
@@ -74,9 +74,9 @@ export async function analyzeSignature(
 
   let examples = `${accessor}${methodName}${signatureTypeParametersString}(${signatureParametersString}): ${signature.type?.toString()}\n`;
 
-  const exampleTags = extractRawExamples(signature);
-  if (exampleTags.length > 0) {
-    examples += `${exampleTags.join('\n').trim()}\n`;
+  const exampleTags = extractJoinedRawExamples(signature);
+  if (exampleTags) {
+    examples += exampleTags;
   }
 
   const seeAlsos = extractSeeAlsos(signature).map((seeAlso) =>

--- a/scripts/apidoc/signature.ts
+++ b/scripts/apidoc/signature.ts
@@ -14,7 +14,7 @@ import type {
   MethodParameter,
 } from '../../docs/.vitepress/components/api-docs/method';
 import { formatTypescript } from './format';
-import { mdToHtml } from './markdown';
+import { codeToHtml, mdToHtml } from './markdown';
 import {
   extractDeprecated,
   extractDescription,
@@ -27,8 +27,6 @@ import {
   joinTagParts,
   toBlock,
 } from './typedoc';
-
-const code = '```';
 
 export async function analyzeSignature(
   signature: SignatureReflection,
@@ -97,7 +95,7 @@ export async function analyzeSignature(
     sourcePath: extractSourcePath(signature),
     throws,
     returns: await typeToText(signature.type),
-    examples: mdToHtml(`${code}ts\n${examples}${code}`),
+    examples: codeToHtml(examples),
     deprecated,
     seeAlsos,
   };

--- a/scripts/apidoc/typedoc.ts
+++ b/scripts/apidoc/typedoc.ts
@@ -244,7 +244,7 @@ export function extractRawDefault(reflection?: CommentHolder): string {
  *
  * @param reflection The reflection to extract the examples from.
  */
-export function extractRawExamples(reflection?: CommentHolder): string[] {
+function extractRawExamples(reflection?: CommentHolder): string[] {
   return extractRawCode('@example', reflection);
 }
 

--- a/scripts/apidoc/typedoc.ts
+++ b/scripts/apidoc/typedoc.ts
@@ -249,6 +249,18 @@ export function extractRawExamples(reflection?: CommentHolder): string[] {
 }
 
 /**
+ * Extracts the examples from the jsdocs without the surrounding md code block, then joins them with newlines and trims.
+ *
+ * @param reflection The reflection to extract the examples from.
+ */
+export function extractJoinedRawExamples(
+  reflection?: CommentHolder
+): string | undefined {
+  const examples = extractRawExamples(reflection);
+  return examples.length === 0 ? undefined : examples.join('\n').trim();
+}
+
+/**
  * Extracts all the `@see` references from the jsdocs separately.
  *
  * @param reflection The reflection to extract the see also references from.

--- a/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
@@ -1,5 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`module > analyzeModule() > ModuleFakerJsExampleTest 1`] = `
+{
+  "comment": "This is a description for a module with a code example",
+  "deprecated": undefined,
+  "examples": "<div class=\\"language-ts\\"><button title=\\"Copy Code\\" class=\\"copy\\"></button><span class=\\"lang\\">ts</span><pre v-pre class=\\"shiki material-theme-palenight\\"><code><span class=\\"line\\"><span style=\\"color:#89DDFF\\">new</span><span style=\\"color:#BABED8\\"> </span><span style=\\"color:#82AAFF\\">ModuleFakerJsExampleTest</span><span style=\\"color:#BABED8\\">()</span><span style=\\"color:#89DDFF\\">\`\`\`</span></span></code></pre>
+</div>",
+}
+`;
+
 exports[`module > analyzeModule() > ModuleFakerJsLinkTest 1`] = `
 {
   "comment": "Description with a link to our [website](/)
@@ -20,6 +29,7 @@ and [api docs](/api/).",
 
 exports[`module > analyzeModule() > expected and actual modules are equal 1`] = `
 [
+  "ModuleFakerJsExampleTest",
   "ModuleFakerJsLinkTest",
   "ModuleNextFakerJsLinkTest",
 ]

--- a/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
@@ -5,6 +5,7 @@ exports[`module > analyzeModule() > ModuleFakerJsLinkTest 1`] = `
   "comment": "Description with a link to our [website](/)
 and [api docs](/api/).",
   "deprecated": undefined,
+  "example": undefined,
 }
 `;
 
@@ -13,6 +14,7 @@ exports[`module > analyzeModule() > ModuleNextFakerJsLinkTest 1`] = `
   "comment": "Description with a link to our [website](/)
 and [api docs](/api/).",
   "deprecated": undefined,
+  "example": undefined,
 }
 `;
 

--- a/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`module > analyzeModule() > ModuleFakerJsLinkTest 1`] = `
   "comment": "Description with a link to our [website](/)
 and [api docs](/api/).",
   "deprecated": undefined,
-  "example": undefined,
+  "examples": undefined,
 }
 `;
 
@@ -14,7 +14,7 @@ exports[`module > analyzeModule() > ModuleNextFakerJsLinkTest 1`] = `
   "comment": "Description with a link to our [website](/)
 and [api docs](/api/).",
   "deprecated": undefined,
-  "example": undefined,
+  "examples": undefined,
 }
 `;
 

--- a/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
@@ -1,10 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`module > analyzeModule() > ModuleFakerJsExampleTest 1`] = `
+exports[`module > analyzeModule() > ModuleExampleTest 1`] = `
 {
   "comment": "This is a description for a module with a code example",
   "deprecated": undefined,
-  "examples": "<div class=\\"language-ts\\"><button title=\\"Copy Code\\" class=\\"copy\\"></button><span class=\\"lang\\">ts</span><pre v-pre class=\\"shiki material-theme-palenight\\"><code><span class=\\"line\\"><span style=\\"color:#89DDFF\\">new</span><span style=\\"color:#BABED8\\"> </span><span style=\\"color:#82AAFF\\">ModuleFakerJsExampleTest</span><span style=\\"color:#BABED8\\">()</span><span style=\\"color:#89DDFF\\">\`\`\`</span></span></code></pre>
+  "examples": "<div class=\\"language-ts\\"><button title=\\"Copy Code\\" class=\\"copy\\"></button><span class=\\"lang\\">ts</span><pre v-pre class=\\"shiki material-theme-palenight\\"><code><span class=\\"line\\"><span style=\\"color:#89DDFF\\">new</span><span style=\\"color:#BABED8\\"> </span><span style=\\"color:#82AAFF\\">ModuleExampleTest</span><span style=\\"color:#BABED8\\">()</span><span style=\\"color:#89DDFF\\">\`\`\`</span></span></code></pre>
 </div>",
 }
 `;
@@ -29,7 +29,7 @@ and [api docs](/api/).",
 
 exports[`module > analyzeModule() > expected and actual modules are equal 1`] = `
 [
-  "ModuleFakerJsExampleTest",
+  "ModuleExampleTest",
   "ModuleFakerJsLinkTest",
   "ModuleNextFakerJsLinkTest",
 ]

--- a/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/module.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`module > analyzeModule() > ModuleExampleTest 1`] = `
 {
   "comment": "This is a description for a module with a code example",
   "deprecated": undefined,
-  "examples": "<div class=\\"language-ts\\"><button title=\\"Copy Code\\" class=\\"copy\\"></button><span class=\\"lang\\">ts</span><pre v-pre class=\\"shiki material-theme-palenight\\"><code><span class=\\"line\\"><span style=\\"color:#89DDFF\\">new</span><span style=\\"color:#BABED8\\"> </span><span style=\\"color:#82AAFF\\">ModuleExampleTest</span><span style=\\"color:#BABED8\\">()</span><span style=\\"color:#89DDFF\\">\`\`\`</span></span></code></pre>
+  "examples": "<div class=\\"language-ts\\"><button title=\\"Copy Code\\" class=\\"copy\\"></button><span class=\\"lang\\">ts</span><pre v-pre class=\\"shiki material-theme-palenight\\"><code><span class=\\"line\\"><span style=\\"color:#89DDFF\\">new</span><span style=\\"color:#BABED8\\"> </span><span style=\\"color:#82AAFF\\">ModuleExampleTest</span><span style=\\"color:#BABED8\\">()</span></span></code></pre>
 </div>",
 }
 `;

--- a/test/scripts/apidoc/__snapshots__/signature.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/signature.spec.ts.snap
@@ -261,7 +261,7 @@ exports[`signature > analyzeSignature() > methodWithExample 1`] = `
   "description": "<p>Test with example marker.</p>
 ",
   "examples": "<div class=\\"language-ts\\"><button title=\\"Copy Code\\" class=\\"copy\\"></button><span class=\\"lang\\">ts</span><pre v-pre class=\\"shiki material-theme-palenight\\"><code><span class=\\"line\\"><span style=\\"color:#82AAFF\\">methodWithExample</span><span style=\\"color:#BABED8\\">(): number</span></span>
-<span class=\\"line\\"><span style=\\"color:#BABED8\\">test</span><span style=\\"color:#89DDFF\\">.</span><span style=\\"color:#BABED8\\">apidoc</span><span style=\\"color:#89DDFF\\">.</span><span style=\\"color:#82AAFF\\">methodWithExample</span><span style=\\"color:#BABED8\\">() </span><span style=\\"color:#676E95;font-style:italic\\">// 0\`\`\`</span></span></code></pre>
+<span class=\\"line\\"><span style=\\"color:#BABED8\\">test</span><span style=\\"color:#89DDFF\\">.</span><span style=\\"color:#BABED8\\">apidoc</span><span style=\\"color:#89DDFF\\">.</span><span style=\\"color:#82AAFF\\">methodWithExample</span><span style=\\"color:#BABED8\\">() </span><span style=\\"color:#676E95;font-style:italic\\">// 0</span></span></code></pre>
 </div>",
   "name": "methodWithExample",
   "parameters": [],

--- a/test/scripts/apidoc/__snapshots__/signature.spec.ts.snap
+++ b/test/scripts/apidoc/__snapshots__/signature.spec.ts.snap
@@ -261,7 +261,7 @@ exports[`signature > analyzeSignature() > methodWithExample 1`] = `
   "description": "<p>Test with example marker.</p>
 ",
   "examples": "<div class=\\"language-ts\\"><button title=\\"Copy Code\\" class=\\"copy\\"></button><span class=\\"lang\\">ts</span><pre v-pre class=\\"shiki material-theme-palenight\\"><code><span class=\\"line\\"><span style=\\"color:#82AAFF\\">methodWithExample</span><span style=\\"color:#BABED8\\">(): number</span></span>
-<span class=\\"line\\"><span style=\\"color:#BABED8\\">test</span><span style=\\"color:#89DDFF\\">.</span><span style=\\"color:#BABED8\\">apidoc</span><span style=\\"color:#89DDFF\\">.</span><span style=\\"color:#82AAFF\\">methodWithExample</span><span style=\\"color:#BABED8\\">() </span><span style=\\"color:#676E95;font-style:italic\\">// 0</span></span></code></pre>
+<span class=\\"line\\"><span style=\\"color:#BABED8\\">test</span><span style=\\"color:#89DDFF\\">.</span><span style=\\"color:#BABED8\\">apidoc</span><span style=\\"color:#89DDFF\\">.</span><span style=\\"color:#82AAFF\\">methodWithExample</span><span style=\\"color:#BABED8\\">() </span><span style=\\"color:#676E95;font-style:italic\\">// 0\`\`\`</span></span></code></pre>
 </div>",
   "name": "methodWithExample",
   "parameters": [],

--- a/test/scripts/apidoc/module.example.ts
+++ b/test/scripts/apidoc/module.example.ts
@@ -9,3 +9,11 @@ export class ModuleFakerJsLinkTest {}
  * and [api docs](https://next.fakerjs.dev/api/).
  */
 export class ModuleNextFakerJsLinkTest {}
+
+/**
+ * This is a description for a module with a code example
+ *
+ * @example
+ * new ModuleFakerJsExampleTest()
+ */
+export class ModuleFakerJsExampleTest {}

--- a/test/scripts/apidoc/module.example.ts
+++ b/test/scripts/apidoc/module.example.ts
@@ -14,6 +14,6 @@ export class ModuleNextFakerJsLinkTest {}
  * This is a description for a module with a code example
  *
  * @example
- * new ModuleFakerJsExampleTest()
+ * new ModuleExampleTest()
  */
-export class ModuleFakerJsExampleTest {}
+export class ModuleExampleTest {}

--- a/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
+++ b/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
@@ -7,8 +7,8 @@ import { analyzeSignature } from '../../../scripts/apidoc/signature';
 import {
   extractDeprecated,
   extractDescription,
+  extractJoinedRawExamples,
   extractModuleFieldName,
-  extractRawExamples,
   extractSeeAlsos,
   extractSince,
   extractTagContent,
@@ -110,7 +110,7 @@ describe('verify JSDoc tags', () => {
             // Write temp files to disk
 
             // Extract examples and make them runnable
-            const examples = extractRawExamples(signature).join('').trim();
+            const examples = extractJoinedRawExamples(signature);
 
             // Save examples to a file to run them later in the specific tests
             const dir = resolveDirToModule(moduleName);
@@ -135,7 +135,7 @@ describe('verify JSDoc tags', () => {
 
           it('verify @example tag', async () => {
             // Extract the examples
-            const examples = extractRawExamples(signature).join('').trim();
+            const examples = extractJoinedRawExamples(signature);
 
             expect(
               examples,


### PR DESCRIPTION
Shows @example blocks for modules (ie Faker and SimpleFaker) in the 
generated docs.

<img width="748" alt="Screenshot 2023-09-18 at 19 22 35" src="https://github.com/faker-js/faker/assets/152770/e4613a52-37a1-4209-8d2b-471213ba3b4a">

