### PR TITLE
infra: remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "typescript": "5.6.3",
     "typescript-eslint": "8.11.0",
     "validator": "13.12.0",
-    "vite": "5.4.10",
     "vitepress": "1.4.1",
     "vitest": "2.1.3",
     "vue": "3.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,9 +110,6 @@ importers:
       validator:
         specifier: 13.12.0
         version: 13.12.0
-      vite:
-        specifier: 5.4.10
-        version: 5.4.10(@types/node@20.16.15)
       vitepress:
         specifier: 1.4.1
         version: 1.4.1(@algolia/client-search@4.24.0)(@types/node@20.16.15)(postcss@8.4.47)(search-insights@2.17.2)(typescript@5.6.3)


### PR DESCRIPTION
Completes #3106

- #3106

---

This PR removes the unused vite dependency that has been replaced by tsup a while ago.