### PR TITLE
docs: fix examples which return string/number

### DIFF
--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -445,7 +445,7 @@ export class ColorModule extends ModuleBase {
    *
    * @example
    * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
-   * faker.color.cmyk({ format: 'css' }) // cmyk(100%, 0%, 0%, 0%)
+   * faker.color.cmyk({ format: 'css' }) // 'cmyk(35%, 39%, 68%, 60%)'
    * faker.color.cmyk({ format: 'binary' }) // (8-32 bits) x 4
    *
    * @since 7.0.0
@@ -487,7 +487,7 @@ export class ColorModule extends ModuleBase {
    * @example
    * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
    * faker.color.cmyk({ format: 'decimal' }) // [0.31, 0.52, 0.32, 0.43]
-   * faker.color.cmyk({ format: 'css' }) // cmyk(100%, 0%, 0%, 0%)
+   * faker.color.cmyk({ format: 'css' }) // 'cmyk(35%, 39%, 68%, 60%)'
    * faker.color.cmyk({ format: 'binary' }) // (8-32 bits) x 4
    *
    * @since 7.0.0
@@ -639,7 +639,7 @@ export class ColorModule extends ModuleBase {
    *
    * @example
    * faker.color.hwb() // [201, 0.21, 0.31]
-   * faker.color.hwb({ format: 'css' }) // hwb(194 0% 0%)
+   * faker.color.hwb({ format: 'css' }) // 'hwb(354 72% 41%)'
    * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
    *
    * @since 7.0.0
@@ -681,7 +681,7 @@ export class ColorModule extends ModuleBase {
    * @example
    * faker.color.hwb() // [201, 0.21, 0.31]
    * faker.color.hwb({ format: 'decimal' }) // [201, 0.21, 0.31]
-   * faker.color.hwb({ format: 'css' }) // hwb(194 0% 0%)
+   * faker.color.hwb({ format: 'css' }) // 'hwb(354 72% 41%)'
    * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
    *
    * @since 7.0.0
@@ -703,7 +703,7 @@ export class ColorModule extends ModuleBase {
    * @example
    * faker.color.hwb() // [201, 0.21, 0.31]
    * faker.color.hwb({ format: 'decimal' }) // [201, 0.21, 0.31]
-   * faker.color.hwb({ format: 'css' }) // hwb(194 0% 0%)
+   * faker.color.hwb({ format: 'css' }) // 'hwb(354 72% 41%)'
    * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
    *
    * @since 7.0.0
@@ -744,7 +744,7 @@ export class ColorModule extends ModuleBase {
    *
    * @example
    * faker.color.lab() // [0.832133, -80.3245, 100.1234]
-   * faker.color.lab({ format: 'css' }) // lab(29.2345% 39.3825 20.0664)
+   * faker.color.lab({ format: 'css' }) // 'lab(29.2345% 39.3825 20.0664)'
    * faker.color.lab({ format: 'binary' }) // (8-32 bits x 3)
    *
    * @since 7.0.0
@@ -786,7 +786,7 @@ export class ColorModule extends ModuleBase {
    * @example
    * faker.color.lab() // [0.832133, -80.3245, 100.1234]
    * faker.color.lab({ format: 'decimal' }) // [0.856773, -80.2345, 100.2341]
-   * faker.color.lab({ format: 'css' }) // lab(29.2345% 39.3825 20.0664)
+   * faker.color.lab({ format: 'css' }) // 'lab(29.2345% 39.3825 20.0664)'
    * faker.color.lab({ format: 'binary' }) // (8-32 bits x 3)
    *
    * @since 7.0.0
@@ -834,7 +834,7 @@ export class ColorModule extends ModuleBase {
    *
    * @example
    * faker.color.lch() // [0.522345, 72.2, 56.2]
-   * faker.color.lch({ format: 'css' }) // lch(52.2345% 72.2 56.2)
+   * faker.color.lch({ format: 'css' }) // 'lch(52.2345% 72.2 56.2)'
    * faker.color.lch({ format: 'binary' }) // (8-32 bits x 3)
    *
    * @since 7.0.0
@@ -882,7 +882,7 @@ export class ColorModule extends ModuleBase {
    * @example
    * faker.color.lch() // [0.522345, 72.2, 56.2]
    * faker.color.lch({ format: 'decimal' }) // [0.522345, 72.2, 56.2]
-   * faker.color.lch({ format: 'css' }) // lch(52.2345% 72.2 56.2)
+   * faker.color.lch({ format: 'css' }) // 'lch(52.2345% 72.2 56.2)'
    * faker.color.lch({ format: 'binary' }) // (8-32 bits x 3)
    *
    * @since 7.0.0

--- a/src/modules/commerce/index.ts
+++ b/src/modules/commerce/index.ts
@@ -129,11 +129,11 @@ export class CommerceModule extends ModuleBase {
    * @param options.symbol The currency value to use. Defaults to `''`.
    *
    * @example
-   * faker.commerce.price() // 828.07
-   * faker.commerce.price({ min: 100 }) // 904.19
-   * faker.commerce.price({ min: 100, max: 200 }) // 154.55
-   * faker.commerce.price({ min: 100, max: 200, dec: 0 }) // 133
-   * faker.commerce.price({ min: 100, max: 200, dec: 0, symbol: '$' }) // $114
+   * faker.commerce.price() // '828.07'
+   * faker.commerce.price({ min: 100 }) // '904.19'
+   * faker.commerce.price({ min: 100, max: 200 }) // '154.55'
+   * faker.commerce.price({ min: 100, max: 200, dec: 0 }) // '133'
+   * faker.commerce.price({ min: 100, max: 200, dec: 0, symbol: '$' }) // '$114'
    *
    * @since 3.0.0
    */

--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -192,12 +192,12 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @example
    * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z' })
    * // [
-   * //   2022-07-02T06:00:00.000Z,
-   * //   2024-12-31T12:00:00.000Z,
-   * //   2027-07-02T18:00:00.000Z
+   * //   '2022-07-02T06:00:00.000Z',
+   * //   '2024-12-31T12:00:00.000Z',
+   * //   '2027-07-02T18:00:00.000Z'
    * // ]
    * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z', count: 2 })
-   * // [ 2023-05-02T16:00:00.000Z, 2026-09-01T08:00:00.000Z ]
+   * // [ '2023-05-02T16:00:00.000Z', '2026-09-01T08:00:00.000Z' ]
    * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z', count: { min: 2, max: 5 }})
    * // [
    * //   2021-12-19T06:35:40.191Z,
@@ -347,7 +347,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `faker.defaultRefDate()`.
    *
    * @example
-   * faker.date.birthdate() // 1977-07-10T01:37:30.719Z
+   * faker.date.birthdate() // '1977-07-10T01:37:30.719Z'
    *
    * @since 7.0.0
    */
@@ -369,7 +369,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `faker.defaultRefDate()`.
    *
    * @example
-   * faker.date.birthdate({ mode: 'age', min: 18, max: 65 }) // 2003-11-02T20:03:20.116Z
+   * faker.date.birthdate({ mode: 'age', min: 18, max: 65 }) // '2003-11-02T20:03:20.116Z'
    *
    * @since 7.0.0
    */
@@ -403,7 +403,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @param options.max The maximum year to generate a birthdate in.
    *
    * @example
-   * faker.date.birthdate({ mode: 'year', min: 1900, max: 2000 }) // 1940-08-20T08:53:07.538Z
+   * faker.date.birthdate({ mode: 'year', min: 1900, max: 2000 }) // '1940-08-20T08:53:07.538Z'
    *
    * @since 7.0.0
    */
@@ -435,9 +435,9 @@ export class SimpleDateModule extends SimpleModuleBase {
    * Defaults to `faker.defaultRefDate()`.
    *
    * @example
-   * faker.date.birthdate() // 1977-07-10T01:37:30.719Z
-   * faker.date.birthdate({ mode: 'age', min: 18, max: 65 }) // 2003-11-02T20:03:20.116Z
-   * faker.date.birthdate({ mode: 'year', min: 1900, max: 2000 }) // 1940-08-20T08:53:07.538Z
+   * faker.date.birthdate() // '1977-07-10T01:37:30.719Z'
+   * faker.date.birthdate({ mode: 'age', min: 18, max: 65 }) // '2003-11-02T20:03:20.116Z'
+   * faker.date.birthdate({ mode: 'year', min: 1900, max: 2000 }) // '1940-08-20T08:53:07.538Z'
    *
    * @since 7.0.0
    */

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -65,8 +65,8 @@ export class FinanceModule extends ModuleBase {
    * @param length The length of the account number. Defaults to `8`.
    *
    * @example
-   * faker.finance.accountNumber() // 92842238
-   * faker.finance.accountNumber(5) // 32564
+   * faker.finance.accountNumber() // '92842238'
+   * faker.finance.accountNumber(5) // '32564'
    *
    * @since 8.0.0
    */
@@ -78,8 +78,8 @@ export class FinanceModule extends ModuleBase {
    * @param options.length The length of the account number. Defaults to `8`.
    *
    * @example
-   * faker.finance.accountNumber() // 92842238
-   * faker.finance.accountNumber({ length: 5 }) // 32564
+   * faker.finance.accountNumber() // '92842238'
+   * faker.finance.accountNumber({ length: 5 }) // '32564'
    *
    * @since 8.0.0
    */
@@ -98,9 +98,9 @@ export class FinanceModule extends ModuleBase {
    * @param optionsOrLength.length The length of the account number. Defaults to `8`.
    *
    * @example
-   * faker.finance.accountNumber() // 92842238
-   * faker.finance.accountNumber(5) // 28736
-   * faker.finance.accountNumber({ length: 5 }) // 32564
+   * faker.finance.accountNumber() // '92842238'
+   * faker.finance.accountNumber(5) // '28736'
+   * faker.finance.accountNumber({ length: 5 }) // '32564'
    *
    * @since 8.0.0
    */
@@ -123,9 +123,9 @@ export class FinanceModule extends ModuleBase {
    * @param options.length The length of the account number. Defaults to `8`.
    *
    * @example
-   * faker.finance.accountNumber() // 92842238
-   * faker.finance.accountNumber(5) // 28736
-   * faker.finance.accountNumber({ length: 5 }) // 32564
+   * faker.finance.accountNumber() // '92842238'
+   * faker.finance.accountNumber(5) // '28736'
+   * faker.finance.accountNumber({ length: 5 }) // '32564'
    *
    * @since 8.0.0
    */

--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -498,7 +498,6 @@ export class InternetModule extends ModuleBase {
    *
    * @example
    * faker.internet.protocol() // 'http'
-   * faker.internet.protocol() // 'https'
    *
    * @since 2.1.5
    */
@@ -784,7 +783,7 @@ export class InternetModule extends ModuleBase {
    * Generates a random port number.
    *
    * @example
-   * faker.internet.port() // '9414'
+   * faker.internet.port() // 9414
    *
    * @since 5.4.0
    */


### PR DESCRIPTION
Partial manual fix for #3335 for clarifying the return type of examples
- unquoted strings
- incorrectly quoted numbers
- doubled up examples


