### PR TITLE
infra: enable no-useless-escape eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,8 +28,6 @@ module.exports = defineConfig({
   },
   plugins: ['@typescript-eslint', 'prettier', 'deprecation', 'jsdoc'],
   rules: {
-    // We may want to use this in the future
-    'no-useless-escape': 'off',
     eqeqeq: ['error', 'always', { null: 'ignore' }],
     'no-else-return': 'error',
     'prefer-template': 'error',

--- a/scripts/generateLocales.ts
+++ b/scripts/generateLocales.ts
@@ -240,7 +240,7 @@ function updateLocaleFile(filePath: string): void {
   if (lstatSync(filePath).isFile()) {
     const pathParts = filePath
       .substring(pathLocales.length + 1, filePath.length - 3)
-      .split(/[\\\/]/);
+      .split(/[\\/]/);
     const locale = pathParts[0];
     pathParts.splice(0, 1);
     updateLocaleFileHook(filePath, locale, pathParts);

--- a/src/modules/git/index.ts
+++ b/src/modules/git/index.ts
@@ -97,7 +97,7 @@ export class GitModule {
     const email = this.faker.internet.email({ firstName, lastName });
 
     // Normalize user according to https://github.com/libgit2/libgit2/issues/5342
-    user = user.replace(/^[\.,:;"\\']|[\<\>\n]|[\.,:;"\\']$/g, '');
+    user = user.replace(/^[.,:;"\\']|[<>\n]|[.,:;"\\']$/g, '');
 
     lines.push(
       `Author: ${user} <${email}>`,

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -99,9 +99,9 @@ function legacyRegexpStringParse(
   string: string = ''
 ): string {
   // Deal with range repeat `{min,max}`
-  const RANGE_REP_REG = /(.)\{(\d+)\,(\d+)\}/;
+  const RANGE_REP_REG = /(.)\{(\d+),(\d+)\}/;
   const REP_REG = /(.)\{(\d+)\}/;
-  const RANGE_REG = /\[(\d+)\-(\d+)\]/;
+  const RANGE_REG = /\[(\d+)-(\d+)\]/;
   let min: number;
   let max: number;
   let tmp: number;
@@ -192,7 +192,7 @@ export class SimpleHelpersModule {
       .normalize('NFKD') //for example è decomposes to as e +  ̀
       .replace(/[\u0300-\u036f]/g, '') // removes combining marks
       .replace(/ /g, '-') // replaces spaces with hyphens
-      .replace(/[^\w\.\-]+/g, ''); // removes all non-word characters except for dots and hyphens
+      .replace(/[^\w.-]+/g, ''); // removes all non-word characters except for dots and hyphens
   }
 
   /**
@@ -416,7 +416,7 @@ export class SimpleHelpersModule {
 
     // Deal with single wildcards
     const SINGLE_CHAR_REG =
-      /([.A-Za-z0-9])(?:\{(\d+)(?:\,(\d+)|)\}|(\?|\*|\+))(?![^[]*]|[^{]*})/;
+      /([.A-Za-z0-9])(?:\{(\d+)(?:,(\d+)|)\}|(\?|\*|\+))(?![^[]*]|[^{]*})/;
     let token = pattern.match(SINGLE_CHAR_REG);
     while (token != null) {
       const quantifierMin: string = token[2];
@@ -439,7 +439,7 @@ export class SimpleHelpersModule {
 
     const SINGLE_RANGE_REG = /(\d-\d|\w-\w|\d|\w|[-!@#$&()`.+,/"])/;
     const RANGE_ALPHANUMEMRIC_REG =
-      /\[(\^|)(-|)(.+?)\](?:\{(\d+)(?:\,(\d+)|)\}|(\?|\*|\+)|)/;
+      /\[(\^|)(-|)(.+?)\](?:\{(\d+)(?:,(\d+)|)\}|(\?|\*|\+)|)/;
     // Deal with character classes with quantifiers `[a-z0-9]{min[, max]}`
     token = pattern.match(RANGE_ALPHANUMEMRIC_REG);
     while (token != null) {
@@ -548,7 +548,7 @@ export class SimpleHelpersModule {
       token = pattern.match(RANGE_ALPHANUMEMRIC_REG);
     }
 
-    const RANGE_REP_REG = /(.)\{(\d+)\,(\d+)\}/;
+    const RANGE_REP_REG = /(.)\{(\d+),(\d+)\}/;
     // Deal with quantifier ranges `{min,max}`
     token = pattern.match(RANGE_REP_REG);
     while (token != null) {

--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -265,7 +265,7 @@ export class InternetModule {
     let localPart: string = this.userName({ firstName, lastName });
     // Strip any special characters from the local part of the email address
     // This could happen if invalid chars are passed in manually in the firstName/lastName
-    localPart = localPart.replace(/[^A-Za-z0-9._+\-]+/g, '');
+    localPart = localPart.replace(/[^A-Za-z0-9._+-]+/g, '');
 
     // The local part of an email address is limited to 64 chars per RFC 3696
     // We limit to 50 chars to be more realistic

--- a/test/modules/commerce.spec.ts
+++ b/test/modules/commerce.spec.ts
@@ -110,7 +110,7 @@ describe('commerce', () => {
           expect(
             amount,
             'The expected match should not include a currency symbol'
-          ).toMatch(/^[0-9\.]+$/);
+          ).toMatch(/^[0-9.]+$/);
         });
 
         it('should handle negative amounts, but return 0', () => {

--- a/test/modules/finance.spec.ts
+++ b/test/modules/finance.spec.ts
@@ -279,7 +279,7 @@ describe('finance', () => {
           expect(
             amount,
             'The expected match should not include a currency symbol'
-          ).toMatch(/^[0-9\.]+$/);
+          ).toMatch(/^[0-9.]+$/);
         });
 
         it('should handle negative amounts', () => {
@@ -456,7 +456,7 @@ describe('finance', () => {
         it('should return a correct credit card number when issuer provided', () => {
           //TODO: implement checks for each format with regexp
           const visa = faker.finance.creditCardNumber('visa');
-          expect(visa).toMatch(/^4(([0-9]){12}|([0-9]){3}(\-([0-9]){4}){3})$/);
+          expect(visa).toMatch(/^4(([0-9]){12}|([0-9]){3}(-([0-9]){4}){3})$/);
           expect(visa).toSatisfy(luhnCheck);
 
           const mastercard = faker.finance.creditCardNumber('mastercard');
@@ -490,7 +490,7 @@ describe('finance', () => {
 
         it('should return custom formatted strings', () => {
           let number = faker.finance.creditCardNumber('###-###-##L');
-          expect(number).toMatch(/^\d{3}\-\d{3}\-\d{3}$/);
+          expect(number).toMatch(/^\d{3}-\d{3}-\d{3}$/);
           expect(number).toSatisfy(luhnCheck);
 
           number = faker.finance.creditCardNumber('234[5-9]#{999}L');

--- a/test/modules/helpers.spec.ts
+++ b/test/modules/helpers.spec.ts
@@ -563,7 +563,7 @@ describe('helpers', () => {
             '6453-####-####-####-###L'
           );
           expect(number).toMatch(
-            /^6453\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}$/
+            /^6453-([0-9]){4}-([0-9]){4}-([0-9]){4}-([0-9]){4}$/
           );
           expect(number).toSatisfy(luhnCheck);
         });
@@ -574,7 +574,7 @@ describe('helpers', () => {
             '*'
           );
           expect(number).toMatch(
-            /^6453\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}$/
+            /^6453-([0-9]){4}-([0-9]){4}-([0-9]){4}-([0-9]){4}$/
           );
           expect(number).toSatisfy(luhnCheck);
         });
@@ -585,14 +585,14 @@ describe('helpers', () => {
             '*'
           );
           expect(number).toMatch(
-            /^6453\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}\-([0-9]){4}$/
+            /^6453-([0-9]){4}-([0-9]){4}-([0-9]){4}-([0-9]){4}$/
           );
           expect(number).toSatisfy(luhnCheck);
           number = faker.helpers.replaceCreditCardSymbols(
             '645[5-9]-#{4,6}-#{1,2}-#{4,6}-#{3}L'
           );
           expect(number).toMatch(
-            /^645[5-9]\-([0-9]){4,6}\-([0-9]){1,2}\-([0-9]){4,6}\-([0-9]){4}$/
+            /^645[5-9]-([0-9]){4,6}-([0-9]){1,2}-([0-9]){4,6}-([0-9]){4}$/
           );
           expect(number).toSatisfy(luhnCheck);
         });
@@ -607,14 +607,14 @@ describe('helpers', () => {
           const string = faker.helpers.regexpStyleStringParse('#{5,10}');
           expect(string.length).toBeLessThanOrEqual(10);
           expect(string.length).toBeGreaterThanOrEqual(5);
-          expect(string).toMatch(/^\#{5,10}$/);
+          expect(string).toMatch(/^#{5,10}$/);
         });
 
         it('flips the range when min > max', () => {
           const string = faker.helpers.regexpStyleStringParse('#{10,5}');
           expect(string.length).toBeLessThanOrEqual(10);
           expect(string.length).toBeGreaterThanOrEqual(5);
-          expect(string).toMatch(/^\#{5,10}$/);
+          expect(string).toMatch(/^#{5,10}$/);
         });
 
         it('repeats string {n} number of times', () => {
@@ -638,9 +638,7 @@ describe('helpers', () => {
           const string = faker.helpers.regexpStyleStringParse(
             'Test#{5}%{2,5}Testing**[1-5]**{10}END'
           );
-          expect(string).toMatch(
-            /^Test\#{5}%{2,5}Testing\*\*[1-5]\*\*{10}END$/
-          );
+          expect(string).toMatch(/^Test#{5}%{2,5}Testing\*\*[1-5]\*\*{10}END$/);
         });
       });
 
@@ -649,7 +647,7 @@ describe('helpers', () => {
           const string = faker.helpers.fromRegExp(/#{5,10}/);
           expect(string.length).toBeLessThanOrEqual(10);
           expect(string.length).toBeGreaterThanOrEqual(5);
-          expect(string).toMatch(/^\#{5,10}$/);
+          expect(string).toMatch(/^#{5,10}$/);
         });
 
         it('repeats string {n} number of times', () => {
@@ -667,7 +665,7 @@ describe('helpers', () => {
           const string = faker.helpers.fromRegExp(
             'Test#{5}%{2,5}Testing*[1-5]{10}END'
           );
-          expect(string).toMatch(/^Test\#{5}%{2,5}Testing*[1-5]{10}END$/);
+          expect(string).toMatch(/^Test#{5}%{2,5}Testing*[1-5]{10}END$/);
         });
 
         it('throws error when min > max outside set', () => {
@@ -1176,7 +1174,7 @@ describe('helpers', () => {
             'lName',
             'domain',
           ]); // third argument is provider, or domain for email
-          expect(result).toMatch(/\@domain/);
+          expect(result).toMatch(/@domain/);
         });
 
         it('should be possible to limit unique call by maxTime in ms', () => {

--- a/test/modules/image.spec.ts
+++ b/test/modules/image.spec.ts
@@ -410,7 +410,7 @@ describe('image', () => {
 
       expect(avatarUrl).toBeTypeOf('string');
       expect(avatarUrl).toMatch(
-        /^https:\/\/cloudflare\-ipfs\.com\/ipfs\/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye\/avatar\/\d{1,4}\.jpg$/
+        /^https:\/\/cloudflare-ipfs\.com\/ipfs\/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye\/avatar\/\d{1,4}\.jpg$/
       );
     });
   });
@@ -463,7 +463,7 @@ describe('image', () => {
 
       expect(imageUrl).toBeTypeOf('string');
       expect(imageUrl).toMatch(
-        /^https\:\/\/loremflickr\.com\/\d+\/\d+\?lock=\d+$/
+        /^https:\/\/loremflickr\.com\/\d+\/\d+\?lock=\d+$/
       );
     });
   });
@@ -474,7 +474,7 @@ describe('image', () => {
 
       expect(imageUrl).toBeTypeOf('string');
       expect(imageUrl).toMatch(
-        /^https\:\/\/picsum\.photos\/seed\/[0-9a-zA-Z]+\/\d+\/\d+$/
+        /^https:\/\/picsum\.photos\/seed\/[0-9a-zA-Z]+\/\d+\/\d+$/
       );
     });
   });
@@ -485,7 +485,7 @@ describe('image', () => {
 
       expect(imageUrl).toBeTypeOf('string');
       expect(imageUrl).toMatch(
-        /^https\:\/\/via\.placeholder\.com\/\d+x\d+\/[0-9a-fA-F]{6}\/[0-9a-fA-F]{6}\.[a-z]{3,4}\?text=.+$/
+        /^https:\/\/via\.placeholder\.com\/\d+x\d+\/[0-9a-fA-F]{6}\/[0-9a-fA-F]{6}\.[a-z]{3,4}\?text=.+$/
       );
     });
   });

--- a/test/modules/internet.spec.ts
+++ b/test/modules/internet.spec.ts
@@ -649,7 +649,7 @@ describe('internet', () => {
           expect(ua).toBeTypeOf('string');
           expect(ua.length).toBeGreaterThanOrEqual(1);
           expect(ua).toMatch(
-            /^(([^\d]+\/[\dA-Za-z\.]+(\s\(.*\)))|([^\d]+\/[\dA-Za-z\.]+(\s\(.*\)*))(\s[^\d]+\/[\dA-Za-z\.]+(\s\(.*\)*))*)$/
+            /^(([^\d]+\/[\dA-Za-z.]+(\s\(.*\)))|([^\d]+\/[\dA-Za-z.]+(\s\(.*\)*))(\s[^\d]+\/[\dA-Za-z.]+(\s\(.*\)*))*)$/
           );
         });
       });

--- a/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
+++ b/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
@@ -118,7 +118,7 @@ describe('verify JSDoc tags', () => {
 
             const path = resolvePathToMethodFile(moduleName, methodName);
             const imports = [
-              ...new Set(examples.match(/(?<!\.)faker[^\.]*(?=\.)/g)),
+              ...new Set(examples.match(/(?<!\.)faker[^.]*(?=\.)/g)),
             ];
             writeFileSync(
               path,


### PR DESCRIPTION
This lint rule is likely to be enabled/"covered" by eslint rule `unicorn/better-regex` after #2418 is merged.

- #2418

This PR is independent of that PR though.