### PR TITLE
chore(deps): remove eslint-define-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "cypress": "13.14.2",
     "eslint": "9.11.0",
     "eslint-config-prettier": "9.1.0",
-    "eslint-define-config": "2.1.0",
     "eslint-plugin-jsdoc": "50.2.4",
     "eslint-plugin-prettier": "5.2.1",
     "eslint-plugin-unicorn": "55.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ importers:
       eslint-config-prettier:
         specifier: 9.1.0
         version: 9.1.0(eslint@9.11.0(jiti@1.21.6))
-      eslint-define-config:
-        specifier: 2.1.0
-        version: 2.1.0
       eslint-plugin-jsdoc:
         specifier: 50.2.4
         version: 50.2.4(eslint@9.11.0(jiti@1.21.6))
@@ -1748,10 +1745,6 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
-
-  eslint-define-config@2.1.0:
-    resolution: {integrity: sha512-QUp6pM9pjKEVannNAbSJNeRuYwW3LshejfyBBpjeMGaJjaDUpVps4C6KVR8R7dWZnD3i0synmrE36znjTkJvdQ==}
-    engines: {node: '>=18.0.0', npm: '>=9.0.0', pnpm: '>=8.6.0'}
 
   eslint-plugin-jsdoc@50.2.4:
     resolution: {integrity: sha512-020jA+dXaXdb+TML3ZJBvpPmzwbNROjnYuTYi/g6A5QEmEjhptz4oPJDKkOGMIByNxsPpdTLzSU1HYVqebOX1w==}
@@ -5326,8 +5319,6 @@ snapshots:
   eslint-config-prettier@9.1.0(eslint@9.11.0(jiti@1.21.6)):
     dependencies:
       eslint: 9.11.0(jiti@1.21.6)
-
-  eslint-define-config@2.1.0: {}
 
   eslint-plugin-jsdoc@50.2.4(eslint@9.11.0(jiti@1.21.6)):
     dependencies:


### PR DESCRIPTION
# Description

The dependency `eslint-define-config` is no longer required, since eslint v9. `typescript-eslint` ships with their own `defineConfig` function.

# Others

Found in #3106.

- #3106
