### PR TITLE
infra: suppress pnpm error

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-manager-strict=false


### PR DESCRIPTION
With pnpm v9 the packageManager field in package.json get checked strictly now
This config suppress the error and converts it just into a warning like

`[ WARN ] This project is configured to use v9.0.1 of pnpm. Your current pnpm is v9.0.4`

This only affects contributors that uses pnpm natively instead of corepack

This is needed so contributors can still run `preflight` without having the exact pnpm bugfix version installed (like with pnpm v8 previously)