### PR TITLE
docs: override default vitepress brand colors

### DIFF
--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -1,3 +1,18 @@
+:root {
+  --faker-brand-hue: 2;
+  --vp-c-brand-1: hsl(var(--faker-brand-hue), 53%, 45%);
+  --vp-c-brand-2: hsl(var(--faker-brand-hue), 53%, 51%);
+  --vp-c-brand-3: hsl(var(--faker-brand-hue), 53%, 57%);
+  --vp-c-brand-soft: hsla(var(--faker-brand-hue), 100%, 70%, 0.14);
+}
+
+.dark {
+  --vp-c-brand-1: hsl(var(--faker-brand-hue), 100%, 83%);
+  --vp-c-brand-2: hsl(var(--faker-brand-hue), 74%, 63%);
+  --vp-c-brand-3: hsl(var(--faker-brand-hue), 70%, 55%);
+  --vp-c-brand-soft: hsla(var(--faker-brand-hue), 100%, 70%, 0.16);
+}
+
 table td * {
   display: inline;
 }

--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -1,16 +1,54 @@
 :root {
-  --faker-brand-hue: 2;
-  --vp-c-brand-1: hsl(var(--faker-brand-hue), 53%, 45%);
-  --vp-c-brand-2: hsl(var(--faker-brand-hue), 53%, 51%);
-  --vp-c-brand-3: hsl(var(--faker-brand-hue), 53%, 57%);
-  --vp-c-brand-soft: hsla(var(--faker-brand-hue), 100%, 70%, 0.14);
+  --fkr-hue: 160;
+  --fkr-saturation: 84%;
+  --fkr-lightness: 39%;
+  --fkr-alpha: 14%;
+  --fkr-step: 2%;
+  --vp-c-brand-1: hsl(
+    var(--fkr-hue),
+    var(--fkr-saturation),
+    var(--fkr-lightness)
+  );
+  --vp-c-brand-2: hsl(
+    var(--fkr-hue),
+    var(--fkr-saturation),
+    calc(var(--fkr-lightness) + var(--fkr-step))
+  );
+  --vp-c-brand-3: hsl(
+    var(--fkr-hue),
+    var(--fkr-saturation),
+    calc(var(--fkr-lightness) + 2 * var(--fkr-step))
+  );
+  --vp-c-brand-soft: hsla(
+    var(--fkr-hue),
+    var(--fkr-saturation),
+    var(--fkr-lightness),
+    var(--fkr-alpha)
+  );
 }
 
 .dark {
-  --vp-c-brand-1: hsl(var(--faker-brand-hue), 100%, 83%);
-  --vp-c-brand-2: hsl(var(--faker-brand-hue), 74%, 63%);
-  --vp-c-brand-3: hsl(var(--faker-brand-hue), 70%, 55%);
-  --vp-c-brand-soft: hsla(var(--faker-brand-hue), 100%, 70%, 0.16);
+  --vp-c-brand-1: hsl(
+    var(--fkr-hue),
+    var(--fkr-saturation),
+    var(--fkr-lightness)
+  );
+  --vp-c-brand-2: hsl(
+    var(--fkr-hue),
+    var(--fkr-saturation),
+    calc(var(--fkr-lightness) - var(--fkr-step))
+  );
+  --vp-c-brand-3: hsl(
+    var(--fkr-hue),
+    var(--fkr-saturation),
+    calc(var(--fkr-lightness) - 2 * var(--fkr-step))
+  );
+  --vp-c-brand-soft: hsla(
+    var(--fkr-hue),
+    var(--fkr-saturation),
+    var(--fkr-lightness),
+    var(--fkr-alpha)
+  );
 }
 
 table td * {

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,6 +4,10 @@
 
 Faker is a popular library that generates fake (but reasonable) data that can be used for things such as:
 
+<p style="background-color:var(--vp-c-brand-1) !important;">Brand 1</p>
+<p style="background-color:var(--vp-c-brand-2) !important;">Brand 2</p>
+<p style="background-color:var(--vp-c-brand-3) !important;">Brand 3</p>
+
 - Unit Testing
 - Performance Testing
 - Building Demos

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,10 +4,6 @@
 
 Faker is a popular library that generates fake (but reasonable) data that can be used for things such as:
 
-<p style="background-color:var(--vp-c-brand-1) !important;">Brand 1</p>
-<p style="background-color:var(--vp-c-brand-2) !important;">Brand 2</p>
-<p style="background-color:var(--vp-c-brand-3) !important;">Brand 3</p>
-
 - Unit Testing
 - Performance Testing
 - Building Demos


### PR DESCRIPTION
fix #2626

Originally I was going to make it green but i think red looks quite nice (took the hue from the Faker logo, the saturation and lightness values are from the default Vitepress theme).

<img width="1304" alt="Screenshot 2024-01-29 at 07 40 46" src="https://github.com/faker-js/faker/assets/152770/60e66770-71c7-482f-9c36-31d4ea5520e9">

<img width="1336" alt="Screenshot 2024-01-29 at 07 40 50" src="https://github.com/faker-js/faker/assets/152770/3efcf28d-6ceb-444d-b24f-9027a87273fb">

<img width="1319" alt="Screenshot 2024-01-29 at 07 41 02" src="https://github.com/faker-js/faker/assets/152770/f606b2d4-d707-4a01-b55f-a5f1186aa708">
()
<img width="1321" alt="Screenshot 2024-01-29 at 07 40 57" src="https://github.com/faker-js/faker/assets/152770/92fcbb12-066c-429d-af64-2a823b17efb6">
