### PR TITLE
docs: fix typo in usage.md

### DIFF
--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -168,7 +168,7 @@ interface User {
 }
 ```
 
-As you can see, your `User` model probably looks completely different from the one you have in your codebase.
+As you can see, our `User` model probably looks completely different from the one you have in your codebase.
 One thing to keep an eye on is the `subscriptionTier` property, as it is not simply a string, but only one of the strings defined in the `SubscriptionTier` type (`'free'` or `'basic'` or `'business'`).
 Also, in a real scenario, your model should not depend on a type of a third party library (`SexType` in this case).
 


### PR DESCRIPTION
>As you can see, your User model probably looks completely different from the one you have in your codebase.

Seems incorrect, should be:
>As you can see, our User model probably looks completely different from the one you have in your codebase.