### PR TITLE
infra(security): switch to use workflow in target branch

### DIFF
--- a/.github/workflows/check-mergable-by-label.yml
+++ b/.github/workflows/check-mergable-by-label.yml
@@ -1,7 +1,7 @@
 name: PR Labels
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened

--- a/.github/workflows/ci-old.yml
+++ b/.github/workflows/ci-old.yml
@@ -1,0 +1,233 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - next
+  pull_request:
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  unit-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node_version: [14, 16, 18, 20]
+        include:
+          - os: macos-latest
+            node_version: 16
+          - os: macos-latest
+            node_version: 18
+          - os: macos-latest
+            node_version: 20
+          - os: windows-latest
+            node_version: 16
+          - os: windows-latest
+            node_version: 18
+          - os: windows-latest
+            node_version: 20
+      fail-fast: false
+    timeout-minutes: 10
+
+    name: 'Build & Unit Test: node-${{ matrix.node_version }}, ${{ matrix.os }}'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          # Required for docs/versions tests
+          fetch-depth: 0
+
+      - name: Install pnpm (node 14, pnpm 7)
+        if: matrix.node_version == 14
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+        with:
+          version: 7
+
+      - name: Install pnpm
+        if: matrix.node_version != 14
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+
+      - name: Set node version to ${{ matrix.node_version }}
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm run test
+
+  timezone-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node_version: [20]
+      fail-fast: false
+    env:
+      LANG: zh_SG.UTF-8
+      TZ: Asia/Singapore
+    timeout-minutes: 10
+
+    name: 'Timezone Test: node-${{ matrix.node_version }}, ${{ matrix.os }}'
+    steps:
+      - name: Set system LANG=zh_SG.UTF-8
+        run: |
+          sudo locale-gen zh_SG.UTF-8
+          sudo update-locale LANG=zh_SG.UTF-8
+
+      - name: Check date
+        run: date
+
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          # Required for docs/versions tests
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+
+      - name: Set node version to ${{ matrix.node_version }}
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm run test
+
+  e2e-test:
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node-20.6.1-chrome-116.0.5845.187-1-ff-117.0-edge-116.0.1938.76-1
+      options: --user 1001
+    timeout-minutes: 10
+    name: 'E2E Doc Test: node-20, ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+
+      - name: Install deps
+        run: pnpm install
+
+      - name: Build docs
+        run: pnpm run docs:build:ci
+
+      - id: e2e
+        name: Run e2e
+        run: pnpm run docs:test:e2e:run
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: 'Lint: node-20, ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+
+      - name: Set node version to 20
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Check formatting
+        run: pnpm prettier --check .
+
+  ts-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: 'TS-Check: node-20, ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+
+      - name: Set node version to 20
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Check scripts
+        run: pnpm run ts-check
+
+  codecov:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: 'Codecov: node-20, ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+
+      - name: Set node version to 20
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Generate coverage report
+        run: pnpm vitest run --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - next
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/pr-old.yml
+++ b/.github/workflows/pr-old.yml
@@ -1,0 +1,64 @@
+name: PR
+
+on:
+  pull_request:
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  check-code-generation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: 'Check Code Generation: node-20, ubuntu-latest'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+
+      - name: Set node version to 20
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install deps
+        run: pnpm install
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+
+      - name: Generate code
+        id: generate
+        run: |
+          pnpm run generate:locales
+          pnpm run generate:api-docs
+          pnpm run build
+          pnpm run test -u
+        continue-on-error: true
+
+      - name: Check diff
+        id: diff
+        run: |
+          git add .
+          git diff --cached --exit-code
+        continue-on-error: true
+
+      - name: Transpile ts
+        run: pnpm exec tsc .github/workflows/commentCodeGeneration.ts --outDir .github/workflows
+
+      - name: Comment
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          script: |
+            const script = require('${{ github.workspace }}/.github/workflows/commentCodeGeneration.js')
+            await script(github, context, ${{ steps.generate.outcome == 'success' && steps.diff.outcome == 'success' }})
+
+      - name: Status
+        if: ${{ steps.generate.outcome == 'failure' || steps.diff.outcome == 'failure' }}
+        run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
# Why?

some contribution would modify the workflow file, when the event included `pull_request`, it would run its modified file directly. This would cause some safe issue because hacker can use it to get token via Github's vulnerability or to another bad things by hackers. And `pull_request` CANNOT get the secret token due to [Github's policy](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow). it will make following code fail directly
```yml
      - name: Comment
        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
        with:
          script: |
            const script = require('${{ github.workspace }}/.github/workflows/commentCodeGeneration.js')
            await script(github, context, ${{ steps.generate.outcome == 'success' && steps.diff.outcome == 'success' }})
```

Use `pull_request_target` is a BETTER way to resolve it. It would let action run workflow file in target branch instead of modified workflow file. Because it CAN get the secret token, it can help the above code run succeed.