### PR TITLE
infra: use text eol=lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text eol=lf
+*.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* -crlf
+* text eol=lf


### PR DESCRIPTION
There was random a comment from a user https://github.com/faker-js/faker/commit/38e890eeced869b41cf0047ef28740bfb79d1c01#commitcomment-138490557 that hinted me to that line of code. I wasn't even aware that we have this configured, as it is from v4.0.0.

I switched the behavior slightly but also upgraded out of a legacy syntax.

The real direct equivalent would be `* -text`, but this would have the downside that it only affects when checking files out.
The `* text eol=lf` is different in that way that it affects the files when you checkin files to the repo. Resulting in new created files directly with the "correct" lf ending. However in most files prettier would do that for us anyway, so only files that are NOT supported by prettier would be affected.

- https://git-scm.com/docs/gitattributes
- https://chat.openai.com/share/bbb3bb28-cb2d-436e-beb8-af36537c0897

---

We have some png files in the docs.

![image](https://github.com/faker-js/faker/assets/7195563/b749dead-0c5f-4f30-9ff1-e79e468254e8)

Adding `*.png binary` fixed that.

And here you instantly see in action the difference :slightly_smiling_face:
As png are not supported by prettier, it would not add eol=lf to such files when checkin in, and that was previously not the case.
Now the gitattributes are more verbose and specific.