### PR TITLE
infra(unicorn): prefer-array-flat-map

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,7 +71,6 @@ module.exports = defineConfig({
     'unicorn/no-useless-switch-case': 'off',
     'unicorn/no-zero-fractions': 'off',
     'unicorn/numeric-separators-style': 'off',
-    'unicorn/prefer-array-flat-map': 'off',
     'unicorn/prefer-array-some': 'off',
     'unicorn/prefer-code-point': 'off',
     'unicorn/prefer-export-from': 'off',

--- a/scripts/apidoc/diff.ts
+++ b/scripts/apidoc/diff.ts
@@ -46,7 +46,7 @@ async function load(source: string): Promise<DocsApiDiffIndex> {
 function allKeys(
   ...entries: ReadonlyArray<Record<string, unknown>>
 ): Set<string> {
-  return new Set(entries.map(Object.keys).flat());
+  return new Set(entries.flatMap(Object.keys));
 }
 
 /**

--- a/src/locales/th/person/last_name.ts
+++ b/src/locales/th/person/last_name.ts
@@ -21,9 +21,9 @@ const common_isan_suffix = [
   'พิมาย',
   'นอก',
 ];
-const isan_complete = common_isan_prefix
-  .map((prefix) => common_isan_suffix.map((suffix) => `${prefix}${suffix}`))
-  .flat();
+const isan_complete = common_isan_prefix.flatMap((prefix) =>
+  common_isan_suffix.map((suffix) => `${prefix}${suffix}`)
+);
 
 // https://www.thairath.co.th/lifestyle/culture/2030525
 const chinese = [


### PR DESCRIPTION
Ref: #2439

- #2439

---

Enables the [`unicorn/prefer-array-flat-map`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md) lint rule.