### PR TITLE
chore: replace obsolete mentions of typedoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ versions.json
 /dist
 /docs/.vitepress/cache
 /docs/.vitepress/dist
-/docs/api/typedoc.json
 /docs/public/api-diff-index.json
 /lib
 

--- a/scripts/apidocs/utils/format.ts
+++ b/scripts/apidocs/utils/format.ts
@@ -3,7 +3,7 @@ import { format } from 'prettier';
 import prettierConfig from '../../../.prettierrc.js';
 
 /**
- * Formats markdown contents.
+ * Formats Markdown contents.
  *
  * @param text The text to format.
  */
@@ -12,7 +12,7 @@ export async function formatMarkdown(text: string): Promise<string> {
 }
 
 /**
- * Formats typedoc contents.
+ * Formats TypeScript contents.
  *
  * @param text The text to format.
  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
   "exclude": [
     "node_modules",
     "dist",
-    // required for the typedoc related tests on macOS #2280
+    // required for the signature related tests on macOS #2280
     "test/scripts/apidocs/temp"
   ]
 }


### PR DESCRIPTION
Replaces mentions of the removed typedoc library from our source code.

Found while developing https://github.com/faker-js/faker/pull/2956

- https://github.com/faker-js/faker/pull/2956