### PR TITLE
infra: remove package.json warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,13 +66,11 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
     "./locale/*": {
       "types": "./dist/types/locale/*.d.ts",
-      "import": "./dist/locale/*.js",
       "require": "./dist/locale/*.cjs",
       "default": "./dist/locale/*.js"
     },


### PR DESCRIPTION
closes #3078

I obviously choose not to remove `default` but `import`, so we fallback to simply `.js` files in any other case, and do not change the runtime behavior.
If we would remove `default` instead of `import`, I highly assume it would either fail for e.g. `browser`, or any other possible kind, instead of at least trying to function.
If then for any other kind either something works or does not work, contributors can then still report an issue.