### PR TITLE
docs: align featured modules on website and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,14 @@ For detailed API documentation, please select the version of the documentation y
 ---
 
 ## 🚀 Features
-
-- 💌 Locations - Generate valid looking Addresses, Zip Codes, Street Names, States, and Countries!
-- ⏰ Time-based Data - Past, present, future, recent, soon... whenever!
-- 🌏 Localization - Pick a locale to generate realistic looking Names, Addresses, and Phone Numbers.
+- 🧍 Person - Generate Names, Genders, Bios, Job titles, and more.
+- 💌 Location - Generate Addresses, Zip Codes, Street Names, States, and Countries!
+- ⏰ Date - Past, present, future, recent, soon... whenever!
 - 💸 Finance - Create stubbed out Account Details, Transactions, and Crypto Addresses.
-- 👠 Products - Generate Prices, Product Names, Adjectives, and Descriptions.
-- 👾 Hacker Jargon - “Try to reboot the SQL bus, maybe it will bypass the virtual application!”
-- 🧍 Names - Generate virtual humans with a complete online and offline identity.
-- 🔢 Numbers - Of course, we can also generate random numbers and strings.
+- 👠 Commerce - Generate Prices, Product Names, Adjectives, and Descriptions.
+- 👾 Hacker - “Try to reboot the SQL bus, maybe it will bypass the virtual application!”
+- 🔢 Number and String - Of course, we can also generate random numbers and strings.
+- 🌏 Localization - Pick from over 60 locales to generate realistic looking Names, Addresses, and Phone Numbers.
 
 > **Note**: Faker tries to generate realistic data and not obvious fake data.
 > The generated names, addresses, emails, phone numbers, and/or other data might be coincidentally valid information.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ For detailed API documentation, please select the version of the documentation y
 ---
 
 ## 🚀 Features
+
 - 🧍 Person - Generate Names, Genders, Bios, Job titles, and more.
 - 💌 Location - Generate Addresses, Zip Codes, Street Names, States, and Countries!
 - ⏰ Date - Past, present, future, recent, soon... whenever!

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For detailed API documentation, please select the version of the documentation y
 ## 🚀 Features
 
 - 🧍 Person - Generate Names, Genders, Bios, Job titles, and more.
-- 💌 Location - Generate Addresses, Zip Codes, Street Names, States, and Countries!
+- 📍 Location - Generate Addresses, Zip Codes, Street Names, States, and Countries!
 - ⏰ Date - Past, present, future, recent, soon... whenever!
 - 💸 Finance - Create stubbed out Account Details, Transactions, and Crypto Addresses.
 - 👠 Commerce - Generate Prices, Product Names, Adjectives, and Descriptions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ features:
   - icon: 🧍
     title: Person
     details: Generate Names, Genders, Bios, Job titles, and more.
-  - icon: 💌
+  - icon: 📍
     title: Location
     details: Generate Addresses, Zip Codes, Street Names, States, and Countries!
   - icon: ⏰

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,24 +20,24 @@ hero:
       link: https://github.com/faker-js/faker
 
 features:
-  - icon: 👠
-    title: Products
-    details: Generate Prices, Product Names, Adjectives, and Descriptions.
+  - icon: 🧍
+    title: Person
+    details: Generate Names, Genders, Bios, Job titles, and more.
+  - icon: 💌
+    title: Location
+    details: Generate Addresses, Zip Codes, Street Names, States, and Countries!
+  - icon: ⏰
+    title: Date
+    details: Past, present, future, recent, soon... whenever!
   - icon: 💸
     title: Finance
     details: Create stubbed out Account Details, Transactions, and Crypto Addresses.
-  - icon: 💌
-    title: Locations
-    details: Generate valid Addresses, Zip Codes, Street Names, States, and Countries!
-  - icon: 👾
-    title: Hacker Jargon
-    details: “Try to reboot the SQL bus, maybe it will bypass the virtual application!”
-  - icon: ⏰
-    title: Time-based Data
-    details: Past, present, future, recent, soon... whenever!
+  - icon: 👠
+    title: Commerce
+    details: Generate Prices, Product Names, Adjectives, and Descriptions.
   - icon: 🌏
     title: Localization
-    details: Pick a locale to generate realistic looking Names, Addresses, and Phone Numbers.
+    details: Pick from over 60 locales to generate realistic looking Names, Addresses, and Phone Numbers.
 ---
 
 <div class="opencollective">


### PR DESCRIPTION
fix #1532

Mostly aligns the modules featured on fakerjs.dev with those in the README. 

Makes the title the module name (Person, Commerce) etc