### PR TITLE
docs(helpers): add missing example results to uniqueArray

### DIFF
--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -664,9 +664,9 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param length The number of elements to generate.
    *
    * @example
-   * faker.helpers.uniqueArray(faker.word.sample, 50)
-   * faker.helpers.uniqueArray(faker.definitions.person.first_name, 6)
-   * faker.helpers.uniqueArray(["Hello", "World", "Goodbye"], 2)
+   * faker.helpers.uniqueArray(faker.word.sample, 3) // ['mob', 'junior', 'ripe']
+   * faker.helpers.uniqueArray(faker.definitions.person.first_name.generic, 6) // ['Silas', 'Montana', 'Lorenzo', 'Alayna', 'Aditya', 'Antone']
+   * faker.helpers.uniqueArray(["Hello", "World", "Goodbye"], 2) // ['World', 'Goodbye']
    *
    * @since 6.0.0
    */


### PR DESCRIPTION
Fixes #3291

- #3291

---

This PR adds the missing example results to `faker.helpers.uniqueArray`.