### PR TITLE
infra(ci): prepare CI for GitHub merge queues

### DIFF
--- a/.github/workflows/check-mergable-by-label.yml
+++ b/.github/workflows/check-mergable-by-label.yml
@@ -9,6 +9,7 @@ on:
       - edited
       - labeled
       - unlabeled
+  merge_group:
 
 permissions: {}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - next
   pull_request:
+  merge_group:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: PR
 
 on:
   pull_request:
+  merge_group:
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
Updates the workflow files to contain triggers for merge queues.

(all files that have required checks, must be tagged with the merge_queue trigger)

- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

This is my first attempt at this, so I'm not sure whether I configured this correctly.
Not sure how to test this, I cannot test this in my private fork of Faker (as merge queues seem to be an organization feature?).

---

Technical explanation about merge queues:

GitHub's merge queues are ways to merge PRs in rapid succession without omitting CI tests.

- PRs that gets added to the queue are synced to the target branch,
- the CI is triggered
  - and if successful, the PR is merged
  - if not successful, the PR is removed from the merge queue
- The next PR from the merge queue is processed

[Documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)

---

At this point in time I'm not sure whether we should use merge queues, but I would like to enable them to gain some experience in their utility. If you have some insides into them, please let me know.