### PR TITLE
refactor(locale): split en_AU_ocker first_names by sex

### DIFF
--- a/src/locales/en_AU_ocker/person/first_name.ts
+++ b/src/locales/en_AU_ocker/person/first_name.ts
@@ -1,5 +1,5 @@
 export default {
-  generic: [
+  female: [
     'Charlotte',
     'Ava',
     'Chloe',
@@ -50,6 +50,8 @@ export default {
     'Evelyn',
     'Mackenzie',
     'Ayla',
+  ],
+  male: [
     'Oliver',
     'Jack',
     'Jackson',


### PR DESCRIPTION
Preparatory PR for #3269 

- #3269

---

Currently, the en_AU_ocker file is just a concattenated list of female and male first names.
This PR splits the generic set into female and male respectively.

This PR intentionally does not sort the elements to make it easier to review.