### PR TITLE
infra(unicorn): no-array-for-each

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -56,7 +56,6 @@ module.exports = defineConfig({
     'unicorn/filename-case': 'off',
     'unicorn/import-style': 'off',
     'unicorn/no-array-callback-reference': 'off',
-    'unicorn/no-array-for-each': 'off',
     'unicorn/no-array-reduce': 'off',
     'unicorn/no-await-expression-member': 'off',
     'unicorn/no-for-loop': 'off',

--- a/scripts/apidoc/parameterDefaults.ts
+++ b/scripts/apidoc/parameterDefaults.ts
@@ -130,8 +130,7 @@ function patchSignatureParameterDefaults(
     throw new Error('Unexpected parameter length mismatch');
   }
 
-  signatureParameters.forEach(
-    (param, index) =>
-      (param.defaultValue = parameterDefaults[index] || param.defaultValue)
-  );
+  for (const [index, param] of signatureParameters.entries()) {
+    param.defaultValue = parameterDefaults[index] || param.defaultValue;
+  }
 }

--- a/src/modules/datatype/index.ts
+++ b/src/modules/datatype/index.ts
@@ -407,11 +407,11 @@ export class DatatypeModule {
     const properties = ['foo', 'bar', 'bike', 'a', 'b', 'name', 'prop'];
     const returnObject: Record<string, string | number> = {};
 
-    properties.forEach((prop) => {
+    for (const prop of properties) {
       returnObject[prop] = this.boolean()
         ? this.faker.string.sample()
         : this.faker.number.int();
-    });
+    }
 
     return JSON.stringify(returnObject);
   }

--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -154,15 +154,11 @@ export class SystemModule {
    * @since 3.1.0
    */
   fileType(): string {
-    const typeSet = new Set<string>();
     const mimeTypes = this.faker.definitions.system.mimeTypes;
 
-    Object.keys(mimeTypes).forEach((m) => {
-      const type = m.split('/')[0];
-
-      typeSet.add(type);
-    });
-
+    const typeSet = new Set(
+      Object.keys(mimeTypes).map((key) => key.split('/')[0])
+    );
     const types = Array.from(typeSet);
     return this.faker.helpers.arrayElement(types);
   }
@@ -179,22 +175,15 @@ export class SystemModule {
    * @since 3.1.0
    */
   fileExt(mimeType?: string): string {
+    const mimeTypes = this.faker.definitions.system.mimeTypes;
+
     if (typeof mimeType === 'string') {
-      const mimes = this.faker.definitions.system.mimeTypes;
-      return this.faker.helpers.arrayElement(mimes[mimeType].extensions);
+      return this.faker.helpers.arrayElement(mimeTypes[mimeType].extensions);
     }
 
-    const mimeTypes = this.faker.definitions.system.mimeTypes;
-    const extensionSet = new Set<string>();
-
-    Object.keys(mimeTypes).forEach((m) => {
-      if (mimeTypes[m].extensions instanceof Array) {
-        mimeTypes[m].extensions.forEach((ext) => {
-          extensionSet.add(ext);
-        });
-      }
-    });
-
+    const extensionSet = new Set(
+      Object.values(mimeTypes).flatMap(({ extensions }) => extensions)
+    );
     const extensions = Array.from(extensionSet);
     return this.faker.helpers.arrayElement(extensions);
   }

--- a/test/all_functional.spec.ts
+++ b/test/all_functional.spec.ts
@@ -119,7 +119,8 @@ describe('functional tests', () => {
     }
 
     describe.each(Object.entries(modules))('%s', (module, methods) => {
-      methods.forEach((meth) => {
+      // eslint-disable-next-line vitest/prefer-each -- need to dynamically succeed/fail
+      for (const meth of methods) {
         const testAssertion = () => {
           // TODO @ST-DDT 2022-03-28: Use random seed once there are no more failures
           faker.seed(1);
@@ -140,7 +141,7 @@ describe('functional tests', () => {
           // We expect a failure here to ensure we remove the exclusions when fixed
           it.fails(`${meth}()`, testAssertion);
         }
-      });
+      }
     });
   });
 });
@@ -153,7 +154,8 @@ describe('faker.helpers.fake functional tests', () => {
     }
 
     describe.each(Object.entries(modules))('%s', (module, methods) => {
-      methods.forEach((meth) => {
+      // eslint-disable-next-line vitest/prefer-each -- need to dynamically succeed/fail
+      for (const meth of methods) {
         const testAssertion = () => {
           // TODO @ST-DDT 2022-03-28: Use random seed once there are no more failures
           faker.seed(1);
@@ -172,7 +174,7 @@ describe('faker.helpers.fake functional tests', () => {
           // We expect a failure here to ensure we remove the exclusions when fixed
           it.fails(`${meth}()`, testAssertion);
         }
-      });
+      }
     });
   });
 });

--- a/test/modules/color.spec.ts
+++ b/test/modules/color.spec.ts
@@ -88,10 +88,10 @@ describe('color', () => {
         it('should return a random rgb color in decimal format', () => {
           const color = faker.color.rgb({ format: 'decimal' });
           expect(color).length(3);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(255);
-          });
+          }
         });
       });
 
@@ -124,10 +124,10 @@ describe('color', () => {
           });
           expect(color[color.length - 1]).toBeGreaterThanOrEqual(0);
           expect(color[color.length - 1]).toBeLessThanOrEqual(1);
-          color.slice(0, 4).forEach((value: number) => {
+          for (const value of color.slice(0, 4)) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(255);
-          });
+          }
         });
       });
 
@@ -154,10 +154,10 @@ describe('color', () => {
         it('should return a random cmyk color', () => {
           const color = faker.color.cmyk();
           expect(color).length(4);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(1);
-          });
+          }
         });
       });
 
@@ -165,10 +165,10 @@ describe('color', () => {
         it('should return a random cmyk color in decimal format', () => {
           const color = faker.color.cmyk({ format: 'decimal' });
           expect(color).length(4);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(1);
-          });
+          }
         });
       });
 
@@ -196,10 +196,10 @@ describe('color', () => {
           expect(color).length(3);
           expect(color[0]).toBeGreaterThanOrEqual(0);
           expect(color[0]).toBeLessThanOrEqual(360);
-          color.slice(1).forEach((value: number) => {
+          for (const value of color.slice(1)) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(1);
-          });
+          }
         });
       });
 
@@ -246,10 +246,10 @@ describe('color', () => {
           expect(color).length(3);
           expect(color[0]).toBeGreaterThanOrEqual(0);
           expect(color[0]).toBeLessThanOrEqual(360);
-          color.slice(1).forEach((value: number) => {
+          for (const value of color.slice(1)) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(1);
-          });
+          }
         });
       });
 
@@ -259,10 +259,10 @@ describe('color', () => {
           expect(color).length(3);
           expect(color[0]).toBeGreaterThanOrEqual(0);
           expect(color[0]).toBeLessThanOrEqual(360);
-          color.slice(1).forEach((value: number) => {
+          for (const value of color.slice(1)) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(1);
-          });
+          }
         });
       });
 
@@ -286,10 +286,10 @@ describe('color', () => {
           expect(color).length(3);
           expect(color[0]).toBeGreaterThanOrEqual(0);
           expect(color[0]).toBeLessThanOrEqual(1);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(-100);
             expect(value).toBeLessThanOrEqual(100);
-          });
+          }
         });
       });
 
@@ -299,10 +299,10 @@ describe('color', () => {
           expect(color).length(3);
           expect(color[0]).toBeGreaterThanOrEqual(0);
           expect(color[0]).toBeLessThanOrEqual(1);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(-100);
             expect(value).toBeLessThanOrEqual(100);
-          });
+          }
         });
       });
 
@@ -328,10 +328,10 @@ describe('color', () => {
           expect(color).length(3);
           expect(color[0]).toBeGreaterThanOrEqual(0);
           expect(color[0]).toBeLessThanOrEqual(1);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(230);
-          });
+          }
         });
       });
 
@@ -341,10 +341,10 @@ describe('color', () => {
           expect(color).length(3);
           expect(color[0]).toBeGreaterThanOrEqual(0);
           expect(color[0]).toBeLessThanOrEqual(1);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(230);
-          });
+          }
         });
       });
 
@@ -368,10 +368,10 @@ describe('color', () => {
         it('should return a random color for a CSS color space in decimal format', () => {
           const color = faker.color.colorByCSSColorSpace();
           expect(color).length(3);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(1);
-          });
+          }
         });
       });
 
@@ -379,10 +379,10 @@ describe('color', () => {
         it('should return a random color for a CSS color space in decimal format', () => {
           const color = faker.color.colorByCSSColorSpace({ format: 'decimal' });
           expect(color).length(3);
-          color.forEach((value: number) => {
+          for (const value of color) {
             expect(value).toBeGreaterThanOrEqual(0);
             expect(value).toBeLessThanOrEqual(1);
-          });
+          }
         });
       });
 

--- a/test/modules/helpers.spec.ts
+++ b/test/modules/helpers.spec.ts
@@ -375,9 +375,9 @@ describe('helpers', () => {
           expect(subset.length).toBeLessThanOrEqual(testArray.length);
 
           // Check elements
-          subset.forEach((element) => {
+          for (const element of subset) {
             expect(testArray).toContain(element);
-          });
+          }
 
           // Check uniqueness
           expect(subset).not.toContainDuplicates();
@@ -391,9 +391,9 @@ describe('helpers', () => {
           expect(subset).toHaveLength(3);
 
           // Check elements
-          subset.forEach((element) => {
+          for (const element of subset) {
             expect(testArray).toContain(element);
-          });
+          }
 
           // Check uniqueness
           expect(subset).toHaveLength(new Set(subset).size);
@@ -411,9 +411,9 @@ describe('helpers', () => {
           expect(subset.length).toBeLessThanOrEqual(4);
 
           // Check elements
-          subset.forEach((element) => {
+          for (const element of subset) {
             expect(testArray).toContain(element);
-          });
+          }
 
           // Check uniqueness
           expect(subset).not.toContainDuplicates();
@@ -427,9 +427,9 @@ describe('helpers', () => {
           expect(subset.length).toBe(5);
 
           // Check elements
-          subset.forEach((element) => {
+          for (const element of subset) {
             expect(testArray).toContain(element);
-          });
+          }
         });
 
         it('should return an empty array when array length > 0 and count = 0', () => {

--- a/test/modules/system.spec.ts
+++ b/test/modules/system.spec.ts
@@ -395,12 +395,12 @@ describe('system', () => {
           (options, count: number) => {
             const cron = faker.system.cron(options).split(' ');
             expect(cron).toHaveLength(count);
-            cron.forEach((cronElement, i) =>
+            for (const [index, cronElement] of cron.entries()) {
               expect(
                 cronElement,
-                `generated cron, ${cronElement} should match regex ${regexElements[i]}`
-              ).toMatch(new RegExp(regexElements[i]))
-            );
+                `generated cron, ${cronElement} should match regex ${regexElements[index]}`
+              ).toMatch(new RegExp(regexElements[index]));
+            }
           }
         );
 

--- a/test/scripts/apidoc/signature.debug.ts
+++ b/test/scripts/apidoc/signature.debug.ts
@@ -12,10 +12,10 @@ const methods = loadExampleMethods();
 
 initMarkdownRenderer()
   .then(() => {
-    Object.entries(methods).forEach(([name, method]) => {
+    for (const [name, method] of Object.entries(methods)) {
       console.log('Analyzing:', name);
       const result = analyzeSignature(method, '', method.name);
       console.log('Result:', result);
-    });
+    }
   })
   .catch(console.error);

--- a/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
+++ b/test/scripts/apidoc/verify-jsdoc-tags.spec.ts
@@ -176,9 +176,9 @@ describe('verify JSDoc tags', () => {
           });
 
           it('verify @param tags', async () => {
-            (
+            for (const param of (
               await analyzeSignature(signature, '', methodName)
-            ).parameters.forEach((param) => {
+            ).parameters) {
               const { name, description } = param;
               const plainDescription = description
                 .replace(/<[^>]+>/g, '')
@@ -188,11 +188,11 @@ describe('verify JSDoc tags', () => {
                 `Expect param ${name} to have a description`
               ).not.toBe(MISSING_DESCRIPTION);
               assertDescription(description, true);
-            });
+            }
           });
 
           it('verify @see tags', () => {
-            extractSeeAlsos(signature).forEach((link) => {
+            for (const link of extractSeeAlsos(signature)) {
               if (link.startsWith('faker.')) {
                 // Expected @see faker.xxx.yyy()
                 expect(link, 'Expect method reference to contain ()').toContain(
@@ -203,7 +203,7 @@ describe('verify JSDoc tags', () => {
                 );
                 expect(allowedReferences).toContain(link.replace(/\(.*/, ''));
               }
-            });
+            }
           });
 
           it('verify @since tag', () => {


### PR DESCRIPTION
Ref: #2439

- #2439

---

Enables the [`unicorn/no-array-for-each`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-for-each.md) lint rule.