### PR TITLE
docs: backport docs changes to v8 branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,18 @@
 A lot of effort has been put into `Faker` to create a useful and handy library.
 There are still a lot of things to be done, so all contributions are welcome!
-If you want to make `Faker` a better, please read the following contribution guide.
+If you want to make `Faker` a better place, please read the following contribution guide.
 
-# Important
+## Before you start
+
+It's generally helpful to [create an issue](https://github.com/faker-js/faker/issues/new/choose) first:
+
+- If you are proposing a new feature, this allows other users to "upvote" the issue and discuss solutions to possible problems.
+  Once an issue has enough upvotes (usually 10+) it will be reviewed for development.
+- If you notice a bug, this allows you to provide steps to reproduce, and allows other users to confirm this is actually a bug.
+- It's not required to create an issue in all cases.
+  For example for fixing a typo in documentation, or adding some new data for a locale, you could immediately create a pull request without an issue.
+
+## Important
 
 Please make sure that you run `pnpm run preflight` before making a PR to ensure that everything is working from the start.  
 This is a shorthand for running the following scripts in order:
@@ -218,7 +228,7 @@ Not every change needs to be in the migration guide. If it is too long, it becom
 
 - New locales
 - Changes to locale data in existing locales
-- Bugfixes where it's unlikely anyone was relying on the old behavior (eg broken values in locale files)
+- Bugfixes where it's unlikely anyone was relying on the old behavior (e.g. broken values in locale files)
 - New methods and parameters
 - Straightforward method aliases, e.g. where a method or parameter is renamed but the old name still works identically. (Runtime warnings will already guide the user in this case)
 - Changes to locale definition files which only affect usage via `faker.helpers.fake`, e.g. if a definition file is renamed, but the public API for the method stays the same

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -246,6 +246,10 @@ const config: UserConfig<DefaultTheme.Config> = {
             text: 'Roadmap',
             link: '/about/roadmap/',
             items: [
+              {
+                text: 'v9 - Tree-Shakeable Module-Functions',
+                link: '/about/roadmap/v9',
+              },
               { text: 'v8 - Make Faker Handier', link: '/about/roadmap/v8' },
               {
                 text: 'v7 - Cleanup & Improvements',

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -123,7 +123,7 @@ const config: UserConfig<DefaultTheme.Config> = {
     socialLinks: [
       { icon: 'discord', link: 'https://chat.fakerjs.dev' },
       { icon: 'mastodon', link: 'https://fosstodon.org/@faker_js' },
-      { icon: 'twitter', link: 'https://twitter.com/faker_js' },
+      { icon: 'x', link: 'https://twitter.com/faker_js' },
       { icon: 'github', link: 'https://github.com/faker-js/faker' },
       {
         icon: {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -125,6 +125,13 @@ const config: UserConfig<DefaultTheme.Config> = {
       { icon: 'mastodon', link: 'https://fosstodon.org/@faker_js' },
       { icon: 'twitter', link: 'https://twitter.com/faker_js' },
       { icon: 'github', link: 'https://github.com/faker-js/faker' },
+      {
+        icon: {
+          svg: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Open Collective</title><path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12c2.54 0 4.894-.79 6.834-2.135l-3.107-3.109a7.715 7.715 0 1 1 0-13.512l3.107-3.109A11.943 11.943 0 0 0 12 0zm9.865 5.166l-3.109 3.107A7.67 7.67 0 0 1 19.715 12a7.682 7.682 0 0 1-.959 3.727l3.109 3.107A11.943 11.943 0 0 0 24 12c0-2.54-.79-4.894-2.135-6.834z"/></svg>',
+        },
+        link: 'https://opencollective.com/fakerjs',
+        ariaLabel: 'Open Collective',
+      },
     ],
 
     algolia:

--- a/docs/.vitepress/theme/index.css
+++ b/docs/.vitepress/theme/index.css
@@ -74,3 +74,33 @@ table td ul li {
     color: var(--vp-button-brand-text) !important;
   }
 }
+
+.opencollective {
+  margin-top: 48px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.opencollective a {
+  margin-top: 24px;
+  border-radius: 20px;
+  padding: 0 20px;
+  line-height: 38px;
+  font-size: 14px;
+  display: inline-block;
+  border: 1px solid transparent;
+  text-align: center;
+  font-weight: 600;
+  white-space: nowrap;
+  text-decoration: none;
+
+  color: var(--vp-button-alt-text);
+  border-color: var(--vp-button-brand-bg) !important;
+  transition:
+    color 0.25s,
+    border-color 0.25s,
+    background-color 0.25s;
+}

--- a/docs/about/roadmap/index.md
+++ b/docs/about/roadmap/index.md
@@ -9,6 +9,10 @@ Click on the specific versions for more details.
 
 ## Upcoming Versions
 
+- [v9 - Tree Shaking](v9.md)
+
+## Current Versions
+
 - [v8 - Make Faker Handier](v8.html)
 
 ## Previous Versions

--- a/docs/about/roadmap/v8.md
+++ b/docs/about/roadmap/v8.md
@@ -26,10 +26,3 @@ Finish the module shuffling.
 Split the Faker class into smaller units so you don't have ship an entire locale if you only generate some strings and numbers.
 
 [v8.1 Tasks](https://github.com/faker-js/faker/milestone/11)
-
-## v8.x - Tree-Shakeable Module-Functions
-
-Refactor modules to be tree shakeable.
-Potentially allowing individual Faker methods to be called by themselves.
-
-[v8.x Tasks](https://github.com/faker-js/faker/milestone/12)

--- a/docs/about/roadmap/v9.md
+++ b/docs/about/roadmap/v9.md
@@ -1,0 +1,6 @@
+## v9.0 - Tree-Shakeable Module-Functions
+
+Fix the issue of Faker not being tree shakeable.
+Potentially allowing individual Faker methods to be called by themselves.
+
+[v9.0 Tasks](https://github.com/faker-js/faker/milestone/12)

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,3 +39,8 @@ features:
     title: Localization
     details: Pick a locale to generate realistic looking Names, Addresses, and Phone Numbers.
 ---
+
+<div class="opencollective">
+  Faker is freely available to use for commercial and non-commercial purposes under the MIT license. The development of Faker is guided by an international team of volunteer maintainers. If you use Faker in your project, please consider making a one-off or recurring donation via Open Collective. 
+  <a target="_blank" href="https://opencollective.com/fakerjs">Support Faker on OpenCollective</a>
+</div>


### PR DESCRIPTION
Backports to the following changes to v8 branch so that the main fakerjs.dev website can be updated without needing to wait for v9 release.

- docs: add donate links (#2806)
- docs: use new X icon instead of twitter icon in social links (#2825)
- docs: update roadmap for v9 (#2802)
- docs: improve contributing guide (#2747)
