### PR TITLE
chore: improve parameter naming of keys.ts

### DIFF
--- a/src/internal/keys.ts
+++ b/src/internal/keys.ts
@@ -6,8 +6,8 @@
  *
  * @internal
  *
- * @param obj The object to get the keys of.
+ * @param object The object to get the keys of.
  */
-export function keys<T extends object>(obj: T): Array<keyof T> {
-  return Object.keys(obj) as Array<keyof T>;
+export function keys<T extends object>(object: T): Array<keyof T> {
+  return Object.keys(object) as Array<keyof T>;
 }


### PR DESCRIPTION
Preparation for #2439

- #2439

Related:

- #3312
- #3313
- #3314
- #3315
- #3316
- #3317
- #3318
- #3319

---

Improves the variable naming in the `internet` module.

---

This change is split from the no abbreviation lint PR, to reduce diff and I consider this slightly more valid than most of the other changes required for that.