### PR TITLE
refactor(helpers): introduce allowHuge flag

### DIFF
--- a/src/internal/check-huge.ts
+++ b/src/internal/check-huge.ts
@@ -1,0 +1,23 @@
+import { FakerError } from '../errors/faker-error';
+
+/**
+ * Check if the count is potentially too huge to be executable in a reasonable time or using default memory limits.
+ *
+ * @internal
+ *
+ * @param count The count to check.
+ * @param name The name of the parameter.
+ * @param allowHuge Whether to allow huge counts.
+ */
+export function checkHuge(
+  count: number | { max: number },
+  name: string,
+  allowHuge: boolean = false
+): void {
+  const maxCount = typeof count === 'number' ? count : count.max;
+  if (!allowHuge && maxCount >= 1e6) {
+    throw new FakerError(
+      `The ${name} parameter is potentially too huge to be executable in a reasonable time or using default memory limits. Please make sure that you didn't confuse count/length with numbers in an expected range. Set the 'allowHuge' option to 'true' to bypass this security check.`
+    );
+  }
+}

--- a/test/internal/check-huge.ts
+++ b/test/internal/check-huge.ts
@@ -1,0 +1,22 @@
+import { describe, expect } from 'vitest';
+import { FakerError } from '../../src';
+import { checkHuge } from '../../src/internal/check-huge';
+
+describe('allow huge', () => {
+  it('should allow small counts', () => {
+    expect(() => checkHuge(1000, 'count')).not.toThrow();
+  });
+
+  it('should not allow huge counts by default', () => {
+    expect(() => checkHuge(1e6, 'count')).toThrow(
+      new FakerError(
+        "The count parameter is potentially too huge to be executable in a reasonable time or using default memory limits. Please make sure that you didn't confuse count/length with numbers in an expected range. Set the 'allowHuge' option to 'true' to bypass this security check."
+      )
+    );
+  });
+
+  // This test is skipped because it takes a long time to run
+  it.skip('should allow huge counts when flag is present', () => {
+    expect(() => checkHuge(1e6, 'count', true)).not.toThrow();
+  });
+});

--- a/test/modules/helpers.spec.ts
+++ b/test/modules/helpers.spec.ts
@@ -1094,7 +1094,7 @@ describe('helpers', () => {
 
       it('should not allow huge counts by default', () => {
         expect(() => faker.helpers.multiple(() => 1, { count: 1e6 })).toThrow(
-          new Error(
+          new FakerError(
             "The count parameter is potentially too huge to be executable in a reasonable time or using default memory limits. Please make sure that you didn't confuse count/length with numbers in an expected range. Set the 'allowHuge' option to 'true' to bypass this security check."
           )
         );

--- a/test/modules/helpers.spec.ts
+++ b/test/modules/helpers.spec.ts
@@ -1091,6 +1091,21 @@ describe('helpers', () => {
           expect(result).toStrictEqual([0, 2, 4]);
         });
       });
+
+      it('should not allow huge counts by default', () => {
+        expect(() => faker.helpers.multiple(() => 1, { count: 1e6 })).toThrow(
+          new Error(
+            "The count parameter is potentially too huge to be executable in a reasonable time or using default memory limits. Please make sure that you didn't confuse count/length with numbers in an expected range. Set the 'allowHuge' option to 'true' to bypass this security check."
+          )
+        );
+      });
+
+      // This test is skipped because it takes a long time to run
+      it.skip('should allow huge counts when flag is present', () => {
+        expect(() =>
+          faker.helpers.multiple(() => 1, { count: 1e6, allowHuge: true })
+        ).not.toThrow();
+      });
     }
   );
 


### PR DESCRIPTION
Second part of #2695

- #2695

---

Adds a `allowHuge` flag to `faker.helpers.multiple`. If not set, the number of elements is limited to < 1 Mio.
I considered lowering the limit to just 100k as even 1 Mio elements take quite the while to generate.

Once this PR is accepted I'll continue with the string and lorem(?) module.