### PR TITLE
infra(unicorn): catch-error-name

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,6 @@ module.exports = defineConfig({
     // TODO @Shinigami92 2023-09-23: The following rules currently conflict with our code.
     // Each rule should be checked whether it should be enabled/configured and the problems fixed, or stay disabled permanently.
     'unicorn/better-regex': 'off',
-    'unicorn/catch-error-name': 'off',
     'unicorn/consistent-function-scoping': 'off',
     'unicorn/escape-case': 'off',
     'unicorn/filename-case': 'off',

--- a/scripts/generateLocales.ts
+++ b/scripts/generateLocales.ts
@@ -296,11 +296,11 @@ async function main(): Promise<void> {
       }
 
       localeTitle = title;
-    } catch (e) {
+    } catch (error) {
       console.error(
         `Failed to load ${pathMetadata}. Please make sure the file exists and exports a MetadataDefinition.`
       );
-      console.error(e);
+      console.error(error);
     }
 
     const localizedFaker = `faker${locale.replace(/^([a-z]+)/, (part) =>
@@ -367,8 +367,8 @@ async function main(): Promise<void> {
   writeFileSync(pathDocsGuideLocalization, localizationContent);
 }
 
-main().catch((e) => {
+main().catch((error) => {
   // Workaround until top level await is available
-  console.error(e);
+  console.error(error);
   process.exit(1);
 });

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -1467,7 +1467,7 @@ export class HelpersModule extends SimpleHelpersModule {
     // If anyone actually needs to optimize this specific code path, please open a support issue on github
     try {
       params = JSON.parse(`[${parameters}]`);
-    } catch (err) {
+    } catch {
       // since JSON.parse threw an error, assume parameters was actually a string
       params = [parameters];
     }


### PR DESCRIPTION
Ref: #2439

- #2439

---

Enables the [`unicorn/catch-error-name`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/catch-error-name.md) lint rule.