### PR TITLE
infra(deps): remove unused glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "eslint-plugin-prettier": "5.1.3",
     "eslint-plugin-unicorn": "52.0.0",
     "eslint-plugin-vitest": "0.4.1",
-    "glob": "10.3.12",
     "npm-run-all2": "6.1.2",
     "prettier": "3.2.5",
     "prettier-plugin-organize-imports": "3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       eslint-plugin-vitest:
         specifier: 0.4.1
         version: 0.4.1(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)(vitest@1.6.0(@types/node@20.12.8)(@vitest/ui@1.6.0)(jsdom@23.2.0))
-      glob:
-        specifier: 10.3.12
-        version: 10.3.12
       npm-run-all2:
         specifier: 6.1.2
         version: 6.1.2


### PR DESCRIPTION
It looks like we no longer use the `glob` dependency.

I searched for it and haven't found any usages of it, but please check as well.