### PR TITLE
docs(guide): add locale error handling sections

### DIFF
--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -202,9 +202,7 @@ console.log(faker.location.country()); // 'Ελλάδα'
 ```
 
 ::: tip Note
-
 Of course, you can use [Custom Locales and Fallbacks](#custom-locales-and-fallbacks) for this as well.
-
 :::
 
 ## Handling Not-Applicable Data Errors
@@ -229,10 +227,8 @@ We could have used an empty array `[]`, but some locale data are stored as objec
 so `null` works for both of them without custom downstream handling of missing data.
 
 :::tip Note
-
 We are by far no experts in all provided languages/countries/locales,
 so if you think this is an error for your locale, please create an issue and consider contributing the relevant data.
-
 :::
 
 If you want to use other fallback data instead, you can define them like this:
@@ -247,7 +243,6 @@ console.log(faker.location.zipCode()); // '17551-0348'
 ```
 
 ::: warning Warning
-
 Since `null` is considered present data, it will not use any fallbacks for that.
 So the following code does **not** work:
 

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -226,7 +226,7 @@ For these cases, we explicitly set the data to `null` to clarify, that we have t
 We could have used an empty array `[]`, but some locale data are stored as objects `{}`,
 so `null` works for both of them without custom downstream handling of missing data.
 
-:::tip Note
+::: tip Note
 We are by far no experts in all provided languages/countries/locales,
 so if you think this is an error for your locale, please create an issue and consider contributing the relevant data.
 :::

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -165,3 +165,113 @@ for (let key of Object.keys(allFakers)) {
   }
 }
 ```
+
+## Handling Missing Data Errors
+
+```txt
+[Error]: The locale data for 'category.entry' are missing in this locale.
+Please contribute the missing data to the project or use a locale/Faker instance that has these data.
+For more information see https://fakerjs.dev/guide/localization.html
+```
+
+If you receive this error, this means you are using a locale (`Faker` instance) that does not have the relevant data for that method yet.
+Please consider contributing the missing data, so that others can use them in the future as well.
+
+As a workaround, you can provide additional fallbacks to your `Faker` instance:
+
+```ts
+import { Faker, el } from '@faker-js/faker'; // [!code --]
+import { Faker, el, en } from '@faker-js/faker'; // [!code ++]
+
+const faker = new Faker({
+  locale: [el], // [!code --]
+  locale: [el, en], // [!code ++]
+});
+console.log(faker.location.country()); // 'Belgium'
+```
+
+If you want to use custom data instead, you can do it like this:
+
+```ts{4}
+import { Faker, el } from '@faker-js/faker';
+
+const faker = new Faker({
+  locale: [{ location: { country: ['Ελλάδα'] } }, el],
+});
+console.log(faker.location.country()); // 'Ελλάδα'
+```
+
+See also: [Custom Locales and Fallbacks](#custom-locales-and-fallbacks)
+
+## Handling Not-Applicable Data Errors
+
+```txt
+[Error]: The locale data for 'category.entry' aren't applicable to this locale.
+If you think this is a bug, please report it at: https://github.com/faker-js/faker
+```
+
+If you receive this error, this means the current locale is unable to provide reasonable values for that method.
+Let's say you have a imaginary locale for the planet `mars`, if you call `fakerMars.location.country()`,
+then you will get this error, because there aren't any countries' territories on mars.
+The same applies to other locales and methods.
+
+```ts
+import type { LocaleDefinition } from '@faker-js/faker';
+
+export const mars: LocaleDefinition = {
+  location: {
+    country: null,
+    ...
+  },
+  ...
+};
+```
+
+```ts
+import { Faker } from '@faker-js/faker';
+import { mars } from 'mars';
+
+const faker = new Faker({
+  locale: mars,
+});
+console.log(faker.location.country()); // Error
+```
+
+For these cases, we explicitly set the data to `null` to clarify, that we have thought about it, but there are no valid values to put there.
+We could have used an empty array `[]`, but some locale data are stored as objects `{}`,
+so `null` works for both of them without custom downstream handling of missing data.
+
+:::tip Note
+
+We are by far no experts in all provided languages/countries/locales,
+so if you think this is an error for your locale, please create an issue and consider contributing the relevant data.
+
+:::
+
+If you want to use other fallback data instead, you can define them like this:
+
+```ts{5}
+import { Faker, en } from '@faker-js/faker';
+import { mars } from 'mars';
+
+const faker = new Faker({
+  locale: [{ location: { country: en.location.country } }, mars],
+});
+console.log(faker.location.country()); // 'Belgium'
+```
+
+Since `null` is considered present data, it will not use any fallbacks for that.
+So the following code does **not** work:
+
+```ts
+import { Faker, en } from '@faker-js/faker';
+
+const mars: LocaleDefinition = ...;
+
+const faker = new Faker({
+  locale: [mars, { location: { state: en.location.state } }],
+});
+console.log(faker.location.state()); // Error
+```
+
+See also: [Custom Locales and Fallbacks](#custom-locales-and-fallbacks)

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -269,9 +269,9 @@ import { Faker, en } from '@faker-js/faker';
 const mars: LocaleDefinition = ...;
 
 const faker = new Faker({
-  locale: [mars, { location: { state: en.location.state } }],
+  locale: [mars, { location: { country: en.location.country } }],
 });
-console.log(faker.location.state()); // Error
+console.log(faker.location.country()); // Error
 ```
 
 See also: [Custom Locales and Fallbacks](#custom-locales-and-fallbacks)

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -190,17 +190,6 @@ const faker = new Faker({
 console.log(faker.location.country()); // 'Belgium'
 ```
 
-If you want to use custom data instead, you can do it like this:
-
-```ts{4}
-import { Faker, el } from '@faker-js/faker';
-
-const faker = new Faker({
-  locale: [{ location: { country: ['Ελλάδα'] } }, el],
-});
-console.log(faker.location.country()); // 'Ελλάδα'
-```
-
 ::: tip Note
 Of course, you can use [Custom Locales and Fallbacks](#custom-locales-and-fallbacks) for this as well.
 :::

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -219,7 +219,7 @@ The same applies to other locales and methods.
 ```ts
 import { fakerEN_HK } from '@faker-js/faker';
 
-console.log(fakerEN_HK.location.zipCode()); // Error
+console.log(fakerEN_HK.location.zipCode()); // Error // [!code error]
 ```
 
 For these cases, we explicitly set the data to `null` to clarify, that we have thought about it, but there are no valid values to put there.
@@ -252,7 +252,7 @@ import { Faker, en, en_HK } from '@faker-js/faker';
 const faker = new Faker({
   locale: [en_HK, { location: { postcode: en.location.postcode } }],
 });
-console.log(faker.location.zipCode()); // Error
+console.log(faker.location.zipCode()); // Error // [!code error]
 ```
 
 :::

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -233,7 +233,7 @@ export const mars: LocaleDefinition = {
 
 ```ts
 import { Faker } from '@faker-js/faker';
-import { mars } from 'mars';
+import { mars } from './locales/mars';
 
 const faker = new Faker({
   locale: mars,

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -215,30 +215,13 @@ If you think this is a bug, please report it at: https://github.com/faker-js/fak
 ```
 
 If you receive this error, this means the current locale is unable to provide reasonable values for that method.
-Let's say you have a imaginary locale for the planet `mars`, if you call `fakerMars.location.country()`,
-then you will get this error, because there aren't any countries' territories on mars, yet.
+For example, there are no zip codes in Hongkong, so for that reason the `en_HK` locale is unable to provide these data.
 The same applies to other locales and methods.
 
 ```ts
-import type { LocaleDefinition } from '@faker-js/faker';
+import { fakerEN_HK } from '@faker-js/faker';
 
-export const mars: LocaleDefinition = {
-  location: {
-    country: null,
-    ...
-  },
-  ...
-};
-```
-
-```ts
-import { Faker } from '@faker-js/faker';
-import { mars } from './locales/mars';
-
-const faker = new Faker({
-  locale: mars,
-});
-console.log(faker.location.country()); // Error
+console.log(fakerEN_HK.location.zipCode()); // Error
 ```
 
 For these cases, we explicitly set the data to `null` to clarify, that we have thought about it, but there are no valid values to put there.
@@ -255,13 +238,12 @@ so if you think this is an error for your locale, please create an issue and con
 If you want to use other fallback data instead, you can define them like this:
 
 ```ts{5}
-import { Faker, en } from '@faker-js/faker';
-import { mars } from './locales/mars';
+import { Faker, en, en_HK } from '@faker-js/faker';
 
 const faker = new Faker({
-  locale: [{ location: { country: en.location.country } }, mars],
+  locale: [{ location: { postcode: en.location.postcode } }, en_HK],
 });
-console.log(faker.location.country()); // 'Belgium'
+console.log(faker.location.zipCode()); // '17551-0348'
 ```
 
 ::: warning Warning
@@ -270,13 +252,12 @@ Since `null` is considered present data, it will not use any fallbacks for that.
 So the following code does **not** work:
 
 ```ts
-import { Faker, en } from '@faker-js/faker';
-import { mars } from './locales/mars';
+import { Faker, en, en_HK } from '@faker-js/faker';
 
 const faker = new Faker({
-  locale: [mars, { location: { country: en.location.country } }],
+  locale: [en_HK, { location: { postcode: en.location.postcode } }],
 });
-console.log(faker.location.country()); // Error
+console.log(faker.location.zipCode()); // Error
 ```
 
 :::

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -250,7 +250,7 @@ So the following code does **not** work:
 import { Faker, en, en_HK } from '@faker-js/faker';
 
 const faker = new Faker({
-  locale: [en_HK, { location: { postcode: en.location.postcode } }],
+  locale: [en_HK, { location: { postcode: en.location.postcode } }], // [!code warning]
 });
 console.log(faker.location.zipCode()); // Error // [!code error]
 ```

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -201,7 +201,11 @@ const faker = new Faker({
 console.log(faker.location.country()); // 'Ελλάδα'
 ```
 
-See also: [Custom Locales and Fallbacks](#custom-locales-and-fallbacks)
+::: tip Note
+
+Of course, you can use [Custom Locales and Fallbacks](#custom-locales-and-fallbacks) for this as well.
+
+:::
 
 ## Handling Not-Applicable Data Errors
 
@@ -212,7 +216,7 @@ If you think this is a bug, please report it at: https://github.com/faker-js/fak
 
 If you receive this error, this means the current locale is unable to provide reasonable values for that method.
 Let's say you have a imaginary locale for the planet `mars`, if you call `fakerMars.location.country()`,
-then you will get this error, because there aren't any countries' territories on mars.
+then you will get this error, because there aren't any countries' territories on mars, yet.
 The same applies to other locales and methods.
 
 ```ts
@@ -252,7 +256,7 @@ If you want to use other fallback data instead, you can define them like this:
 
 ```ts{5}
 import { Faker, en } from '@faker-js/faker';
-import { mars } from 'mars';
+import { mars } from './locales/mars';
 
 const faker = new Faker({
   locale: [{ location: { country: en.location.country } }, mars],
@@ -260,18 +264,21 @@ const faker = new Faker({
 console.log(faker.location.country()); // 'Belgium'
 ```
 
+::: warning Warning
+
 Since `null` is considered present data, it will not use any fallbacks for that.
 So the following code does **not** work:
 
 ```ts
 import { Faker, en } from '@faker-js/faker';
-
-const mars: LocaleDefinition = ...;
+import { mars } from './locales/mars';
 
 const faker = new Faker({
   locale: [mars, { location: { country: en.location.country } }],
 });
 console.log(faker.location.country()); // Error
 ```
+
+:::
 
 See also: [Custom Locales and Fallbacks](#custom-locales-and-fallbacks)

--- a/docs/guide/localization.md
+++ b/docs/guide/localization.md
@@ -233,7 +233,7 @@ so if you think this is an error for your locale, please create an issue and con
 
 If you want to use other fallback data instead, you can define them like this:
 
-```ts{5}
+```ts{4}
 import { Faker, en, en_HK } from '@faker-js/faker';
 
 const faker = new Faker({


### PR DESCRIPTION
Fixes: #3053 

- #3053 

This PR adds an explanation to the missing and non-applicable locale errors and ways to handle them.

**Preview:**

- https://deploy-preview-3055.fakerjs.dev/guide/localization.html#handling-missing-data-errors
- https://deploy-preview-3055.fakerjs.dev/guide/localization.html#handling-not-applicable-data-errors