### PR TITLE
infra(unicorn): prefer-string-slice

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -153,13 +153,13 @@ const config: ReturnType<typeof tseslint.config> = tseslint.config(
       'unicorn/number-literal-case': 'off', // incompatible with prettier
       'unicorn/numeric-separators-style': 'off', // "magic numbers" may carry specific meaning
       'unicorn/prefer-string-raw': 'off', // The additional prefix doesn't help readability
+      'unicorn/prefer-string-slice': 'off', // string.substring is sometimes easier to use
       'unicorn/prefer-ternary': 'off', // ternaries aren't always better
 
       // TODO @Shinigami92 2023-09-23: The following rules currently conflict with our code.
       // Each rule should be checked whether it should be enabled/configured and the problems fixed, or stay disabled permanently.
       'unicorn/consistent-function-scoping': 'off',
       'unicorn/prefer-export-from': 'off',
-      'unicorn/prefer-string-slice': 'off',
       'unicorn/prevent-abbreviations': 'off',
     },
   },


### PR DESCRIPTION
Ref: #2439

- #2439

Previous failed PR: #2814

- #2814

---

Permanently disables the [`unicorn/prefer-string-slice`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-slice.md) lint rule.

- string.substring is sometimes easier to use than string.slice
- string.slice is less known than string.substring