### PR TITLE
fix(food): use arrayElement instead of fake for adjective

### DIFF
--- a/src/modules/food/index.ts
+++ b/src/modules/food/index.ts
@@ -18,7 +18,9 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   adjective(): string {
-    return this.faker.helpers.fake(this.faker.definitions.food.adjective);
+    return this.faker.helpers.arrayElement(
+      this.faker.definitions.food.adjective
+    );
   }
 
   /**


### PR DESCRIPTION
The faker.food.adjective method incorrectly uses `faker.helpers.fake` instead of `faker.helpers.arrayElement`.
This PR fixes that.

---

Found while writing: #3176 

- #3176 