### PR TITLE
fix(locale): add Isadora to female names in pt_BR for consistency

### DIFF
--- a/src/locales/pt_BR/person/first_name.ts
+++ b/src/locales/pt_BR/person/first_name.ts
@@ -201,6 +201,7 @@ export default {
     'Isabela',
     'Isabella',
     'Isabelly',
+    'Isadora',
     'Isis',
     'Janaína',
     'Joana',


### PR DESCRIPTION
Preparation for #3269

Isadora is the only entry in pt_BR first_name which is only in generic, not in male or female. 

This will cause issues when #3266 is merged

Hence, add Isadora to the female list too
