### PR TITLE
fix(date): fix birthdate

### DIFF
--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -523,7 +523,10 @@ export class SimpleDateModule extends SimpleModuleBase {
 
     switch (mode) {
       case 'age': {
-        const from = new Date(refDate).setUTCFullYear(refYear - max - 1);
+        // Add one day to the `from` date to avoid generating the same date as the reference date.
+        const oneDay = 24 * 60 * 60 * 1000;
+        const from =
+          new Date(refDate).setUTCFullYear(refYear - max - 1) + oneDay;
         const to = new Date(refDate).setUTCFullYear(refYear - min);
 
         if (from > to) {

--- a/test/modules/__snapshots__/date.spec.ts.snap
+++ b/test/modules/__snapshots__/date.spec.ts.snap
@@ -65,11 +65,11 @@ exports[`date > 42 > betweens > with string dates and count 1`] = `
 ]
 `;
 
-exports[`date > 42 > birthdate > with age and refDate 1`] = `1980-07-07T19:06:53.165Z`;
+exports[`date > 42 > birthdate > with age and refDate 1`] = `1980-07-08T10:07:32.899Z`;
 
-exports[`date > 42 > birthdate > with age range and refDate 1`] = `1962-12-27T20:14:08.437Z`;
+exports[`date > 42 > birthdate > with age range and refDate 1`] = `1962-12-28T11:14:48.171Z`;
 
-exports[`date > 42 > birthdate > with only refDate 1`] = `1963-09-27T06:10:42.813Z`;
+exports[`date > 42 > birthdate > with only refDate 1`] = `1963-09-27T21:11:22.547Z`;
 
 exports[`date > 42 > birthdate > with year 1`] = `2000-05-16T22:59:36.655Z`;
 
@@ -189,11 +189,11 @@ exports[`date > 1211 > betweens > with string dates and count 1`] = `
 ]
 `;
 
-exports[`date > 1211 > birthdate > with age and refDate 1`] = `1981-01-26T13:16:31.426Z`;
+exports[`date > 1211 > birthdate > with age and refDate 1`] = `1981-01-26T14:59:27.285Z`;
 
-exports[`date > 1211 > birthdate > with age range and refDate 1`] = `1996-10-13T01:44:07.954Z`;
+exports[`date > 1211 > birthdate > with age range and refDate 1`] = `1996-10-13T03:27:03.813Z`;
 
-exports[`date > 1211 > birthdate > with only refDate 1`] = `1998-08-21T21:24:31.101Z`;
+exports[`date > 1211 > birthdate > with only refDate 1`] = `1998-08-21T23:07:26.960Z`;
 
 exports[`date > 1211 > birthdate > with year 1`] = `2000-12-04T01:16:03.291Z`;
 
@@ -311,11 +311,11 @@ exports[`date > 1337 > betweens > with string dates and count 1`] = `
 ]
 `;
 
-exports[`date > 1337 > birthdate > with age and refDate 1`] = `1980-05-27T14:46:44.794Z`;
+exports[`date > 1337 > birthdate > with age and refDate 1`] = `1980-05-28T08:29:25.862Z`;
 
-exports[`date > 1337 > birthdate > with age range and refDate 1`] = `1956-02-15T21:16:37.850Z`;
+exports[`date > 1337 > birthdate > with age range and refDate 1`] = `1956-02-16T14:59:18.918Z`;
 
-exports[`date > 1337 > birthdate > with only refDate 1`] = `1956-08-25T03:56:58.153Z`;
+exports[`date > 1337 > birthdate > with only refDate 1`] = `1956-08-25T21:39:39.221Z`;
 
 exports[`date > 1337 > birthdate > with year 1`] = `2000-04-06T02:45:32.287Z`;
 

--- a/test/modules/date.spec.ts
+++ b/test/modules/date.spec.ts
@@ -528,6 +528,19 @@ describe('date', () => {
       });
 
       describe('birthdate', () => {
+        function calculateAge(birthdate: Date, refDate: Date): number {
+          let age = refDate.getFullYear() - birthdate.getFullYear();
+          if (
+            refDate.getMonth() < birthdate.getMonth() ||
+            (refDate.getMonth() === birthdate.getMonth() &&
+              refDate.getDate() < birthdate.getDate())
+          ) {
+            age--;
+          }
+
+          return age;
+        }
+
         it('returns a random birthdate', () => {
           const birthdate = faker.date.birthdate();
           expect(birthdate).toBeInstanceOf(Date);
@@ -577,8 +590,8 @@ describe('date', () => {
           const value = birthdate.valueOf();
           const refDateValue = refDate.valueOf();
           expect(value).toBeLessThanOrEqual(refDateValue);
-          const deltaDate = new Date(refDateValue - value);
-          expect(deltaDate.getUTCFullYear() - 1970).toBe(21);
+          const age = calculateAge(birthdate, refDate);
+          expect(age).toBe(21);
         });
 
         it('returns a random birthdate between two ages', () => {
@@ -592,9 +605,9 @@ describe('date', () => {
           const value = birthdate.valueOf();
           const refDateValue = refDate.valueOf();
           expect(value).toBeLessThanOrEqual(refDateValue);
-          const deltaDate = new Date(refDateValue - value);
-          expect(deltaDate.getUTCFullYear() - 1970).toBeGreaterThanOrEqual(21);
-          expect(deltaDate.getUTCFullYear() - 1970).toBeLessThanOrEqual(22);
+          const age = calculateAge(birthdate, refDate);
+          expect(age).toBeGreaterThanOrEqual(21);
+          expect(age).toBeLessThanOrEqual(22);
         });
 
         it.each(['min', 'max', 'mode'] as const)(


### PR DESCRIPTION
Fixes #2783

- #2783

There are actually two errors:

- One where it is possible to generate the exact same date as the refDate (aka 2020-03-31 and 2000-03-31 for age 20)
- The other lies in the test, where the age is calculated wrongly if the refDate is within a leap year and after Feb 29