### PR TITLE
chore(deps): remove @algolia/client-search

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,7 +57,7 @@
     },
     {
       "groupName": "doc-dependencies",
-      "matchPackageNames": ["@algolia/client-search", "ts-morph", "vitepress"]
+      "matchPackageNames": ["ts-morph", "vitepress"]
     }
   ],
   "stopUpdatingLabel": "s: on hold",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   ],
   "devDependencies": {
     "@actions/github": "6.0.0",
-    "@algolia/client-search": "5.5.3",
     "@eslint/compat": "1.1.1",
     "@eslint/js": "9.11.0",
     "@stylistic/eslint-plugin": "2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@actions/github':
         specifier: 6.0.0
         version: 6.0.0
-      '@algolia/client-search':
-        specifier: 5.5.3
-        version: 5.5.3
       '@eslint/compat':
         specifier: 1.1.1
         version: 1.1.1


### PR DESCRIPTION
# Description

The dependency `@algolia/client-search` does not seem to be required. Our docs use VitePress, which is [integrating Algolia](https://vitepress.dev/reference/default-theme-search#algolia-search) out of the box. For that they use algolias [DocSearch](https://docsearch.algolia.com/docs/DocSearch-v3) under the hood. This does not seem to require `@algolia/client-search` (at least from my research). Maybe it did in the previous v2, but I did not dig deeper into that.

# Others

Found in and extracted from #3106.

- #3106