### PR TITLE
infra(eslint): logical-assignment-operators

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,6 +33,7 @@ module.exports = defineConfig({
   },
   rules: {
     eqeqeq: ['error', 'always', { null: 'ignore' }],
+    'logical-assignment-operators': 'error',
     'no-else-return': 'error',
     'no-restricted-globals': ['error', 'Intl'],
     'prefer-exponentiation-operator': 'error',

--- a/test/modules/finance.spec.ts
+++ b/test/modules/finance.spec.ts
@@ -168,7 +168,7 @@ describe('finance', () => {
         it('should set a specified length', () => {
           let expected = faker.number.int(20);
 
-          expected = expected || 4;
+          expected ||= 4;
 
           const mask = faker.finance.maskedNumber({
             length: expected,

--- a/test/modules/finance.spec.ts
+++ b/test/modules/finance.spec.ts
@@ -166,9 +166,7 @@ describe('finance', () => {
         });
 
         it('should set a specified length', () => {
-          let expected = faker.number.int(20);
-
-          expected ||= 4;
+          const expected = faker.number.int(20) || 4;
 
           const mask = faker.finance.maskedNumber({
             length: expected,


### PR DESCRIPTION
Permanently enables the [`logical-assignment-operators`](https://eslint.org/docs/latest/rules/logical-assignment-operators) lint rule.

This will be in draft until we merged the deprecation PRs, because this will reduce the diff to only affect 1 line in test.