### PR TITLE
docs: separate signature and examples

### DIFF
--- a/docs/.vitepress/components/api-docs/method.ts
+++ b/docs/.vitepress/components/api-docs/method.ts
@@ -6,6 +6,7 @@ export interface ApiDocsMethod {
   readonly parameters: ApiDocsMethodParameter[];
   readonly returns: string;
   readonly throws: string | undefined; // HTML
+  readonly signature: string; // HTML
   readonly examples: string; // HTML
   readonly seeAlsos: string[];
   readonly sourcePath: string; // URL-Suffix

--- a/docs/.vitepress/components/api-docs/method.vue
+++ b/docs/.vitepress/components/api-docs/method.vue
@@ -40,6 +40,9 @@ function seeAlsoToUrl(see: string): string {
       <strong>Throws:</strong> <span v-html="props.method.throws" />
     </p>
 
+    <div v-html="props.method.signature" />
+
+    <h3>Examples</h3>
     <div v-html="props.method.examples" />
 
     <div v-if="props.method.seeAlsos.length > 0">

--- a/scripts/apidocs/output/page.ts
+++ b/scripts/apidocs/output/page.ts
@@ -165,7 +165,8 @@ async function toMethodData(method: RawApiDocsMethod): Promise<ApiDocsMethod> {
     sourcePath: `${filePath}#L${line}`,
     throws: throws.length === 0 ? undefined : mdToHtml(throws.join('\n'), true),
     returns: returns.text,
-    examples: codeToHtml([formattedSignature, ...examples].join('\n')),
+    signature: codeToHtml(formattedSignature),
+    examples: codeToHtml(examples.join('\n')),
     deprecated: mdToHtml(deprecated),
     seeAlsos: seeAlsos.map((seeAlso) => mdToHtml(seeAlso, true)),
   };


### PR DESCRIPTION
Splits the signature and examples block into two.

Based upon:

- https://github.com/faker-js/faker/pull/2628#issuecomment-1925615223

Not sure which (additional) headers are actually useful.

**Before**

![grafik](https://github.com/faker-js/faker/assets/1579362/cb0fab6d-13c9-4c3c-b6c5-f3be120dea5a)

**After**

![grafik](https://github.com/faker-js/faker/assets/1579362/0ee7cd6a-4821-4d03-96e6-410f59a4f1d6)
