### PR TITLE
docs(system): fix bad description

### DIFF
--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -290,7 +290,7 @@ export class SystemModule extends ModuleBase {
    *
    * @param options The optional options to use.
    * @param options.includeYear Whether to include a year in the generated expression. Defaults to `false`.
-   * @param options.includeNonStandard Whether to include a @yearly, @monthly, @daily, etc text labels in the generated expression. Defaults to `false`.
+   * @param options.includeNonStandard Whether to include a `@yearly`, `@monthly`, `@daily`, etc text labels in the generated expression. Defaults to `false`.
    *
    * @example
    * faker.system.cron() // '45 23 * * 6'

--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -310,7 +310,7 @@ export class SystemModule extends ModuleBase {
        */
       includeYear?: boolean;
       /**
-       * Whether to include a @yearly, @monthly, @daily, etc text labels in the generated expression.
+       * Whether to include a `@yearly`, `@monthly`, `@daily`, etc text labels in the generated expression.
        *
        * @default false
        */


### PR DESCRIPTION
<details>
<summary>VSCode</summary>

Old:
![grafik](https://github.com/faker-js/faker/assets/1579362/ddb4c385-b375-40af-9f60-221c979a6a3f)
New:
![grafik](https://github.com/faker-js/faker/assets/1579362/d33efc3b-49b6-4980-bd6c-75257ab4ba92)

</details>


<details>
<summary>ApiDocs</summary>

Old:
![grafik](https://github.com/faker-js/faker/assets/1579362/56086516-eb25-4e3f-9255-1230c81c5660)
New:
![grafik](https://github.com/faker-js/faker/assets/1579362/8afa3bab-1fdc-40eb-bc49-03294eca1dea)

</details>

---

I also checked whether there is a jsdoc-eslint rule, but sadly I couldn't find any.

- https://github.com/gajus/eslint-plugin-jsdoc/issues/1201