### PR TITLE
infra(netlify): remove ignore script

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,15 +5,6 @@
 [build]
   publish = "docs/.vitepress/dist"
   command = "pnpm docs:build:ci"
-  ignore = '''
-    if [ "$CONTEXT" != "deploy-preview" ]; then
-      # Always build when not a PR preview
-      exit 1;
-    else
-      # Otherwise check if something doc related changed.
-      git diff --quiet origin/next...$COMMIT_REF -- . ":!src/locale/" ":!src/locales/" ":!test/" ":!package.json" ":!pnpm-lock.yaml" ":!.github/"
-    fi
-  '''
 
 # Alias for the main page
 [[redirects]]


### PR DESCRIPTION
Removes the netlify ignore check.

- There are some cases where it would be nice if there was a preview of the changes (aka as some dependency changes).
- The ignore script does not reduce the number of notifications and we aren't close to the build limits either