### PR TITLE
chore: update LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,45 +1,6 @@
-Faker - Copyright (c) 2022-2024
+MIT License
 
-This software consists of voluntary contributions made by many individuals.
-For exact contribution history, see the revision history
-available at https://github.com/faker-js/faker
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-===
-
-From: https://github.com/faker-js/faker/commit/a9f98046c7d5eeaabe12fc587024c06d683800b8
-To: https://github.com/faker-js/faker/commit/29234378807c4141588861f69421bf20b5ac635e
-
-Based on faker.js, copyright Marak Squires and contributor, what follows below is the original license.
-
-===
-
-faker.js - Copyright (c) 2020
-Marak Squires
-http://github.com/marak/faker.js/
-
-faker.js was inspired by and has used data definitions from:
-
- * https://github.com/stympy/faker/ - Copyright (c) 2007-2010 Benjamin Curtis
- * http://search.cpan.org/~jasonk/Data-Faker-0.07/ - Copyright 2004-2005 by Jason Kohles
+Copyright 2022-2025 FakerJS Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
This PR updates the year in the license file and removes the repeated LICENSE text.

<details>
<summary>This also fixes the GitHub License detection:</summary>

Before:

![grafik](https://github.com/user-attachments/assets/a2009a73-1705-43c9-8af7-752e4c615a57)

After (Screenshot is from a fork, so it looks slightly different):

![grafik](https://github.com/user-attachments/assets/d81a7111-fd74-4ffb-a11b-1c0c1a5c9244)


</details>