### PR TITLE
fix(system): semver parts should not be limited to 0-9

### DIFF
--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -213,15 +213,15 @@ export class SystemModule extends ModuleBase {
    * Returns a [semantic version](https://semver.org).
    *
    * @example
-   * faker.system.semver() // '1.1.2'
+   * faker.system.semver() // '1.15.2'
    *
    * @since 3.1.0
    */
   semver(): string {
     return [
       this.faker.number.int(9),
-      this.faker.number.int(9),
-      this.faker.number.int(9),
+      this.faker.number.int(20),
+      this.faker.number.int(20),
     ].join('.');
   }
 

--- a/test/modules/__snapshots__/internet.spec.ts.snap
+++ b/test/modules/__snapshots__/internet.spec.ts.snap
@@ -254,7 +254,7 @@ exports[`internet > 1211 > url > with slash appended 1`] = `"https://velvety-tar
 
 exports[`internet > 1211 > url > without slash appended and with http protocol 1`] = `"http://velvety-tarragon.biz"`;
 
-exports[`internet > 1211 > userAgent 1`] = `"Mozilla/5.0 (Linux; Android 13; SM-G998B) AppleWebKit/605.67 (KHTML, like Gecko) Chrome/107.7.3.6 Mobile Safari/592.76"`;
+exports[`internet > 1211 > userAgent 1`] = `"Mozilla/5.0 (Linux; Android 13; SM-G998B) AppleWebKit/605.67 (KHTML, like Gecko) Chrome/107.7.7.14 Mobile Safari/592.76"`;
 
 exports[`internet > 1211 > userName > noArgs 1`] = `"Tito67"`;
 

--- a/test/modules/__snapshots__/system.spec.ts.snap
+++ b/test/modules/__snapshots__/system.spec.ts.snap
@@ -78,7 +78,7 @@ exports[`system > 42 > networkInterface > with {"interfaceType":"ww"} 1`] = `"ww
 
 exports[`system > 42 > networkInterface > with {} 1`] = `"wlp5s1f0"`;
 
-exports[`system > 42 > semver 1`] = `"3.9.7"`;
+exports[`system > 42 > semver 1`] = `"3.19.15"`;
 
 exports[`system > 1211 > commonFileExt 1`] = `"shtml"`;
 
@@ -158,7 +158,7 @@ exports[`system > 1211 > networkInterface > with {"interfaceType":"ww"} 1`] = `"
 
 exports[`system > 1211 > networkInterface > with {} 1`] = `"P9wwp6s6d6"`;
 
-exports[`system > 1211 > semver 1`] = `"9.8.2"`;
+exports[`system > 1211 > semver 1`] = `"9.18.4"`;
 
 exports[`system > 1337 > commonFileExt 1`] = `"wav"`;
 
@@ -238,4 +238,4 @@ exports[`system > 1337 > networkInterface > with {"interfaceType":"ww"} 1`] = `"
 
 exports[`system > 1337 > networkInterface > with {} 1`] = `"eno2"`;
 
-exports[`system > 1337 > semver 1`] = `"2.1.2"`;
+exports[`system > 1337 > semver 1`] = `"2.3.5"`;


### PR DESCRIPTION
Semver components shouldnt be limited to one digit

Assuming all semvers are in the form x.y.z with single digits is likely to cause bugs with sorting etc

This PR allows y and z to go up to 20 for more variety, while keeping the numbers realistic
