### PR TITLE
infra(renovate): disable rimraf update for now

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,6 +59,12 @@
     {
       "groupName": "doc-dependencies",
       "matchPackageNames": ["ts-morph", "vitepress"]
+    },
+    {
+      // Disable updates for rimraf until Node 18 support is dropped
+      "groupName": "disabled",
+      "matchPackageNames": ["rimraf"],
+      "enabled": false
     }
   ],
   "stopUpdatingLabel": "s: on hold",


### PR DESCRIPTION
`rimraf` dropped node v18 support.
To prevent it from contaminating renovates PRs, we should disable it until we drop Node 18 support.

- https://github.com/isaacs/rimraf/issues/312
- https://github.com/isaacs/rimraf/blob/main/CHANGELOG.md#60
- https://docs.renovatebot.com/configuration-options/#enabled