### PR TITLE
infra: remove redirect from current stable

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,8 +17,8 @@
 
 # Alias for the next page
 [[redirects]]
-  from = "https://v10.fakerjs.dev"
-  to = "https://next.fakerjs.dev"
+  from = "https://v10.fakerjs.dev/*"
+  to = "https://next.fakerjs.dev/:splat"
   status = 302
   force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,13 +15,6 @@
     fi
   '''
 
-# Alias for the main page
-[[redirects]]
-  from = "https://v9.fakerjs.dev"
-  to = "https://fakerjs.dev"
-  status = 302
-  force = true
-
 # Alias for the next page
 [[redirects]]
   from = "https://v10.fakerjs.dev"


### PR DESCRIPTION
Removes the redirect from v9.fakerjs.dev -> fakerjs.dev

- This makes it easier to create permanent links to our documentation
- This fixes the broken search index for v9 (when merged/pushed to the v9 branch).