### PR TITLE
docs(finance): fix bad see tags

### DIFF
--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -643,10 +643,9 @@ export class FinanceModule extends ModuleBase {
   /**
    * Returns a random currency object, containing `code`, `name `and `symbol` properties.
    *
-   * @see
-   * faker.finance.currencyCode(): For generating specifically the currency code.
-   * faker.finance.currencyName(): For generating specifically the currency name.
-   * faker.finance.currencySymbol(): For generating specifically the currency symbol.
+   * @see faker.finance.currencyCode(): For generating specifically the currency code.
+   * @see faker.finance.currencyName(): For generating specifically the currency name.
+   * @see faker.finance.currencySymbol(): For generating specifically the currency symbol.
    *
    * @example
    * faker.finance.currency() // { code: 'USD', name: 'US Dollar', symbol: '$' }


### PR DESCRIPTION
<details>
<summary>VSCode</summary>

Old:
![grafik](https://github.com/faker-js/faker/assets/1579362/58e92bba-2ee7-4769-be61-ad1adcabe8e4)
New:
![grafik](https://github.com/faker-js/faker/assets/1579362/a165ac42-91fd-4b3b-b10e-b3b6d5f0113e)

</details>

<details>
<summary>ApiDoc</summary>

Old:
![grafik](https://github.com/faker-js/faker/assets/1579362/bb77be30-774c-44c4-9258-a7c0aa3f0875)
New:
![grafik](https://github.com/faker-js/faker/assets/1579362/bfeaf963-b683-492e-80f0-9cdf364b30ea)

</details>

( I put this in a separate PR because I thought I had to fix our apidocs generation, but seems like I didn't have to )