### PR TITLE
fix(helpers): multiple update argument types

### DIFF
--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -1252,7 +1252,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @since 8.0.0
    */
   multiple<TResult>(
-    method: () => TResult,
+    method: (_: undefined, index: number) => TResult,
     options: {
       /**
        * The number or range of elements to generate.


### PR DESCRIPTION
With this change users of `faker.helpers.multiple()` will know that `method` function may have access to `index` of current element.

Use case: generator wants to know the index of element that it is generating.

This is not a breaking change, because it add argument types for already used code, any current code that is using this function will work without any changes/warnings. But in future it may lead to some difficulties with changing method signature or refactoring inner code (`Array.from`). There is a way to mitigate this issue but it requires to modify `Array.from` call will additional wrapper-function, that will negotiate `method` definition with actual used code.

`pnpm run preflight` runs without errors.

Usage example:
```typescript
// case: create array of negative numbers
const value = faker.helpers.multiple((_, index) => -1 - index);
// value = [ -1, -2, -3 ]

// case: create array of objects {id: number}, with ids 100, 200, 300
const value = faker.helpers.multiple((_, index) => ({id: (index+1) *100}));
// value = [ { id: 100 }, { id: 200 }, { id: 300 } ]

```