### PR TITLE
test(image): improve error text

### DIFF
--- a/test/integration/modules/image.spec.ts
+++ b/test/integration/modules/image.spec.ts
@@ -30,7 +30,7 @@ async function assertWorkingUrl(address: string): Promise<void> {
       https
         .get(address, ({ statusCode, headers: { location } }) => {
           if (statusCode == null) {
-            reject(new Error(`No StatusCode, expected 200`));
+            reject(new Error(`No StatusCode, expected 200 for '${address}'`));
           } else if (statusCode === 200) {
             resolve(true);
           } else if (statusCode >= 300 && statusCode < 400 && location) {
@@ -47,7 +47,7 @@ async function assertWorkingUrl(address: string): Promise<void> {
           } else {
             reject(
               new Error(
-                `Bad StatusCode ${statusCode} expected 200 for '${location}'`
+                `Bad StatusCode ${statusCode} expected 200 for '${address}'`
               )
             );
           }


### PR DESCRIPTION
Fixes/improves the error messages in the image integration test.

> promise rejected "Error: Bad StatusCode 504 expected 200 for 'undefined'" instead of resolving

`location` contains the redirect target, so it isn't set for errors.
I also adjusted the no statusCode case to include the address similar to all the other cases.