### PR TITLE
refactor(color): use signature level defaults

### DIFF
--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -466,11 +466,12 @@ export class ColorModule extends ModuleBase {
      */
     format?: ColorFormat;
   }): string | number[];
-  cmyk(options?: { format?: ColorFormat }): string | number[] {
+  cmyk(options: { format?: ColorFormat } = {}): string | number[] {
+    const { format = 'decimal' } = options;
     const color: string | number[] = Array.from({ length: 4 }, () =>
       this.faker.number.float({ multipleOf: 0.01 })
     );
-    return toColorFormat(color, options?.format || 'decimal', 'cmyk');
+    return toColorFormat(color, format, 'cmyk');
   }
 
   /**
@@ -572,20 +573,19 @@ export class ColorModule extends ModuleBase {
      */
     includeAlpha?: boolean;
   }): string | number[];
-  hsl(options?: {
-    format?: ColorFormat;
-    includeAlpha?: boolean;
-  }): string | number[] {
+  hsl(
+    options: {
+      format?: ColorFormat;
+      includeAlpha?: boolean;
+    } = {}
+  ): string | number[] {
+    const { format = 'decimal', includeAlpha = false } = options;
     const hsl: number[] = [this.faker.number.int(360)];
     for (let i = 0; i < (options?.includeAlpha ? 3 : 2); i++) {
       hsl.push(this.faker.number.float({ multipleOf: 0.01 }));
     }
 
-    return toColorFormat(
-      hsl,
-      options?.format || 'decimal',
-      options?.includeAlpha ? 'hsla' : 'hsl'
-    );
+    return toColorFormat(hsl, format, includeAlpha ? 'hsla' : 'hsl');
   }
 
   /**
@@ -674,20 +674,23 @@ export class ColorModule extends ModuleBase {
    *
    * @since 7.0.0
    */
-  hwb(options?: {
-    /**
-     * Format of generated RGB color.
-     *
-     * @default 'decimal'
-     */
-    format?: ColorFormat;
-  }): string | number[] {
+  hwb(
+    options: {
+      /**
+       * Format of generated RGB color.
+       *
+       * @default 'decimal'
+       */
+      format?: ColorFormat;
+    } = {}
+  ): string | number[] {
+    const { format = 'decimal' } = options;
     const hsl: number[] = [this.faker.number.int(360)];
     for (let i = 0; i < 2; i++) {
       hsl.push(this.faker.number.float({ multipleOf: 0.01 }));
     }
 
-    return toColorFormat(hsl, options?.format || 'decimal', 'hwb');
+    return toColorFormat(hsl, format, 'hwb');
   }
 
   /**
@@ -762,7 +765,8 @@ export class ColorModule extends ModuleBase {
      */
     format?: ColorFormat;
   }): string | number[];
-  lab(options?: { format?: ColorFormat }): string | number[] {
+  lab(options: { format?: ColorFormat } = {}): string | number[] {
+    const { format = 'decimal' } = options;
     const lab = [this.faker.number.float({ multipleOf: 0.000001 })];
     for (let i = 0; i < 2; i++) {
       lab.push(
@@ -770,7 +774,7 @@ export class ColorModule extends ModuleBase {
       );
     }
 
-    return toColorFormat(lab, options?.format || 'decimal', 'lab');
+    return toColorFormat(lab, format, 'lab');
   }
 
   /**
@@ -857,13 +861,14 @@ export class ColorModule extends ModuleBase {
      */
     format?: ColorFormat;
   }): string | number[];
-  lch(options?: { format?: ColorFormat }): string | number[] {
+  lch(options: { format?: ColorFormat } = {}): string | number[] {
+    const { format = 'decimal' } = options;
     const lch = [this.faker.number.float({ multipleOf: 0.000001 })];
     for (let i = 0; i < 2; i++) {
       lch.push(this.faker.number.float({ max: 230, multipleOf: 0.1 }));
     }
 
-    return toColorFormat(lch, options?.format || 'decimal', 'lch');
+    return toColorFormat(lch, format, 'lch');
   }
 
   /**
@@ -959,22 +964,17 @@ export class ColorModule extends ModuleBase {
      */
     space?: CssSpaceType;
   }): string | number[];
-  colorByCSSColorSpace(options?: {
-    format?: ColorFormat;
-    space?: CssSpaceType;
-  }): string | number[] {
-    if (options?.format === 'css' && !options?.space) {
-      options = { ...options, space: 'sRGB' };
-    }
+  colorByCSSColorSpace(
+    options: {
+      format?: ColorFormat;
+      space?: CssSpaceType;
+    } = {}
+  ): string | number[] {
+    const { format = 'decimal', space = 'sRGB' } = options;
 
     const color = Array.from({ length: 3 }, () =>
       this.faker.number.float({ multipleOf: 0.0001 })
     );
-    return toColorFormat(
-      color,
-      options?.format || 'decimal',
-      'color',
-      options?.space
-    );
+    return toColorFormat(color, format, 'color', space);
   }
 }


### PR DESCRIPTION
Fixes #2432

- #2432

**Old**

![grafik](https://github.com/faker-js/faker/assets/1579362/32622207-3da5-4f54-8395-c43431599e7d)


**New**

![grafik](https://github.com/faker-js/faker/assets/1579362/ce9a4338-f895-44a3-8a3a-79c07f2577af)

These were all cases that I know of, if we find others later, we can create a new PR for them then.