### PR TITLE
chore: fix docs type import

### DIFF
--- a/docs/api/ApiIndex.vue
+++ b/docs/api/ApiIndex.vue
@@ -4,7 +4,7 @@
 import { computed, ref } from 'vue';
 import { slugify } from '../.vitepress/shared/utils/slugify';
 import apiSearchIndex from './api-search-index.json';
-import { APIGroup } from './api-types';
+import type { APIGroup } from './api-types';
 
 const query = ref('');
 const normalize = (s: string) => s.toLowerCase().replace(/-/g, ' ');


### PR DESCRIPTION
Fixes the following log output from `pnpm run docs:build`:

> docs/api/ApiIndex.vue?vue&type=script&setup=true&lang.ts (22:9): "APIGroup" is not exported by "docs/api/api-types.ts", imported by "docs/api/ApiIndex.vue?vue&type=script&setup=true&lang.ts".
> docs/api/ApiIndex.vue?vue&type=script&setup=true&lang.ts (8:9): "APIGroup" is not exported by "docs/api/api-types.ts", imported by "docs/api/ApiIndex.vue?vue&type=script&setup=true&lang.ts".