### PR TITLE
chore: improve variable naming of system module

### DIFF
--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -77,21 +77,21 @@ export class SystemModule extends ModuleBase {
       .toLowerCase()
       .replaceAll(/\W/g, '_');
 
-    const extensionsStr = this.faker.helpers
+    const extensionsSuffix = this.faker.helpers
       .multiple(() => this.fileExt(), { count: extensionCount })
       .join('.');
 
-    if (extensionsStr.length === 0) {
+    if (extensionsSuffix.length === 0) {
       return baseName;
     }
 
-    return `${baseName}.${extensionsStr}`;
+    return `${baseName}.${extensionsSuffix}`;
   }
 
   /**
    * Returns a random file name with a given extension or a commonly used extension.
    *
-   * @param ext Extension. Empty string is considered to be not set.
+   * @param extension The file extension to use. Empty string is considered to be not set.
    *
    * @example
    * faker.system.commonFileName() // 'dollar.jpg'
@@ -99,10 +99,10 @@ export class SystemModule extends ModuleBase {
    *
    * @since 3.1.0
    */
-  commonFileName(ext?: string): string {
-    const str = this.fileName({ extensionCount: 0 });
+  commonFileName(extension?: string): string {
+    const fileName = this.fileName({ extensionCount: 0 });
 
-    return `${str}.${ext || this.commonFileExt()}`;
+    return `${fileName}.${extension || this.commonFileExt()}`;
   }
 
   /**

--- a/test/modules/system.spec.ts
+++ b/test/modules/system.spec.ts
@@ -66,8 +66,8 @@ describe('system', () => {
     () => {
       describe('commonFileExt()', () => {
         it('should return common file types', () => {
-          const fileExt = faker.system.commonFileExt();
-          const extList = [
+          const actual = faker.system.commonFileExt();
+          const extensions = [
             'gif',
             'htm',
             'html',
@@ -96,11 +96,11 @@ describe('system', () => {
           ];
 
           expect(
-            extList,
-            `generated common file ext should be one of [${extList.join(
+            extensions,
+            `generated common file ext should be one of [${extensions.join(
               ', '
-            )}]. Got "${fileExt}".`
-          ).include(fileExt);
+            )}]. Got "${actual}".`
+          ).include(actual);
         });
       });
 
@@ -164,15 +164,15 @@ describe('system', () => {
 
       describe('fileExt()', () => {
         it('should return file ext', () => {
-          const fileExt = faker.system.fileExt();
+          const actual = faker.system.fileExt();
 
-          expect(fileExt).toBeTypeOf('string');
-          expect(fileExt).not.toBe('');
+          expect(actual).toBeTypeOf('string');
+          expect(actual).not.toBe('');
         });
 
         it('should return file ext based on mimeType', () => {
-          const fileExt = faker.system.fileExt('text/plain');
-          const extList = [
+          const actual = faker.system.fileExt('text/plain');
+          const extensions = [
             'txt',
             'text',
             'conf',
@@ -184,11 +184,11 @@ describe('system', () => {
           ];
 
           expect(
-            extList,
-            `generated common file ext should be one of [${extList.join(
+            extensions,
+            `generated common file ext should be one of [${extensions.join(
               ','
-            )}]. Got "${fileExt}".`
-          ).include(fileExt);
+            )}]. Got "${actual}".`
+          ).include(actual);
         });
       });
 


### PR DESCRIPTION
Preparation for #2439

- #2439

Related:

- #3312
- #3313
- #3314
- #3315
- #3316
- #3317
- #3318
- #3319

---

Improves the variable naming in the `system` module.
Feel free to suggest better names.

---

This change is split from the no abbreviation lint PR, to reduce diff and I consider this slightly more valid than most of the other changes required for that.