### PR TITLE
chore: import validator functions individually

### DIFF
--- a/test/modules/commerce.spec.ts
+++ b/test/modules/commerce.spec.ts
@@ -1,4 +1,4 @@
-import validator from 'validator';
+import { isISBN } from 'validator';
 import { describe, expect, it } from 'vitest';
 import { faker } from '../../src';
 import { seededTests } from '../support/seeded-runs';
@@ -204,7 +204,7 @@ describe('commerce', () => {
             isbn,
             'The expected match should be ISBN-13 with hyphens'
           ).toMatch(/^978-[01]-[\d-]{9}-\d$/);
-          expect(isbn).toSatisfy((isbn: string) => validator.isISBN(isbn, 13));
+          expect(isbn).toSatisfy((isbn: string) => isISBN(isbn, 13));
         });
 
         it('should return ISBN-10 with hyphen separators when passing variant 10 as argument', () => {
@@ -214,7 +214,7 @@ describe('commerce', () => {
             isbn,
             'The expected match should be ISBN-10 with hyphens'
           ).toMatch(/^[01]-[\d-]{9}-[\dX]$/);
-          expect(isbn).toSatisfy((isbn: string) => validator.isISBN(isbn, 10));
+          expect(isbn).toSatisfy((isbn: string) => isISBN(isbn, 10));
         });
 
         it('should return ISBN-13 with hyphen separators when passing variant 13 as argument', () => {
@@ -224,7 +224,7 @@ describe('commerce', () => {
             isbn,
             'The expected match should be ISBN-13 with hyphens'
           ).toMatch(/^978-[01]-[\d-]{9}-\d$/);
-          expect(isbn).toSatisfy((isbn: string) => validator.isISBN(isbn, 13));
+          expect(isbn).toSatisfy((isbn: string) => isISBN(isbn, 13));
         });
 
         it('should return ISBN-10 with space separators when passing variant 10 and space separators as argument', () => {
@@ -234,7 +234,7 @@ describe('commerce', () => {
             isbn,
             'The expected match should be ISBN-10 with space separators'
           ).toMatch(/^[01] [\d ]{9} [\dX]$/);
-          expect(isbn).toSatisfy((isbn: string) => validator.isISBN(isbn, 10));
+          expect(isbn).toSatisfy((isbn: string) => isISBN(isbn, 10));
         });
 
         it('should return ISBN-13 with space separators when passing space separators as argument', () => {
@@ -244,7 +244,7 @@ describe('commerce', () => {
             isbn,
             'The expected match should be ISBN-13 with space separators'
           ).toMatch(/^978 [01] [\d ]{9} \d$/);
-          expect(isbn).toSatisfy((isbn: string) => validator.isISBN(isbn, 13));
+          expect(isbn).toSatisfy((isbn: string) => isISBN(isbn, 13));
         });
       });
     }

--- a/test/modules/finance-iban.spec.ts
+++ b/test/modules/finance-iban.spec.ts
@@ -1,4 +1,4 @@
-import validator from 'validator';
+import { isIBAN } from 'validator';
 import { describe, expect, it } from 'vitest';
 import { faker } from '../../src';
 import { prettyPrintIban } from '../../src/modules/finance';
@@ -17,7 +17,7 @@ describe('finance_iban', () => {
       });
 
       expect(actual).toMatch(new RegExp(`^${country}`));
-      expect(actual).toSatisfy(validator.isIBAN);
+      expect(actual).toSatisfy(isIBAN);
     });
   });
 
@@ -41,7 +41,7 @@ describe('finance_iban', () => {
             countryCode: 'GE',
           });
 
-          expect(iban).toSatisfy(validator.isIBAN);
+          expect(iban).toSatisfy(isIBAN);
 
           const ibanFormatted = prettyPrintIban(iban);
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -104,7 +104,7 @@ describe('finance_iban', () => {
             countryCode: 'PK',
           });
 
-          expect(iban).toSatisfy(validator.isIBAN);
+          expect(iban).toSatisfy(isIBAN);
 
           const ibanFormated = prettyPrintIban(iban);
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -173,7 +173,7 @@ describe('finance_iban', () => {
             countryCode: 'TR',
           });
 
-          expect(iban).toSatisfy(validator.isIBAN);
+          expect(iban).toSatisfy(isIBAN);
 
           const ibanFormated = prettyPrintIban(iban);
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -246,7 +246,7 @@ describe('finance_iban', () => {
             countryCode: 'AZ',
           });
 
-          expect(iban).toSatisfy(validator.isIBAN);
+          expect(iban).toSatisfy(isIBAN);
 
           const ibanFormated = prettyPrintIban(iban);
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -308,7 +308,7 @@ describe('finance_iban', () => {
             countryCode: 'CR',
           });
 
-          expect(iban).toSatisfy(validator.isIBAN);
+          expect(iban).toSatisfy(isIBAN);
 
           const ibanFormated = prettyPrintIban(iban);
           const bban = iban.substring(4) + iban.substring(0, 4);
@@ -360,7 +360,7 @@ describe('finance_iban', () => {
           });
           const ibanFormated = prettyPrintIban(iban);
 
-          expect(iban).toSatisfy(validator.isIBAN);
+          expect(iban).toSatisfy(isIBAN);
 
           expect(
             28,

--- a/test/modules/git.spec.ts
+++ b/test/modules/git.spec.ts
@@ -1,4 +1,4 @@
-import validator from 'validator';
+import { isEmail, isHexadecimal, isSlug } from 'validator';
 import { describe, expect, it } from 'vitest';
 import { faker } from '../../src';
 import { seededTests } from '../support/seeded-runs';
@@ -13,7 +13,7 @@ function isValidCommitAuthor(email: string): boolean {
   // that contain unquoted characters like . output by Git so we need
   // to quote the display name
   const quotedEmail = email.replace(/^(.*) </, '"$1" <');
-  return validator.isEmail(quotedEmail, {
+  return isEmail(quotedEmail, {
     require_display_name: true,
   });
 }
@@ -49,7 +49,7 @@ describe('git', () => {
 
           expect(branch).toBeTruthy();
           expect(branch).toBeTypeOf('string');
-          expect(branch).toSatisfy(validator.isSlug);
+          expect(branch).toSatisfy(isSlug);
         });
       });
 
@@ -145,7 +145,7 @@ describe('git', () => {
 
           expect(commitSha).toBeTruthy();
           expect(commitSha).toBeTypeOf('string');
-          expect(commitSha).toSatisfy(validator.isHexadecimal);
+          expect(commitSha).toSatisfy(isHexadecimal);
           expect(commitSha).toHaveLength(40);
         });
 
@@ -159,7 +159,7 @@ describe('git', () => {
 
             expect(commitSha).toBeTruthy();
             expect(commitSha).toBeTypeOf('string');
-            expect(commitSha).toSatisfy(validator.isHexadecimal);
+            expect(commitSha).toSatisfy(isHexadecimal);
             expect(commitSha).toHaveLength(length);
           }
         );

--- a/test/modules/internet.spec.ts
+++ b/test/modules/internet.spec.ts
@@ -1,4 +1,16 @@
-import validator from 'validator';
+import {
+  isEmail,
+  isFQDN,
+  isHexadecimal,
+  isHexColor,
+  isIP,
+  isJWT,
+  isMACAddress,
+  isPort,
+  isSlug,
+  isStrongPassword,
+  isURL,
+} from 'validator';
 import { describe, expect, it } from 'vitest';
 import { allFakers, faker, fakerKO } from '../../src';
 import { FakerError } from '../../src/errors/faker-error';
@@ -174,7 +186,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [, suffix] = email.split('@');
           expect(faker.definitions.internet.free_email).toContain(suffix);
@@ -191,7 +203,7 @@ describe('internet', () => {
 
             expect(email).toBeTruthy();
             expect(email).toBeTypeOf('string');
-            expect(email).toSatisfy(validator.isEmail);
+            expect(email).toSatisfy(isEmail);
           }
         );
 
@@ -200,7 +212,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [prefix, suffix] = email.split('@');
 
@@ -219,7 +231,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [prefix] = email.split('@');
           expect(prefix).not.toMatch(/^\./);
@@ -231,7 +243,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [prefix] = email.split('@');
           //expect it not to contain multiple .s
@@ -246,7 +258,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [prefix, suffix] = email.split('@');
 
@@ -266,7 +278,7 @@ describe('internet', () => {
           });
           // should truncate to 50 chars
           // e.g. ElizabethAlexandraMaryJaneAnnabelVictoria.SmithJon@yahoo.com
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
           const localPart = email.split('@')[0];
           expect(localPart.length).toBeLessThanOrEqual(50);
         });
@@ -278,7 +290,7 @@ describe('internet', () => {
           });
           // should strip invalid chars
           // e.g. MatthewMatt_Smith@yahoo.com
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
         });
 
         it('should return an email with special characters', () => {
@@ -290,7 +302,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [prefix, suffix] = email.split('@');
 
@@ -305,7 +317,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const suffix = email.split('@')[1];
 
@@ -320,7 +332,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [prefix, suffix] = email.split('@');
 
@@ -337,7 +349,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [prefix, suffix] = email.split('@');
           expect(email).includes('Aiden');
@@ -357,7 +369,7 @@ describe('internet', () => {
 
           expect(email).toBeTruthy();
           expect(email).toBeTypeOf('string');
-          expect(email).toSatisfy(validator.isEmail);
+          expect(email).toSatisfy(isEmail);
 
           const [prefix, suffix] = email.split('@');
 
@@ -608,7 +620,7 @@ describe('internet', () => {
 
           expect(url).toBeTruthy();
           expect(url).toBeTypeOf('string');
-          expect(url).toSatisfy(validator.isURL);
+          expect(url).toSatisfy(isURL);
         });
 
         it('should return a valid url with slash appended at the end', () => {
@@ -616,7 +628,7 @@ describe('internet', () => {
 
           expect(url).toBeTruthy();
           expect(url).toBeTypeOf('string');
-          expect(url).toSatisfy(validator.isURL);
+          expect(url).toSatisfy(isURL);
           expect(url.endsWith('/')).toBeTruthy();
         });
 
@@ -625,7 +637,7 @@ describe('internet', () => {
 
           expect(url).toBeTruthy();
           expect(url).toBeTypeOf('string');
-          expect(url).toSatisfy(validator.isURL);
+          expect(url).toSatisfy(isURL);
         });
       });
 
@@ -635,11 +647,11 @@ describe('internet', () => {
 
           expect(domainName).toBeTruthy();
           expect(domainName).toBeTypeOf('string');
-          expect(domainName).toSatisfy(validator.isFQDN);
+          expect(domainName).toSatisfy(isFQDN);
 
           const [prefix, suffix] = domainName.split('.');
 
-          expect(prefix).toSatisfy(validator.isSlug);
+          expect(prefix).toSatisfy(isSlug);
           expect(faker.definitions.internet.domain_suffix).toContain(suffix);
         });
       });
@@ -662,9 +674,9 @@ describe('internet', () => {
 
           expect(domainWord).toBeTruthy();
           expect(domainWord).toBeTypeOf('string');
-          expect(domainWord).toSatisfy(validator.isSlug);
+          expect(domainWord).toSatisfy(isSlug);
           expect(domainWord).toSatisfy((value: string) =>
-            validator.isFQDN(value, { require_tld: false })
+            isFQDN(value, { require_tld: false })
           );
         });
 
@@ -673,9 +685,9 @@ describe('internet', () => {
 
           expect(domainWord).toBeTruthy();
           expect(domainWord).toBeTypeOf('string');
-          expect(domainWord).toSatisfy(validator.isSlug);
+          expect(domainWord).toSatisfy(isSlug);
           expect(domainWord).toSatisfy((value: string) =>
-            validator.isFQDN(value, { require_tld: false })
+            isFQDN(value, { require_tld: false })
           );
         });
       });
@@ -686,7 +698,7 @@ describe('internet', () => {
 
           expect(ip).toBeTruthy();
           expect(ip).toBeTypeOf('string');
-          expect(ip).toSatisfy(validator.isIP);
+          expect(ip).toSatisfy(isIP);
         });
       });
 
@@ -696,7 +708,7 @@ describe('internet', () => {
 
           expect(ip).toBeTruthy();
           expect(ip).toBeTypeOf('string');
-          expect(ip).toSatisfy((value: string) => validator.isIP(value, 4));
+          expect(ip).toSatisfy((value: string) => isIP(value, 4));
 
           const parts = ip.split('.');
 
@@ -716,7 +728,7 @@ describe('internet', () => {
 
           expect(actual).toBeTruthy();
           expect(actual).toBeTypeOf('string');
-          expect(actual).toSatisfy((value: string) => validator.isIP(value, 4));
+          expect(actual).toSatisfy((value: string) => isIP(value, 4));
           expect(actual).toMatch(/^192\.168\.42\.\d{1,3}$/);
         });
 
@@ -727,7 +739,7 @@ describe('internet', () => {
 
           expect(actual).toBeTruthy();
           expect(actual).toBeTypeOf('string');
-          expect(actual).toSatisfy((value: string) => validator.isIP(value, 4));
+          expect(actual).toSatisfy((value: string) => isIP(value, 4));
 
           const [first, second, third, fourth] = actual.split('.').map(Number);
           expect(first).toBe(192);
@@ -791,9 +803,7 @@ describe('internet', () => {
 
             expect(actual).toBeTruthy();
             expect(actual).toBeTypeOf('string');
-            expect(actual).toSatisfy((value: string) =>
-              validator.isIP(value, 4)
-            );
+            expect(actual).toSatisfy((value: string) => isIP(value, 4));
             expect(actual).toMatch(regex);
           }
         );
@@ -805,7 +815,7 @@ describe('internet', () => {
 
           expect(ipv6).toBeTruthy();
           expect(ipv6).toBeTypeOf('string');
-          expect(ipv6).toSatisfy((value: string) => validator.isIP(value, 6));
+          expect(ipv6).toSatisfy((value: string) => isIP(value, 6));
 
           const parts = ipv6.split(':');
 
@@ -820,7 +830,7 @@ describe('internet', () => {
           expect(port).toBeTypeOf('number');
           expect(port).toBeGreaterThanOrEqual(0);
           expect(port).toBeLessThanOrEqual(65535);
-          expect(String(port)).toSatisfy(validator.isPort);
+          expect(String(port)).toSatisfy(isPort);
         });
       });
 
@@ -843,7 +853,7 @@ describe('internet', () => {
 
           expect(color).toBeTruthy();
           expect(color).toBeTypeOf('string');
-          expect(color).toSatisfy(validator.isHexColor);
+          expect(color).toSatisfy(isHexColor);
         });
 
         it('should return a random hex value with given values', () => {
@@ -855,7 +865,7 @@ describe('internet', () => {
 
           expect(color).toBeTruthy();
           expect(color).toBeTypeOf('string');
-          expect(color).toSatisfy(validator.isHexColor);
+          expect(color).toSatisfy(isHexColor);
         });
       });
 
@@ -867,7 +877,7 @@ describe('internet', () => {
           expect(mac).toBeTypeOf('string');
           expect(mac).toHaveLength(17);
           expect(mac).toMatch(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/);
-          expect(mac).toSatisfy(validator.isMACAddress);
+          expect(mac).toSatisfy(isMACAddress);
         });
 
         it('should return a random MAC address with 6 hexadecimal digits and given separator', () => {
@@ -877,7 +887,7 @@ describe('internet', () => {
           expect(mac).toBeTypeOf('string');
           expect(mac).toHaveLength(17);
           expect(mac).toMatch(/^([a-f0-9]{2}-){5}[a-f0-9]{2}$/);
-          expect(mac).toSatisfy(validator.isMACAddress);
+          expect(mac).toSatisfy(isMACAddress);
         });
 
         it('should return a random MAC address with 6 hexadecimal digits and empty separator', () => {
@@ -885,7 +895,7 @@ describe('internet', () => {
 
           expect(mac).toBeTruthy();
           expect(mac).toBeTypeOf('string');
-          expect(mac).toSatisfy(validator.isHexadecimal);
+          expect(mac).toSatisfy(isHexadecimal);
           expect(mac).toHaveLength(12);
           // It's not a valid MAC address
         });
@@ -899,7 +909,7 @@ describe('internet', () => {
             expect(mac).toBeTypeOf('string');
             expect(mac).toHaveLength(17);
             expect(mac).toMatch(/^([a-f0-9]{2}:){5}[a-f0-9]{2}$/);
-            expect(mac).toSatisfy(validator.isMACAddress);
+            expect(mac).toSatisfy(isMACAddress);
           }
         );
       });
@@ -978,7 +988,7 @@ describe('internet', () => {
           expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(32);
           expect(password).toMatch(/^a!G6/);
-          expect(password).toSatisfy(validator.isStrongPassword);
+          expect(password).toSatisfy(isStrongPassword);
         });
       });
 
@@ -998,7 +1008,7 @@ describe('internet', () => {
 
           expect(jwt).toBeTruthy();
           expect(jwt).toBeTypeOf('string');
-          expect(jwt).toSatisfy(validator.isJWT);
+          expect(jwt).toSatisfy(isJWT);
         });
 
         it('should return the header and payload values from the token', () => {
@@ -1013,7 +1023,7 @@ describe('internet', () => {
           const actual = faker.internet.jwt({ header, payload });
 
           expect(actual).toBeTypeOf('string');
-          expect(actual).toSatisfy(validator.isJWT);
+          expect(actual).toSatisfy(isJWT);
 
           const parts = actual.split('.');
 

--- a/test/modules/lorem.spec.ts
+++ b/test/modules/lorem.spec.ts
@@ -1,4 +1,4 @@
-import validator from 'validator';
+import { isSlug } from 'validator';
 import { describe, expect, it } from 'vitest';
 import { faker } from '../../src';
 import { seededTests } from '../support/seeded-runs';
@@ -154,7 +154,7 @@ describe('lorem', () => {
 
           expect(actual).toBeTruthy();
           expect(actual).toBeTypeOf('string');
-          expect(actual).toSatisfy(validator.isSlug);
+          expect(actual).toSatisfy(isSlug);
         });
 
         it.each(times(25))(
@@ -170,7 +170,7 @@ describe('lorem', () => {
             expect(words).toHaveLength(wordCount);
 
             if (wordCount > 1) {
-              expect(actual).toSatisfy(validator.isSlug);
+              expect(actual).toSatisfy(isSlug);
             }
           }
         );

--- a/test/modules/number.spec.ts
+++ b/test/modules/number.spec.ts
@@ -1,4 +1,4 @@
-import validator from 'validator';
+import { isHexadecimal, isOctal } from 'validator';
 import { describe, expect, it, vi } from 'vitest';
 import { FakerError, SimpleFaker, faker } from '../../src';
 import { seededTests } from '../support/seeded-runs';
@@ -464,7 +464,7 @@ describe('number', () => {
         const octal = faker.number.octal();
 
         expect(octal).toBeTypeOf('string');
-        expect(octal).toSatisfy(validator.isOctal);
+        expect(octal).toSatisfy(isOctal);
 
         expect(octal).toHaveLength(1);
       });
@@ -473,7 +473,7 @@ describe('number', () => {
         const octal = faker.number.octal(5);
 
         expect(octal).toBeTypeOf('string');
-        expect(octal).toSatisfy(validator.isOctal);
+        expect(octal).toSatisfy(isOctal);
 
         const octalNum = Number.parseInt(octal, 8);
         expect(octalNum).toBeLessThanOrEqual(5);
@@ -483,7 +483,7 @@ describe('number', () => {
         const octal = faker.number.octal({ min: 15, max: 255 });
 
         expect(octal).toBeTypeOf('string');
-        expect(octal).toSatisfy(validator.isOctal);
+        expect(octal).toSatisfy(isOctal);
 
         const octalNum = Number.parseInt(octal, 8);
         expect(octalNum).toBeLessThanOrEqual(255);
@@ -515,7 +515,7 @@ describe('number', () => {
         const hex = faker.number.hex();
 
         expect(hex).toBeTypeOf('string');
-        expect(hex).toSatisfy(validator.isHexadecimal);
+        expect(hex).toSatisfy(isHexadecimal);
 
         expect(hex).toHaveLength(1);
       });
@@ -524,14 +524,14 @@ describe('number', () => {
         const hex = faker.number.hex(5);
 
         expect(hex).toBeTypeOf('string');
-        expect(hex).toSatisfy(validator.isHexadecimal);
+        expect(hex).toSatisfy(isHexadecimal);
       });
 
       it('generates a random hex in a specific range', () => {
         const hex = faker.number.hex({ min: 15, max: 255 });
 
         expect(hex).toBeTypeOf('string');
-        expect(hex).toSatisfy(validator.isHexadecimal);
+        expect(hex).toSatisfy(isHexadecimal);
 
         const hexNum = Number.parseInt(hex, 16);
         expect(hexNum).toBeLessThanOrEqual(255);

--- a/test/modules/system.spec.ts
+++ b/test/modules/system.spec.ts
@@ -1,4 +1,4 @@
-import validator from 'validator';
+import { isMimeType, isSemVer } from 'validator';
 import { describe, expect, it } from 'vitest';
 import { faker } from '../../src';
 import { seededTests } from '../support/seeded-runs';
@@ -285,7 +285,7 @@ describe('system', () => {
           expect(
             mimeType,
             `generated mime types should be valid mime types.`
-          ).toSatisfy(validator.isMimeType);
+          ).toSatisfy(isMimeType);
         });
       });
 
@@ -294,7 +294,7 @@ describe('system', () => {
           expect(
             faker.system.semver(),
             `generated semver, first number should be between 0 and 9.`
-          ).toSatisfy(validator.isSemVer);
+          ).toSatisfy(isSemVer);
         });
       });
 

--- a/test/scripts/apidocs/verify-jsdoc-tags.spec.ts
+++ b/test/scripts/apidocs/verify-jsdoc-tags.spec.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import validator from 'validator';
+import { isSemVer, isURL } from 'validator';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { processComponents } from '../../../scripts/apidocs/generate';
 import { extractSummaryDefault } from '../../../scripts/apidocs/output/page';
@@ -68,7 +68,7 @@ function assertDescription(description: string): void {
 
   for (const link of links) {
     expect(link).toMatch(/^https?:\/\//);
-    expect(link).toSatisfy(validator.isURL);
+    expect(link).toSatisfy(isURL);
 
     if (link.includes('fakerjs.dev/api/')) {
       expect(allowedLinks, `${link} to point to a valid target`).toContain(
@@ -291,7 +291,7 @@ ${examples}`;
                 expect(since, '@since to be present').toBeTruthy();
                 expect(since).not.toBe('');
                 expect(since, '@since to be a valid semver').toSatisfy(
-                  validator.isSemVer
+                  isSemVer
                 );
               });
             }


### PR DESCRIPTION
Validatorjs now supports importing validator functions individually.
Since we mostly use partial imports, we should do the same for validatorJS's functions.