### PR TITLE
docs: improve docs for faker.number.float

### DIFF
--- a/docs/guide/upgrading_v9/2472.md
+++ b/docs/guide/upgrading_v9/2472.md
@@ -1,0 +1,9 @@
+### Images now have a random width and height by default
+
+`faker.image.url()` now returns an image with a random width and height by default. To obtain the previous behavior, pass `{width: 640, height: 480}`.
+
+`faker.image.urlLoremFlickr()` now returns an image with a random width and height by default. To obtain the previous behavior, pass `{width: 640, height: 480}`.
+
+`faker.image.urlPicsumPhotos()` now returns an image with a random width and height by default, additionally images may be converted to grayscale and blurred at random. To obtain the previous behavior, pass `{width: 640, height: 480, blur: 0, grayscale: false}`
+
+`faker.image.dataUri()` now returns an image with a random width and height by default, additionally the type of the image is now random. To obtain the previous behavior, pass `{width: 640, height: 480, type: 'svg-uri'}`.

--- a/docs/guide/upgrading_v9/2472.md
+++ b/docs/guide/upgrading_v9/2472.md
@@ -1,9 +1,0 @@
-### Images now have a random width and height by default
-
-`faker.image.url()` now returns an image with a random width and height by default. To obtain the previous behavior, pass `{width: 640, height: 480}`.
-
-`faker.image.urlLoremFlickr()` now returns an image with a random width and height by default. To obtain the previous behavior, pass `{width: 640, height: 480}`.
-
-`faker.image.urlPicsumPhotos()` now returns an image with a random width and height by default, additionally images may be converted to grayscale and blurred at random. To obtain the previous behavior, pass `{width: 640, height: 480, blur: 0, grayscale: false}`
-
-`faker.image.dataUri()` now returns an image with a random width and height by default, additionally the type of the image is now random. To obtain the previous behavior, pass `{width: 640, height: 480, type: 'svg-uri'}`.

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -120,7 +120,7 @@ export class NumberModule extends SimpleModuleBase {
       | number
       | {
           /**
-           * Lower bound for generated number, inclusive. Defaults to `0.0`.
+           * Lower bound for generated number, inclusive.
            *
            * @default 0.0
            */

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -125,7 +125,7 @@ export class NumberModule extends SimpleModuleBase {
            */
           min?: number;
           /**
-           * exclusive, unless `multipleOf`, `precision` or `fractionDigits` are passed. Defaults to `1.0`.
+           * Upper bound for generated number, exclusive, unless `multipleOf`, `precision` or `fractionDigits` are passed. Defaults to `1.0`.
            *
            * @default 1.0
            */

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -86,21 +86,14 @@ export class NumberModule extends SimpleModuleBase {
   }
 
   /**
-   * Returns a single random floating-point number.
-   * The lower bound is inclusive, the upper bound is exclusive, unless `multipleOf` is passed.
+   * Returns a single random floating-point number, by default between `0.0` and `1.0`. To change the range, pass a `min` and `max` value. To limit the number of decimal places, pass a `multipleOf` or `fractionDigits` parameter.
    *
    * @param options Upper bound or options object.
-   * @param options.min Lower bound for generated number. Defaults to `0.0`.
-   * @param options.max Upper bound for generated number. Defaults to `1.0`.
-   * @param options.precision Precision of the generated number, for example `0.01` will round to 2 decimal points.
-   * If precision is passed, the upper bound is inclusive.
-   * @param options.multipleOf The generated number will be a multiple of this property.
-   * This property can be used to limit the result to a specific number of decimal digits.
-   * For example `0.01` will round to 2 decimal points.
-   * If `multipleOf` is passed, the upper bound is inclusive.
-   * This option is incompatible with the `fractionDigits` option.
-   * @param options.fractionDigits The maximum number of digits to appear after the decimal point.
-   * This option is incompatible with the `multipleOf` option.
+   * @param options.min Lower bound for generated number, inclusive. Defaults to `0.0`.
+   * @param options.max Upper bound for generated number, exclusive, unless `multipleOf`, `precision` or `fractionDigits` are passed. Defaults to `1.0`.
+   * @param options.precision Deprecated alias for `multipleOf`. Only one of `multipleOf`, `precision` or `fractionDigits` should be passed.
+   * @param options.multipleOf The generated number will be a multiple of this parameter. Only one of `multipleOf`, `precision` or `fractionDigits` should be passed.
+   * @param options.fractionDigits The maximum number of digits to appear after the decimal point, for example `2` will round to 2 decimal points.  Only one of `multipleOf`, `precision` or `fractionDigits` should be passed.
    *
    * @throws When `min` is greater than `max`.
    * @throws When `precision` is negative.
@@ -111,13 +104,14 @@ export class NumberModule extends SimpleModuleBase {
    * @example
    * faker.number.float() // 0.5688541042618454
    * faker.number.float(3) // 2.367973240558058
-   * faker.number.float({ min: -1000000 }) //-780678.849672846
+   * faker.number.float({ min: -1000000, max: 0 }) //-780678.849672846
    * faker.number.float({ max: 100 }) // 17.3687307164073
-   * faker.number.float({ multipleOf: 0.25 }) // 3.75
+   * faker.number.float({ multipleOf: 0.25 }) // 0.75
+   * faker.number.float({ multipleOf: 0.25, min: 0, max:10 }) // 7.75
    * faker.number.float({ fractionDigits: 1 }) // 0.9
    * faker.number.float({ min: 10, max: 100, multipleOf: 0.02 }) // 35.42
    * faker.number.float({ min: 10, max: 100, fractionDigits: 3 }) // 65.716
-   *
+   * faker.number.float({ min: 10, max: 100, multipleOf: 0.001 }) // 65.716 - same as above
    * @since 8.0.0
    */
   float(
@@ -125,30 +119,29 @@ export class NumberModule extends SimpleModuleBase {
       | number
       | {
           /**
-           * Lower bound for generated number.
+           * Lower bound for generated number, inclusive. Defaults to `0.0`.
            *
            * @default 0.0
            */
           min?: number;
           /**
-           * Upper bound for generated number.
+           * exclusive, unless `multipleOf`, `precision` or `fractionDigits` are passed. Defaults to `1.0`.
            *
            * @default 1.0
            */
           max?: number;
           /**
-           * The number of digits to appear after the decimal point.
+           * The maximum number of digits to appear after the decimal point, for example `2` will round to 2 decimal points.  Only one of `multipleOf`, `precision` or `fractionDigits` should be passed.
            */
           fractionDigits?: number;
           /*
-           * Precision of the generated number.
+           * Deprecated alias for `multipleOf`. Only one of `multipleOf`, `precision` or `fractionDigits` should be passed.
            *
            * @deprecated Use `multipleOf` instead.
            */
           precision?: number;
           /**
-           * The generated number will be a multiple of this property.
-           * If multipleOf is passed, the upper bound is inclusive.
+           * The generated number will be a multiple of this parameter. Only one of `multipleOf`, `precision` or `fractionDigits` should be passed.
            */
           multipleOf?: number;
         } = {}

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -126,7 +126,7 @@ export class NumberModule extends SimpleModuleBase {
            */
           min?: number;
           /**
-           * Upper bound for generated number, exclusive, unless `multipleOf`, `precision` or `fractionDigits` are passed. Defaults to `1.0`.
+           * Upper bound for generated number, exclusive, unless `multipleOf`, `precision` or `fractionDigits` are passed.
            *
            * @default 1.0
            */

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -112,6 +112,7 @@ export class NumberModule extends SimpleModuleBase {
    * faker.number.float({ min: 10, max: 100, multipleOf: 0.02 }) // 35.42
    * faker.number.float({ min: 10, max: 100, fractionDigits: 3 }) // 65.716
    * faker.number.float({ min: 10, max: 100, multipleOf: 0.001 }) // 65.716 - same as above
+   *
    * @since 8.0.0
    */
   float(

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -104,9 +104,8 @@ export class NumberModule extends SimpleModuleBase {
    * @example
    * faker.number.float() // 0.5688541042618454
    * faker.number.float(3) // 2.367973240558058
-   * faker.number.float({ min: -1000000, max: 0 }) //-780678.849672846
    * faker.number.float({ max: 100 }) // 17.3687307164073
-   * faker.number.float({ multipleOf: 0.25 }) // 0.75
+   * faker.number.float({ min: 20, max: 30 }) // 23.94764115102589
    * faker.number.float({ multipleOf: 0.25, min: 0, max:10 }) // 7.75
    * faker.number.float({ fractionDigits: 1 }) // 0.9
    * faker.number.float({ min: 10, max: 100, multipleOf: 0.02 }) // 35.42


### PR DESCRIPTION
cleanup of docs after #1855 and #2564

Make it clearer that precision is a deprecated version of multipleOf, and that you should only pass one of {precision, multipleOf, fractionDigits}. Fix an example. Move information about inclusive/exclusive to the min/max parameters.
