### PR TITLE
infra(unicorn): require-array-join-separator

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -57,7 +57,6 @@ module.exports = defineConfig({
     'unicorn/prefer-export-from': 'off',
     'unicorn/prefer-string-slice': 'off',
     'unicorn/prevent-abbreviations': 'off',
-    'unicorn/require-array-join-separator': 'off',
 
     '@typescript-eslint/array-type': [
       'error',


### PR DESCRIPTION
Ref: #2439

- #2439

---

Enables the [`unicorn/require-array-join-separator`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/require-array-join-separator.md) lint rule.

