### PR TITLE
docs: fix outdated comment regarding multiple faker locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,6 @@ export const USERS: User[] = faker.helpers.multiple(createRandomUser, {
 });
 ```
 
-The above code indicates a basic usage of Faker.
-The point of interest is the import statements at the top.
-The first import indicates how one can import the entirety of Faker, which includes every locale, while the commented-out import showcases how to import only a single locale.
-In most situations, importing a single locale is preferable for performance because some testing frameworks reload imports for every test file, which causes startup latencies to add up quickly.
-Thus, limiting the import to a single locale can speed up startup times.
-
 ## 💎 Modules
 
 An in-depth overview of the API methods is available in the documentation for [v8 (stable)](https://fakerjs.dev/api/) and [v8.\* (next)](https://next.fakerjs.dev/api/).


### PR DESCRIPTION
Fixes #2392 

- #2392

I searched for other related outdated sections, but couldn't find any.

I removed the section because faker now only contains a single locale per faker instance.