### PR TITLE
infra(renovate): update config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,12 +34,16 @@
       "rangeStrategy": "replace"
     },
     {
-      "groupName": "typescript-eslint",
-      "matchPackagePrefixes": ["@typescript-eslint/"]
+      "groupName": "eslint",
+      "matchPackagePrefixes": [
+        "@typescript-eslint/",
+        "@eslint-types/",
+        "eslint"
+      ]
     },
     {
       "groupName": "vitest",
-      "matchPackageNames": ["@vitest/coverage-v8", "@vitest/ui", "vitest"]
+      "matchPackagePrefixes": ["@vitest/", "vitest"]
     },
     {
       "groupName": "prettier",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,12 +11,11 @@
     "enabled": true
   },
   "reviewersFromCodeOwners": true,
-  "rangeStrategy": "replace",
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "groupName": "devDependencies",
-      "matchDepTypes": ["devDependencies"],
-      "rangeStrategy": "replace"
+      "matchDepTypes": ["devDependencies"]
     },
     {
       "groupName": "dependencies",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
     "group:allNonMajor",
     ":prHourlyLimitNone"
   ],
-  "labels": ["c: dependencies"],
+  "labels": ["c: dependencies", "p: 1-normal"],
   "lockFileMaintenance": {
     "enabled": true
   },
@@ -63,7 +63,7 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "labels": ["c: security"],
+    "labels": ["c: security", "p: 2-high"],
     "assignees": ["team:maintainers"]
   }
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     "schedule:earlyMondays",
     "group:allNonMajor",
-    ":prHourlyLimitNone",
-    "helpers:pinGitHubActionDigests"
+    ":prHourlyLimitNone"
   ],
   "labels": ["c: dependencies"],
   "lockFileMaintenance": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "schedule:earlyMondays",
     "group:allNonMajor",
     ":prHourlyLimitNone",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,7 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "milestone": 15,
   "reviewersFromCodeOwners": true,
   "rangeStrategy": "pin",
   "packageRules": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,12 +11,12 @@
     "enabled": true
   },
   "reviewersFromCodeOwners": true,
-  "rangeStrategy": "bump",
+  "rangeStrategy": "replace",
   "packageRules": [
     {
       "groupName": "devDependencies",
       "matchDepTypes": ["devDependencies"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "replace"
     },
     {
       "groupName": "dependencies",


### PR DESCRIPTION
Changes:

- Follow rename of [`config:base`](https://github.com/renovatebot/renovate/pull/21136) to [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended)
- Upgrade config to [`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices)
- Use [`pin` rangeStrategy](https://docs.renovatebot.com/configuration-options/#rangestrategy) (Not sure about this one)
- Update the groups to be broader in their domain
- Assign [priority](https://github.com/faker-js/faker/labels/p%3A%201-normal) labels
- Assign [`vAnytime`](https://github.com/faker-js/faker/milestone/15) [milestone](https://docs.renovatebot.com/configuration-options/#milestone)

See also:

- https://github.com/renovatebot/renovate/pull/21136