### PR TITLE
infra(unicorn): no-array-callback-reference

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -38,6 +38,7 @@ module.exports = defineConfig({
     'prefer-exponentiation-operator': 'error',
     'prefer-template': 'error',
 
+    'unicorn/no-array-callback-reference': 'off', // reduces readability
     'unicorn/no-nested-ternary': 'off', // incompatible with prettier
     'unicorn/no-null': 'off', // incompatible with TypeScript
     'unicorn/no-zero-fractions': 'off', // deactivated to raise awareness of floating operations
@@ -49,7 +50,6 @@ module.exports = defineConfig({
     'unicorn/better-regex': 'off',
     'unicorn/consistent-function-scoping': 'off',
     'unicorn/import-style': 'off',
-    'unicorn/no-array-callback-reference': 'off',
     'unicorn/no-await-expression-member': 'off',
     'unicorn/no-object-as-default-parameter': 'off',
     'unicorn/numeric-separators-style': 'off',


### PR DESCRIPTION
Ref: #2439

- #2439

---

Permanently disables the [`unicorn/no-array-callback-reference`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-callback-reference.md) lint rule.

