### PR TITLE
docs: fix deprecated text for internet.password

### DIFF
--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -1358,7 +1358,7 @@ export class InternetModule {
    *
    * @since 2.0.1
    *
-   * @deprecated Use `faker.internet({ length, memorable, pattern, prefix })` instead.
+   * @deprecated Use `faker.internet.password({ length, memorable, pattern, prefix })` instead.
    */
   password(
     len?: number,


### PR DESCRIPTION
The `.password` is missing in the "deprecated" message.