### PR TITLE
fix(internet): ensure domainWord always returns a valid value in all locales

### DIFF
--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -595,9 +595,32 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   domainWord(): string {
-    return this.faker.helpers
-      .slugify(`${this.faker.word.adjective()}-${this.faker.word.noun()}`)
-      .toLowerCase();
+    // Generate an ASCII "word" in the form `noun-adjective`
+    // For locales with non-ASCII characters, we fall back to lorem words, or a random string
+    const isValidSlug = (slug: string): boolean => {
+      return /^[a-z][a-z-]*[a-z]$/i.exec(slug) !== null;
+    };
+
+    const makeValidSlug = (word: string): string => {
+      const slug1 = this.faker.helpers.slugify(word);
+      if (isValidSlug(slug1)) {
+        return slug1;
+      }
+
+      const slug2 = this.faker.helpers.slugify(this.faker.lorem.word());
+      if (isValidSlug(slug2)) {
+        return slug2;
+      }
+
+      return this.faker.string.alpha({
+        casing: 'lower',
+        length: this.faker.number.int({ min: 4, max: 8 }),
+      });
+    };
+
+    const word1 = makeValidSlug(this.faker.word.adjective());
+    const word2 = makeValidSlug(this.faker.word.noun());
+    return `${word1}-${word2}`.toLowerCase();
   }
 
   /**

--- a/test/modules/internet.spec.ts
+++ b/test/modules/internet.spec.ts
@@ -1,6 +1,6 @@
 import validator from 'validator';
 import { describe, expect, it } from 'vitest';
-import { allFakers, faker } from '../../src';
+import { allFakers, faker, fakerKO } from '../../src';
 import { FakerError } from '../../src/errors/faker-error';
 import { IPv4Network } from '../../src/modules/internet';
 import { seededTests } from '../support/seeded-runs';
@@ -659,6 +659,17 @@ describe('internet', () => {
       describe('domainWord()', () => {
         it('should return a lower-case adjective + noun', () => {
           const domainWord = faker.internet.domainWord();
+
+          expect(domainWord).toBeTruthy();
+          expect(domainWord).toBeTypeOf('string');
+          expect(domainWord).toSatisfy(validator.isSlug);
+          expect(domainWord).toSatisfy((value: string) =>
+            validator.isFQDN(value, { require_tld: false })
+          );
+        });
+
+        it('should return a lower-case domain in non-ASCII locales', () => {
+          const domainWord = fakerKO.internet.domainWord();
 
           expect(domainWord).toBeTruthy();
           expect(domainWord).toBeTypeOf('string');


### PR DESCRIPTION
fix #3251

If `faker.word.noun()/adjective()` doesnt return useful output, fall back to `faker.lorem.word()` or a random string

Fixes issues in `fa,ko,zh-CN`

```
af_ZA silent-couch
ar married-minister
az trained-thigh
base
cs_CZ thick-strategy
da larmende-myndighed
de ehrgeizig-verhutung
de_AT heimlich-kilometer
de_CH standhaft-ph-wert
dv tangible-reach
el small-trench
en tough-perfection
en_AU baggy-alert
en_AU_ocker rare-platypus
en_BORK dim-euphonium
en_CA authentic-viability
en_GB flowery-larva
en_GH ecstatic-characterization
en_HK cumbersome-desk
en_IE self-reliant-academics
en_IN deficient-doorpost
en_NG troubled-co-producer
en_US happy-taro
en_ZA tense-chasuble
eo insistent-sprinkles
es esteemed-catalyst
es_MX crushing-bookend
fa omhjh-vkzoy
fi feline-independence
fr sympathique-communaute-etudiante
fr_BE lache-hote
fr_CA rectangulaire-personnel
fr_CH timide-rectorat
fr_LU turquoise-commissionnaire
fr_SN dense-police
he stark-entry
hr golden-priesthood
hu narancssargas-szalagos-likacsosgomba
hy short-transom
id_ID tall-elevation
it grimy-pomelo
ja whopping-slime
ka_GE frightened-sarong
ko slek-adwpi
lv unhealthy-dream
mk natural-heroine
nb_NO apenbar-eyebrow
ne necessary-mixture
nl circular-space
nl_BE unknown-range
pl talkative-hyphenation
pt_BR bright-membership
pt_PT chilly-devil
ro bright-spirit
ro_MD flashy-obesity
ru parallel-feather
sk soft-fedora
sr_RS_latin unfinished-bog
sv vengeful-flight
th brilliant-cassava
tr foolish-widow
uk strong-expense
ur warm-distinction
uz_UZ_latin petty-label
vi delectable-kick
yo_NG both-pigsty
zh_CN venustas-reporter
zh_TW better-range
zu_ZA inexperienced-republican
```