### PR TITLE
infra(release): use PAT for releases

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -14,9 +14,7 @@ on:
           - beta
           - rc
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {} # we use a personal access token to push the branch and create the PR
 
 jobs:
   prepare_release_pr:
@@ -29,6 +27,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
@@ -46,8 +45,8 @@ jobs:
 
       - name: Run release
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "FakerJS Bot"
+          git config user.email "github-bot@fakerjs.dev"
           if [ $RELEASE_TYPE = 'stable' ]; then
             pnpm run release
           else
@@ -82,4 +81,4 @@ jobs:
           - Checklist: TODO add link to issue
           "
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
 
-permissions: {}
+permissions: {} # we use a personal access token to push the release branch
 
 jobs:
   publish:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,8 +4,7 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write # to push the release branch
+permissions: {}
 
 jobs:
   publish:
@@ -17,6 +16,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0 # we want to push the release branch later
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0


### PR DESCRIPTION
This PR changes the release steps to use a fixed PAT instead of github-actions bot.

This should solve the issues with the CI not running automatically on push/being unable to push to vX branches.

- Test PR: https://github.com/faker-js/faker/pull/3028
- Related actions: https://github.com/faker-js/faker/actions/runs/10084426339/job/27883189013?pr=3028