### PR TITLE
infra(unicorn): prefer-optional-catch-binding

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,7 +66,6 @@ module.exports = defineConfig({
     'unicorn/prefer-module': 'off',
     'unicorn/prefer-native-coercion-functions': 'off',
     'unicorn/prefer-negative-index': 'off',
-    'unicorn/prefer-optional-catch-binding': 'off',
     'unicorn/prefer-string-slice': 'off',
     'unicorn/prefer-ternary': 'off',
     'unicorn/prefer-top-level-await': 'off',


### PR DESCRIPTION
Ref: #2439

- #2439

---

Enables the [`unicorn/prefer-optional-catch-binding`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-optional-catch-binding.md) lint rule.