### PR TITLE
docs: use new X icon instead of twitter icon in social links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -123,7 +123,7 @@ const config: UserConfig<DefaultTheme.Config> = {
     socialLinks: [
       { icon: 'discord', link: 'https://chat.fakerjs.dev' },
       { icon: 'mastodon', link: 'https://fosstodon.org/@faker_js' },
-      { icon: 'twitter', link: 'https://twitter.com/faker_js' },
+      { icon: 'x', link: 'https://twitter.com/faker_js' },
       { icon: 'github', link: 'https://github.com/faker-js/faker' },
     ],
 


### PR DESCRIPTION
old

<img width="164" alt="image" src="https://github.com/faker-js/faker/assets/152770/716bddd4-3477-4069-9cb6-b432dc7ad6c5">


new

<img width="168" alt="image" src="https://github.com/faker-js/faker/assets/152770/c2f3e9ac-d18e-4cc6-a83f-93d0d6493d1f">
