### PR TITLE
chore: align variable naming style of internet user agent

### DIFF
--- a/src/modules/internet/user-agent.ts
+++ b/src/modules/internet/user-agent.ts
@@ -180,14 +180,14 @@ export function generate(faker: Faker): string {
     );
 
   const randomRevision = (dots: number): string => {
-    let return_val = '';
+    let result = '';
     //generate a random revision
     //dots = 2 returns .x.y where x & y are between 0 and 9
     for (let x = 0; x < dots; x++) {
-      return_val += `.${faker.string.numeric({ allowLeadingZeros: true })}`;
+      result += `.${faker.string.numeric({ allowLeadingZeros: true })}`;
     }
 
-    return return_val;
+    return result;
   };
 
   const version_string = {
@@ -245,29 +245,29 @@ export function generate(faker: Faker): string {
   const browserMap = {
     firefox(arch: OS): string {
       //https://developer.mozilla.org/en-US/docs/Gecko_user_agent_string_reference
-      const firefox_ver = `${faker.number.int({
+      const firefoxVersion = `${faker.number.int({
           min: 5,
           max: 15,
         })}${randomRevision(2)}`,
-        gecko_ver = `Gecko/20100101 Firefox/${firefox_ver}`,
+        geckoVersion = `Gecko/20100101 Firefox/${firefoxVersion}`,
         proc = randomProc(arch),
-        os_ver =
+        osVersion =
           arch === 'win'
             ? `(Windows NT ${version_string.nt()}${proc ? `; ${proc}` : ''}`
             : arch === 'mac'
               ? `(Macintosh; ${proc} Mac OS X ${version_string.osx()}`
               : `(X11; Linux ${proc}`;
 
-      return `Mozilla/5.0 ${os_ver}; rv:${firefox_ver.slice(
+      return `Mozilla/5.0 ${osVersion}; rv:${firefoxVersion.slice(
         0,
         -2
-      )}) ${gecko_ver}`;
+      )}) ${geckoVersion}`;
     },
 
     iexplorer(): string {
-      const ver = version_string.ie();
+      const version = version_string.ie();
 
-      if (ver >= 11) {
+      if (version >= 11) {
         //http://msdn.microsoft.com/en-us/library/ie/hh869301(v=vs.85).aspx
         return `Mozilla/5.0 (Windows NT 6.${faker.number.int({
           min: 1,
@@ -278,36 +278,36 @@ export function generate(faker: Faker): string {
       }
 
       //http://msdn.microsoft.com/en-us/library/ie/ms537503(v=vs.85).aspx
-      return `Mozilla/5.0 (compatible; MSIE ${ver}.0; Windows NT ${version_string.nt()}; Trident/${version_string.trident()}${
+      return `Mozilla/5.0 (compatible; MSIE ${version}.0; Windows NT ${version_string.nt()}; Trident/${version_string.trident()}${
         faker.datatype.boolean() ? `; .NET CLR ${version_string.net()}` : ''
       })`;
     },
 
     opera(arch: OS): string {
       //http://www.opera.com/docs/history/
-      const presto_ver = ` Presto/${version_string.presto()} Version/${version_string.presto2()})`,
-        os_ver =
+      const prestoVersion = ` Presto/${version_string.presto()} Version/${version_string.presto2()})`,
+        osVersion =
           arch === 'win'
-            ? `(Windows NT ${version_string.nt()}; U; ${randomLang()}${presto_ver}`
+            ? `(Windows NT ${version_string.nt()}; U; ${randomLang()}${prestoVersion}`
             : arch === 'lin'
               ? `(X11; Linux ${randomProc(
                   arch
-                )}; U; ${randomLang()}${presto_ver}`
+                )}; U; ${randomLang()}${prestoVersion}`
               : `(Macintosh; Intel Mac OS X ${version_string.osx()} U; ${randomLang()} Presto/${version_string.presto()} Version/${version_string.presto2()})`;
 
       return `Opera/${faker.number.int({
         min: 9,
         max: 14,
-      })}.${faker.number.int(99)} ${os_ver}`;
+      })}.${faker.number.int(99)} ${osVersion}`;
     },
 
     safari(arch: OS): string {
       const safari = version_string.safari(),
-        ver = `${faker.number.int({
+        version = `${faker.number.int({
           min: 4,
           max: 7,
         })}.${faker.number.int(1)}.${faker.number.int(10)}`,
-        os_ver =
+        osVersion =
           arch === 'mac'
             ? `(Macintosh; ${randomProc('mac')} Mac OS X ${version_string.osx(
                 '_'
@@ -317,12 +317,12 @@ export function generate(faker: Faker): string {
               })}.0; ${randomLang()}) `
             : `(Windows; U; Windows NT ${version_string.nt()})`;
 
-      return `Mozilla/5.0 ${os_ver}AppleWebKit/${safari} (KHTML, like Gecko) Version/${ver} Safari/${safari}`;
+      return `Mozilla/5.0 ${osVersion}AppleWebKit/${safari} (KHTML, like Gecko) Version/${version} Safari/${safari}`;
     },
 
     chrome(arch: OS): string {
       const safari = version_string.safari(),
-        os_ver =
+        osVersion =
           arch === 'mac'
             ? `(Macintosh; ${randomProc('mac')} Mac OS X ${version_string.osx(
                 '_'
@@ -331,7 +331,7 @@ export function generate(faker: Faker): string {
               ? `(Windows; U; Windows NT ${version_string.nt()})`
               : `(X11; Linux ${randomProc(arch)}`;
 
-      return `Mozilla/5.0 ${os_ver} AppleWebKit/${safari} (KHTML, like Gecko) Chrome/${version_string.chrome()} Safari/${safari}`;
+      return `Mozilla/5.0 ${osVersion} AppleWebKit/${safari} (KHTML, like Gecko) Chrome/${version_string.chrome()} Safari/${safari}`;
     },
   };
 


### PR DESCRIPTION
Preparation for #2439

- #2439

Related:

- #3312
- #3313
- #3314
- #3315
- #3316
- #3317
- #3318
- #3319

---

Most of our code uses camelCase variables instead of snake_case.

This PR changes the `internet/user-agent.ts` to follow the same style.

---

This change is split from the no abbreviation lint PR, to reduce diff and I consider this slightly more valid than most of the other changes required for that.