### PR TITLE
chore: align coding style of deprecated.ts

### DIFF
--- a/src/internal/deprecated.ts
+++ b/src/internal/deprecated.ts
@@ -28,19 +28,20 @@ export interface DeprecatedOptions {
 /**
  * @internal
  */
-export function deprecated(opts: DeprecatedOptions): void {
-  let message = `[@faker-js/faker]: ${opts.deprecated} is deprecated`;
+export function deprecated(options: DeprecatedOptions): void {
+  const { deprecated, since, until, proposed } = options;
+  let message = `[@faker-js/faker]: ${deprecated} is deprecated`;
 
-  if (opts.since) {
-    message += ` since v${opts.since}`;
+  if (since) {
+    message += ` since v${since}`;
   }
 
-  if (opts.until) {
-    message += ` and will be removed in v${opts.until}`;
+  if (until) {
+    message += ` and will be removed in v${until}`;
   }
 
-  if (opts.proposed) {
-    message += `. Please use ${opts.proposed} instead`;
+  if (proposed) {
+    message += `. Please use ${proposed} instead`;
   }
 
   // eslint-disable-next-line no-undef -- Using console here is intentional and required


### PR DESCRIPTION
Preparation for #2439

- #2439

Related:

- #3312
- #3313
- #3314
- #3315
- #3316
- #3317
- #3318
- #3319

---

Most of our methods deconstruct `options` before using them.

This PR changes the `deprecated.ts` to follow the same style.

---

This change is split from the no abbreviation lint PR, to reduce diff and I consider this slightly more valid than most of the other changes required for that.