### PR TITLE
docs(utilities): add missing since

### DIFF
--- a/src/randomizer.ts
+++ b/src/randomizer.ts
@@ -37,6 +37,8 @@
  *   locale: ...,
  *   randomizer,
  * });
+ *
+ * @since 8.2.0
  */
 export interface Randomizer {
   /**
@@ -46,6 +48,8 @@ export interface Randomizer {
    * randomizer.next() // 0.3404027920160495
    * randomizer.next() // 0.929890375900335
    * randomizer.next() // 0.5866362918861691
+   *
+   * @since 8.2.0
    */
   next(): number;
 
@@ -60,6 +64,8 @@ export interface Randomizer {
    * // Fixed seeds (for reproducibility)
    * randomizer.seed(42);
    * randomizer.seed([42, 13.37]);
+   *
+   * @since 8.2.0
    */
   seed(seed: number | number[]): void;
 }

--- a/src/utils/merge-locales.ts
+++ b/src/utils/merge-locales.ts
@@ -12,6 +12,8 @@ import type { LocaleDefinition } from '..';
  *
  * @example
  * const de_CH_with_fallbacks = mergeLocales([ de_CH, de, en ]);
+ *
+ * @since 8.0.0
  */
 export function mergeLocales(locales: LocaleDefinition[]): LocaleDefinition {
   const merged: LocaleDefinition = {};


### PR DESCRIPTION
The last of the missing `@since`s. Found in #2628 

- #2628 