### PR TITLE
infra(CI): skip required CI steps in merge_queues

### DIFF
--- a/.github/workflows/check-mergable-by-label.yml
+++ b/.github/workflows/check-mergable-by-label.yml
@@ -16,6 +16,7 @@ permissions: {}
 jobs:
   fail-by-blocking-label:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - name: Check for blocking labels
         run: |

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Semantic Pull Request
+    if: ${{ github.event_name != 'merge_group' }}
     steps:
       - name: Validate PR title
         uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3


### PR DESCRIPTION
Another attempt at enabling the merge queue.

Previous attempt: #3245

- #3245

---

Both the `fail-by-blocking-label` and `Semantic Pull Request` pipelines require the `pull_request` context.

- https://github.com/faker-js/faker/actions/runs/11845914641/job/33012371158
- https://github.com/faker-js/faker/actions/runs/11845914639/job/33012371530
- https://github.com/faker-js/faker/pull/3250#event-15304630954

There are two solutions to the problem:

- Make these steps optional, which might lead to accidental merges of bad values
- Let the CI skip the failing tasks in merge queues, but keep them otherwise required

I decided to try the later one first.

These solutions were suggested here:

- https://github.com/amannn/action-semantic-pull-request/issues/236#issuecomment-1695654373
- https://github.com/Azure-Samples/chat-with-your-data-solution-accelerator/pull/860

I'm once again unable to test these changes myself.