### PR TITLE
ci: publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: Publish
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -26,9 +29,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Set publishing config
-        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_AUTH_TOKEN}"
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN}}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: Publish
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Set node version to 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Prepare
+        run: pnpm install --frozen-lockfile
+
+      - name: Set publishing config
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish
+        run: |
+          PACKAGE_DIST_TAG=$(node -e "console.log(/^\d+\.\d+\.\d+(\-(\w+)\.\d+)$/.exec(require('./package.json').version)?.[2] || 'latest')")
+          pnpm publish --access public --tag $PACKAGE_DIST_TAG

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,3 +37,8 @@ jobs:
         run: |
           PACKAGE_DIST_TAG=$(node -e "console.log(/^\d+\.\d+\.\d+(\-(\w+)\.\d+)$/.exec(require('./package.json').version)?.[2] || 'latest')")
           pnpm publish --access public --tag $PACKAGE_DIST_TAG
+
+      - name: Set next dist-tag
+        run: |
+          PACKAGE_VERSION=$(node -e "console.log(require('./package.json').version)")
+          pnpm dist-tag add @faker-js/faker@$PACKAGE_VERSION next

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set publishing config
         run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN}}
 
       - name: Publish
         run: |


### PR DESCRIPTION
This is a GitHub action workflow that let's maintainers of Faker run a npm publish process, so that the package `@faker-js/faker` will be published to npm registry.

It is respecting the version and dist-tag by reading the package.json.

The process will be:
1. Someone create a normal release PR
2. The release PR gets merged into next branch
3. Someone hits the publish workflow in the github actions menu `// <- this was done locally before`
4. After the release succeeded, someone will normally create the GitHub Release

It requires that one of the maintainers create a new access token on NPM for the `@faker-js/faker` package, or for the `@faker/*` orga-scope.
This then needs to be configured in GitHub as a secret with the name `NPM_AUTH_TOKEN`, so it can be picked up by the CI.

Note that `publish` will run the `prepublishOnly` script that is configured in the `package.json`

This workflow will NOT "craft" a release, nor will it create tags/releases on github.
It just and only automates the publishing to npm.

Hint: the workflow is tested for 3 months now in https://github.com/salsita/node-pg-migrate