### PR TITLE
infra(docs): add script to regenerate jsdoc examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ versions.json
 !/docs/api/index.md
 /docs/api/api-search-index.json
 /docs/public/api-diff-index.json
+/script/temp/
 
 # Faker
 TAGS

--- a/docs/.vitepress/components/api-docs/format.ts
+++ b/docs/.vitepress/components/api-docs/format.ts
@@ -5,10 +5,13 @@ export function formatResult(result: unknown): string {
       ? `${result}n`
       : JSON.stringify(result, undefined, 2)
           .replaceAll('\\r', '')
-          .replaceAll('<', '&lt;')
           .replaceAll(
             /(^ *|: )"([^'\n]*?)"(?=,?$|: )/gm,
             (_, p1, p2) => `${p1}'${p2.replace(/\\"/g, '"')}'`
           )
           .replaceAll(/\n */g, ' ');
+}
+
+export function formatResultForHtml(result: unknown): string {
+  return formatResult(result).replaceAll('<', '&lt;');
 }

--- a/docs/.vitepress/components/api-docs/format.ts
+++ b/docs/.vitepress/components/api-docs/format.ts
@@ -1,3 +1,5 @@
+const nbsp = '\u00A0';
+
 export function formatResult(result: unknown): string {
   return result === undefined
     ? 'undefined'
@@ -5,6 +7,7 @@ export function formatResult(result: unknown): string {
       ? `${result}n`
       : JSON.stringify(result, undefined, 2)
           .replaceAll('\\r', '')
+          .replaceAll(nbsp, ' ')
           .replaceAll(
             /(^ *|: )"([^'\n]*?)"(?=,?$|: )/gm,
             (_, p1, p2) => `${p1}'${p2.replace(/\\"/g, '"')}'`

--- a/docs/.vitepress/components/api-docs/method.vue
+++ b/docs/.vitepress/components/api-docs/method.vue
@@ -2,7 +2,7 @@
 import { computed, ref, useTemplateRef } from 'vue';
 import { sourceBaseUrl } from '../../../api/source-base-url';
 import { slugify } from '../../shared/utils/slugify';
-import { formatResult } from './format';
+import { formatResultForHtml } from './format';
 import type { ApiDocsMethod } from './method';
 import MethodParameters from './method-parameters.vue';
 import RefreshButton from './refresh-button.vue';
@@ -102,7 +102,7 @@ async function onRefresh(): Promise<void> {
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       const domLine = codeLines.value[i];
-      const prettyResult = formatResult(result);
+      const prettyResult = formatResultForHtml(result);
       const resultLines = prettyResult.split('\\n');
 
       if (resultLines.length === 1) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "run-s build:clean build:code",
     "generate": "run-s generate:locales generate:api-docs",
     "generate:api-docs": "tsx ./scripts/apidocs.ts",
+    "generate:examples": "tsx ./scripts/examples.ts",
     "generate:locales": "tsx ./scripts/generate-locales.ts",
     "docs:build": "run-s generate:api-docs docs:build:run",
     "docs:build:run": "vitepress build docs",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "run-s build:clean build:code",
     "generate": "run-s generate:locales generate:api-docs",
     "generate:api-docs": "tsx ./scripts/apidocs.ts",
-    "generate:examples": "tsx ./scripts/examples.ts",
+    "generate:examples": "tsx ./scripts/examples.ts && pnpm run format",
     "generate:locales": "tsx ./scripts/generate-locales.ts",
     "docs:build": "run-s generate:api-docs docs:build:run",
     "docs:build:run": "vitepress build docs",

--- a/scripts/apidocs/examples.ts
+++ b/scripts/apidocs/examples.ts
@@ -1,0 +1,159 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import type { ClassDeclaration, MethodDeclaration } from 'ts-morph';
+import { formatResult } from '../../docs/.vitepress/components/api-docs/format';
+import * as globalFaker from '../../src';
+import { groupBy } from '../../src/internal/group-by';
+import { prepareExampleCapturing } from './output/page';
+import { findModuleClasses, findProjectClasses } from './processing/class';
+import { getExamples, getJsDocs, getTagsFromJSDoc } from './processing/jsdocs';
+import { isApiMethod } from './processing/method';
+import type { SignatureLikeDeclaration } from './processing/signature';
+import { getProject } from './project';
+import { FILE_PATH_PROJECT } from './utils/paths';
+
+const tempDir = resolve(FILE_PATH_PROJECT, 'script/temp');
+let i = 0;
+
+Object.assign(globalThis, globalFaker);
+
+export async function refreshExamples(): Promise<void> {
+  console.log('Reading project');
+  const project = getProject();
+  const classes = [
+    ...findProjectClasses(project),
+    ...findModuleClasses(project),
+  ];
+  const classesByFile = groupBy(classes, (clazz) =>
+    clazz.getSourceFile().getFilePath()
+  );
+
+  await mkdir(tempDir, { recursive: true });
+
+  console.log('Processing...');
+  for (const classes of Object.values(classesByFile)) {
+    for (const clazz of classes) {
+      console.log(`- ${clazz.getName()}`);
+      await processClass(clazz);
+    }
+
+    await classes[0].getSourceFile().save();
+  }
+
+  await rm(tempDir, { recursive: true });
+
+  console.log('Completed');
+  console.log('Remember to check the changes before committing');
+}
+
+async function processClass(clazz: ClassDeclaration) {
+  const methods = clazz.getMethods().filter(isApiMethod);
+  for (const method of methods) {
+    await processMethod(method);
+  }
+
+  const baseClass = clazz.getBaseClass();
+  if (baseClass != null) {
+    await processClass(baseClass);
+  }
+}
+
+async function processMethod(method: MethodDeclaration) {
+  console.log(`  - ${method.getName()}`);
+  const overloads = method.getOverloads();
+  const signatures: SignatureLikeDeclaration[] =
+    overloads.length > 0 ? overloads : [method];
+  for (const [index, signature] of Object.entries(signatures)) {
+    await processSignature(index, signature);
+  }
+}
+
+async function processSignature(
+  index: string,
+  signature: SignatureLikeDeclaration
+) {
+  const jsdocs = getJsDocs(signature);
+  const exampleTags = getTagsFromJSDoc(jsdocs, 'example');
+  const exampleTag = exampleTags[0];
+  if (exampleTags.length === 0) {
+    console.log('No examples found');
+    return;
+  } else if (exampleTags.length > 1) {
+    console.error('Multiple examples found');
+    return;
+  }
+
+  const exampleCode = getExamples(jsdocs).join('\n');
+  const exampleLines = exampleCode.split('\n');
+
+  const captureCode = prepareExampleCapturing({
+    main: exampleCode,
+    async: false,
+    init: [
+      'faker.seed(0);',
+      'faker.setDefaultRefDate(new Date(2025, 0, 1));',
+      ...(exampleCode.match(/^(faker[A-Z]\w+)\./gm) ?? []).map(
+        (match) => `${match}seed(0);`
+      ),
+    ],
+  });
+
+  const tempFilePath = resolve(tempDir, `example-${i++}.ts`);
+  await writeFile(tempFilePath, `export const fn = ${captureCode}`);
+
+  const { fn } = (await import(`file://${tempFilePath}`)) as {
+    fn: () => unknown[];
+  };
+  const result = fn();
+  let lineIndex = 0;
+  let resultIndex = 0;
+  while (lineIndex < exampleLines.length && resultIndex < result.length) {
+    // Skip empty and preparatory lines (no '^faker.' invocation)
+    if (!/^\w*faker\w*\./i.test(exampleLines[lineIndex])) {
+      lineIndex++;
+      continue;
+    }
+
+    // Skip to end of the invocation (if multiline)
+    while (
+      lineIndex < exampleLines.length &&
+      !/^([^ ].*)?\)(\.\w+)?;? ?(\/\/|$)/.test(exampleLines[lineIndex])
+    ) {
+      lineIndex++;
+    }
+
+    if (lineIndex >= exampleLines.length) {
+      break;
+    }
+
+    // Purge old results
+    if (exampleLines[lineIndex].includes('//')) {
+      // Inline comments
+      exampleLines[lineIndex] = exampleLines[lineIndex].replace(/ ?\/\/.*/, '');
+    } else {
+      // Multiline comments
+      while (exampleLines[lineIndex + 1]?.trimStart().startsWith('//')) {
+        exampleLines.splice(lineIndex + 1, 1);
+      }
+    }
+
+    // Insert new results
+    const prettyResult = formatResult(result[resultIndex++]);
+    const resultLines = prettyResult.split('\\n');
+    if (resultLines.length === 1) {
+      exampleLines[lineIndex] = `${exampleLines[lineIndex]} // ${prettyResult}`;
+    } else {
+      exampleLines.splice(
+        lineIndex + 1,
+        0,
+        ...resultLines.map((line) => `// ${line}`)
+      );
+    }
+
+    lineIndex += resultLines.length;
+  }
+
+  // Update jsdoc
+  exampleLines.unshift('@example');
+  exampleTag.replaceWithText(exampleLines.join('\n * '));
+}

--- a/scripts/apidocs/processing/class.ts
+++ b/scripts/apidocs/processing/class.ts
@@ -66,9 +66,11 @@ function getAllClasses(
 }
 
 export function processProjectClasses(project: Project): RawApiDocsPage[] {
-  return processClasses(
-    valuesForKeys(getAllClasses(project), ['Faker', 'SimpleFaker'])
-  );
+  return processClasses(findProjectClasses(project));
+}
+
+export function findProjectClasses(project: Project): ClassDeclaration[] {
+  return valuesForKeys(getAllClasses(project), ['Faker', 'SimpleFaker']);
 }
 
 function processClasses(classes: ClassDeclaration[]): RawApiDocsPage[] {
@@ -95,15 +97,17 @@ export function processClass(clazz: ClassDeclaration): RawApiDocsPage {
 // Modules
 
 export function processModuleClasses(project: Project): RawApiDocsPage[] {
-  return processModules(
-    Object.values(
-      getAllClasses(
-        project,
-        (module: string): boolean =>
-          module.endsWith('Module') && !module.startsWith('Simple')
-      )
-    ).sort((a, b) => a.getNameOrThrow().localeCompare(b.getNameOrThrow()))
-  );
+  return processModules(findModuleClasses(project));
+}
+
+export function findModuleClasses(project: Project): ClassDeclaration[] {
+  return Object.values(
+    getAllClasses(
+      project,
+      (module: string): boolean =>
+        module.endsWith('Module') && !module.startsWith('Simple')
+    )
+  ).sort((a, b) => a.getNameOrThrow().localeCompare(b.getNameOrThrow()));
 }
 
 function processModules(modules: ClassDeclaration[]): RawApiDocsPage[] {

--- a/scripts/apidocs/processing/jsdocs.ts
+++ b/scripts/apidocs/processing/jsdocs.ts
@@ -58,40 +58,41 @@ export function getDefault(jsdocs: JSDoc): string | undefined {
 }
 
 export function getThrows(jsdocs: JSDoc): string[] {
-  return getTagsFromJSDoc(jsdocs, 'throws');
+  return getTagsContentsFromJSDoc(jsdocs, 'throws');
 }
 
 export function getExamples(jsdocs: JSDoc): string[] {
-  return getTagsFromJSDoc(jsdocs, 'example');
+  return getTagsContentsFromJSDoc(jsdocs, 'example');
 }
 
 export function getSeeAlsos(jsdocs: JSDoc): string[] {
-  return getTagsFromJSDoc(jsdocs, 'see', true);
+  return getTagsContentsFromJSDoc(jsdocs, 'see', true);
 }
 
 function getOptionalTagFromJSDoc(
   jsdocs: JSDoc,
   type: string
 ): string | undefined {
-  return optionalOne(getTagsFromJSDoc(jsdocs, type), `@${type}`);
+  return optionalOne(getTagsContentsFromJSDoc(jsdocs, type), `@${type}`);
 }
 
 function getExactlyOneTagFromJSDoc(jsdocs: JSDoc, type: string): string {
-  return exactlyOne(getTagsFromJSDoc(jsdocs, type), `@${type}`);
+  return exactlyOne(getTagsContentsFromJSDoc(jsdocs, type), `@${type}`);
 }
 
-function getTagsFromJSDoc(
+function getTagsContentsFromJSDoc(
   jsdocs: JSDoc,
   type: string,
   full: boolean = false
 ): string[] {
   return allRequired(
-    jsdocs
-      .getTags()
-      .filter((tag) => tag.getTagName() === type)
-      .map((tag) =>
-        full ? tag.getStructure().text?.toString() : tag.getCommentText()
-      ),
+    getTagsFromJSDoc(jsdocs, type).map((tag) =>
+      full ? tag.getStructure().text?.toString() : tag.getCommentText()
+    ),
     `@${type}`
   );
+}
+
+export function getTagsFromJSDoc(jsdocs: JSDoc, type: string): JSDocTag[] {
+  return jsdocs.getTags().filter((tag) => tag.getTagName() === type);
 }

--- a/scripts/apidocs/processing/method.ts
+++ b/scripts/apidocs/processing/method.ts
@@ -156,7 +156,7 @@ function processMethodLikes<T extends MethodLikeDeclaration>(
   nameResolver: (value: T) => string
 ): RawApiDocsMethod[] {
   return methods
-    .filter((method) => !method.hasModifier(SyntaxKind.PrivateKeyword))
+    .filter(isApiMethod)
     .map((method) => {
       const name = nameResolver(method);
       try {
@@ -171,6 +171,10 @@ function processMethodLikes<T extends MethodLikeDeclaration>(
       }
     })
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function isApiMethod(method: MethodLikeDeclaration): boolean {
+  return !method.hasModifier(SyntaxKind.PrivateKeyword);
 }
 
 export function processMethodLike(

--- a/scripts/examples.ts
+++ b/scripts/examples.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { refreshExamples } from './apidocs/examples';
+
+await refreshExamples();

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -196,8 +196,8 @@ export class Faker extends SimpleFaker {
    * @example
    * import { faker, fakerES_MX } from '@faker-js/faker';
    * // const { faker, fakerES_MX } = require("@faker-js/faker")
-   * faker.getMetadata(); // { title: 'English', code: 'en', language: 'en', endonym: 'English', dir: 'ltr', script: 'Latn' }
-   * fakerES_MX.getMetadata(); // { title: 'Spanish (Mexico)', code: 'es_MX', language: 'es', endonym: 'Español (México)', dir: 'ltr', script: 'Latn', country: 'MX' }
+   * faker.getMetadata(); // { 'title': 'English', 'code': 'en', 'language': 'en', 'endonym': 'English', 'dir': 'ltr', 'script': 'Latn' }
+   * fakerES_MX.getMetadata(); // { 'title': 'Spanish (Mexico)', 'code': 'es_MX', 'language': 'es', 'endonym': 'Español (México)', 'dir': 'ltr', 'script': 'Latn', 'country': 'MX' }
    *
    * @since 8.1.0
    */

--- a/src/modules/airline/index.ts
+++ b/src/modules/airline/index.ts
@@ -82,7 +82,7 @@ export class AirlineModule extends ModuleBase {
    * Generates a random airport.
    *
    * @example
-   * faker.airline.airport() // { name: 'Dallas Fort Worth International Airport', iataCode: 'DFW' }
+   * faker.airline.airport() // { 'name': 'Leonardo da Vinci-Fiumicino Airport', 'iataCode': 'FCO' }
    *
    * @since 8.0.0
    */
@@ -96,7 +96,7 @@ export class AirlineModule extends ModuleBase {
    * Generates a random airline.
    *
    * @example
-   * faker.airline.airline() // { name: 'American Airlines', iataCode: 'AA' }
+   * faker.airline.airline() // { 'name': 'Korean Air', 'iataCode': 'KE' }
    *
    * @since 8.0.0
    */
@@ -110,7 +110,7 @@ export class AirlineModule extends ModuleBase {
    * Generates a random airplane.
    *
    * @example
-   * faker.airline.airplane() // { name: 'Airbus A321neo', iataTypeCode: '32Q' }
+   * faker.airline.airplane() // { 'name': 'Canadair CL-44', 'iataTypeCode': 'CL4' }
    *
    * @since 8.0.0
    */
@@ -130,10 +130,10 @@ export class AirlineModule extends ModuleBase {
    * @param options.allowVisuallySimilarCharacters Whether to allow visually similar characters such as '1' and 'I'. Defaults to `false`.
    *
    * @example
-   * faker.airline.recordLocator() // 'KIFRWE'
-   * faker.airline.recordLocator({ allowNumerics: true }) // 'E5TYEM'
-   * faker.airline.recordLocator({ allowVisuallySimilarCharacters: true }) // 'ANZNEI'
-   * faker.airline.recordLocator({ allowNumerics: true, allowVisuallySimilarCharacters: true }) // '1Z2Z3E'
+   * faker.airline.recordLocator() // 'PTQPKR'
+   * faker.airline.recordLocator({ allowNumerics: true }) // 'FWYDTJ'
+   * faker.airline.recordLocator({ allowVisuallySimilarCharacters: true }) // 'OYBCAV'
+   * faker.airline.recordLocator({ allowNumerics: true, allowVisuallySimilarCharacters: true }) // 'SVZSGS'
    *
    * @since 8.0.0
    */
@@ -178,9 +178,9 @@ export class AirlineModule extends ModuleBase {
    * @param options.aircraftType The aircraft type. Can be one of `narrowbody`, `regional`, `widebody`. Defaults to `narrowbody`.
    *
    * @example
-   * faker.airline.seat() // '22C'
-   * faker.airline.seat({ aircraftType: 'regional' }) // '7A'
-   * faker.airline.seat({ aircraftType: 'widebody' }) // '42K'
+   * faker.airline.seat() // '20E'
+   * faker.airline.seat({ aircraftType: 'regional' }) // '13C'
+   * faker.airline.seat({ aircraftType: 'widebody' }) // '26G'
    *
    * @since 8.0.0
    */
@@ -206,7 +206,7 @@ export class AirlineModule extends ModuleBase {
    * Returns a random aircraft type.
    *
    * @example
-   * faker.airline.aircraftType() // 'narrowbody'
+   * faker.airline.aircraftType() // 'regional'
    *
    * @since 8.0.0
    */
@@ -230,12 +230,12 @@ export class AirlineModule extends ModuleBase {
    * @param options.addLeadingZeros Whether to pad the flight number up to 4 digits with leading zeros. Defaults to `false`.
    *
    * @example
-   * faker.airline.flightNumber() // '2405'
-   * faker.airline.flightNumber({ addLeadingZeros: true }) // '0249'
-   * faker.airline.flightNumber({ addLeadingZeros: true, length: 2 }) // '0042'
-   * faker.airline.flightNumber({ addLeadingZeros: true, length: { min: 2, max: 3 } }) // '0624'
-   * faker.airline.flightNumber({ length: 3 }) // '425'
-   * faker.airline.flightNumber({ length: { min: 2, max: 3 } }) // '84'
+   * faker.airline.flightNumber() // '765'
+   * faker.airline.flightNumber({ addLeadingZeros: true }) // '0064'
+   * faker.airline.flightNumber({ addLeadingZeros: true, length: 2 }) // '0099'
+   * faker.airline.flightNumber({ addLeadingZeros: true, length: { min: 2, max: 3 } }) // '0085'
+   * faker.airline.flightNumber({ length: 3 }) // '690'
+   * faker.airline.flightNumber({ length: { min: 2, max: 3 } }) // '18'
    *
    * @since 8.0.0
    */

--- a/src/modules/animal/index.ts
+++ b/src/modules/animal/index.ts
@@ -16,7 +16,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random dog breed.
    *
    * @example
-   * faker.animal.dog() // 'Irish Water Spaniel'
+   * faker.animal.dog() // 'Kuvasz'
    *
    * @since 5.5.0
    */
@@ -28,7 +28,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random cat breed.
    *
    * @example
-   * faker.animal.cat() // 'Singapura'
+   * faker.animal.cat() // 'Norwegian Forest Cat'
    *
    * @since 5.5.0
    */
@@ -40,7 +40,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random snake species.
    *
    * @example
-   * faker.animal.snake() // 'Eyelash viper'
+   * faker.animal.snake() // "Malcolm's tree viper"
    *
    * @since 5.5.0
    */
@@ -52,7 +52,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random bear species.
    *
    * @example
-   * faker.animal.bear() // 'Asian black bear'
+   * faker.animal.bear() // 'Polar bear'
    *
    * @since 5.5.0
    */
@@ -64,7 +64,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random lion species.
    *
    * @example
-   * faker.animal.lion() // 'Northeast Congo Lion'
+   * faker.animal.lion() // 'Masai Lion'
    *
    * @since 5.5.0
    */
@@ -76,7 +76,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random cetacean species.
    *
    * @example
-   * faker.animal.cetacean() // 'Spinner Dolphin'
+   * faker.animal.cetacean() // 'Irrawaddy Dolphin'
    *
    * @since 5.5.0
    */
@@ -90,7 +90,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random horse breed.
    *
    * @example
-   * faker.animal.horse() // 'Swedish Warmblood'
+   * faker.animal.horse() // "M'Par"
    *
    * @since 5.5.0
    */
@@ -102,7 +102,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random bird species.
    *
    * @example
-   * faker.animal.bird() // 'Buller's Shearwater'
+   * faker.animal.bird() // 'Magnificent Frigatebird'
    *
    * @since 5.5.0
    */
@@ -114,7 +114,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random cow species.
    *
    * @example
-   * faker.animal.cow() // 'Brava'
+   * faker.animal.cow() // 'Kenana cattle'
    *
    * @since 5.5.0
    */
@@ -126,7 +126,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random fish species.
    *
    * @example
-   * faker.animal.fish() // 'Mandarin fish'
+   * faker.animal.fish() // 'Japanese jack mackerel'
    *
    * @since 5.5.0
    */
@@ -138,7 +138,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random crocodilian species.
    *
    * @example
-   * faker.animal.crocodilia() // 'Philippine Crocodile'
+   * faker.animal.crocodilia() // 'New Guinea Freshwater Crocodile'
    *
    * @since 5.5.0
    */
@@ -152,7 +152,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random insect species.
    *
    * @example
-   * faker.animal.insect() // 'Pyramid ant'
+   * faker.animal.insect() // 'Mossyrose gall wasp'
    *
    * @since 5.5.0
    */
@@ -166,7 +166,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random rabbit species.
    *
    * @example
-   * faker.animal.rabbit() // 'Florida White'
+   * faker.animal.rabbit() // 'Havana'
    *
    * @since 5.5.0
    */
@@ -180,7 +180,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random rodent breed.
    *
    * @example
-   * faker.animal.rodent() // 'Cuscomys ashanika'
+   * faker.animal.rodent() // 'Indian porcupine'
    *
    * @since 7.4.0
    */
@@ -194,7 +194,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random animal type.
    *
    * @example
-   * faker.animal.type() // 'crocodile'
+   * faker.animal.type() // 'koala'
    *
    * @since 5.5.0
    */
@@ -206,7 +206,7 @@ export class AnimalModule extends ModuleBase {
    * Returns a random pet name.
    *
    * @example
-   * faker.animal.petName() // 'Coco'
+   * faker.animal.petName() // 'Leo'
    *
    * @since 9.2.0
    */

--- a/src/modules/book/index.ts
+++ b/src/modules/book/index.ts
@@ -21,7 +21,7 @@ export class BookModule extends ModuleBase {
    * Returns a random author name.
    *
    * @example
-   * faker.book.author() // 'William Shakespeare'
+   * faker.book.author() // 'Joseph Conrad'
    *
    * @since 9.1.0
    */
@@ -45,7 +45,7 @@ export class BookModule extends ModuleBase {
    * Returns a random genre.
    *
    * @example
-   * faker.book.genre() // 'Fantasy'
+   * faker.book.genre() // 'Memoir'
    *
    * @since 9.1.0
    */
@@ -57,7 +57,7 @@ export class BookModule extends ModuleBase {
    * Returns a random publisher.
    *
    * @example
-   * faker.book.publisher() // 'Addison-Wesley'
+   * faker.book.publisher() // 'Jarrolds Publishing'
    *
    * @since 9.1.0
    */
@@ -71,7 +71,7 @@ export class BookModule extends ModuleBase {
    * Returns a random series.
    *
    * @example
-   * faker.book.series() // 'Harry Potter'
+   * faker.book.series() // 'The Dresden Files'
    *
    * @since 9.1.0
    */
@@ -83,7 +83,7 @@ export class BookModule extends ModuleBase {
    * Returns a random title.
    *
    * @example
-   * faker.book.title() // 'Romeo and Juliet'
+   * faker.book.title() // 'Second Treatise of Government'
    *
    * @since 9.1.0
    */

--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -212,7 +212,7 @@ export class ColorModule extends ModuleBase {
    * Returns a random human-readable color name.
    *
    * @example
-   * faker.color.human() // 'red'
+   * faker.color.human() // 'orchid'
    *
    * @since 7.0.0
    */
@@ -225,7 +225,7 @@ export class ColorModule extends ModuleBase {
    * Source: https://en.wikipedia.org/wiki/List_of_color_spaces_and_their_uses
    *
    * @example
-   * faker.color.space() // 'sRGB'
+   * faker.color.space() // 'Natural Color System (NSC)'
    *
    * @since 7.0.0
    */
@@ -237,7 +237,7 @@ export class ColorModule extends ModuleBase {
    * Returns a random css supported color function name.
    *
    * @example
-   * faker.color.cssSupportedFunction() // 'rgb'
+   * faker.color.cssSupportedFunction() // 'hwb'
    *
    * @since 7.0.0
    */
@@ -249,7 +249,7 @@ export class ColorModule extends ModuleBase {
    * Returns a random css supported color space name.
    *
    * @example
-   * faker.color.cssSupportedSpace() // 'display-p3'
+   * faker.color.cssSupportedSpace() // 'rec2020'
    *
    * @since 7.0.0
    */
@@ -261,7 +261,7 @@ export class ColorModule extends ModuleBase {
    * Returns an RGB color.
    *
    * @example
-   * faker.color.rgb() // '#8be4ab'
+   * faker.color.rgb() // '#cfdb9e'
    *
    * @since 7.0.0
    */
@@ -276,16 +276,16 @@ export class ColorModule extends ModuleBase {
    * @param options.includeAlpha Adds an alpha value to the color (RGBA). Defaults to `false`.
    *
    * @example
-   * faker.color.rgb() // '#0d7f26'
-   * faker.color.rgb({ prefix: '0x' }) // '0x9ddc8b'
-   * faker.color.rgb({ casing: 'upper' }) // '#B8A51E'
-   * faker.color.rgb({ casing: 'lower' }) // '#b12f8b'
-   * faker.color.rgb({ prefix: '#', casing: 'lower' }) // '#eb0c16'
-   * faker.color.rgb({ format: 'hex', casing: 'lower' }) // '#bb9d17'
-   * faker.color.rgb({ format: 'css' }) // 'rgb(216, 17, 192)'
-   * faker.color.rgb({ format: 'binary' }) // '00110010 00001000 01110110'
-   * faker.color.rgb({ includeAlpha: true }) // '#f96efb5e'
-   * faker.color.rgb({ format: 'css', includeAlpha: true }) // 'rgba(180, 158, 24, 0.75)'
+   * faker.color.rgb() // '#cfdb9e'
+   * faker.color.rgb({ prefix: '0x' }) // '0x9df8bb'
+   * faker.color.rgb({ casing: 'upper' }) // '#CE110C'
+   * faker.color.rgb({ casing: 'lower' }) // '#bdfbab'
+   * faker.color.rgb({ prefix: '#', casing: 'lower' }) // '#2e3eb9'
+   * faker.color.rgb({ format: 'hex', casing: 'lower' }) // '#5bac0d'
+   * faker.color.rgb({ format: 'css' }) // 'rgb(156, 157, 241)'
+   * faker.color.rgb({ format: 'binary' }) // '10101110 01011100 01101111'
+   * faker.color.rgb({ includeAlpha: true }) // '#f1ee4268'
+   * faker.color.rgb({ format: 'css', includeAlpha: true }) // 'rgba(145, 112, 253, 0.1)'
    *
    * @since 7.0.0
    */
@@ -323,9 +323,9 @@ export class ColorModule extends ModuleBase {
    * @param options.includeAlpha Adds an alpha value to the color (RGBA). Defaults to `false`.
    *
    * @example
-   * faker.color.rgb() // '0x8be4ab'
-   * faker.color.rgb({ format: 'decimal' }) // [64, 192,174]
-   * faker.color.rgb({ format: 'decimal', includeAlpha: true }) // [52, 250, 209, 0.21]
+   * faker.color.rgb() // '#cfdb9e'
+   * faker.color.rgb({ format: 'decimal' }) // [ 112, 228, 246 ]
+   * faker.color.rgb({ format: 'decimal', includeAlpha: true }) // [ 98, 202, 135, 0.57 ]
    *
    * @since 7.0.0
    */
@@ -353,18 +353,18 @@ export class ColorModule extends ModuleBase {
    * @param options.includeAlpha Adds an alpha value to the color (RGBA). Defaults to `false`.
    *
    * @example
-   * faker.color.rgb() // '#0d7f26'
-   * faker.color.rgb({ prefix: '0x' }) // '0x9ddc8b'
-   * faker.color.rgb({ casing: 'upper' }) // '#B8A51E'
-   * faker.color.rgb({ casing: 'lower' }) // '#b12f8b'
-   * faker.color.rgb({ prefix: '#', casing: 'lower' }) // '#eb0c16'
-   * faker.color.rgb({ format: 'hex', casing: 'lower' }) // '#bb9d17'
-   * faker.color.rgb({ format: 'decimal' }) // [64, 192,174]
-   * faker.color.rgb({ format: 'css' }) // 'rgb(216, 17, 192)'
-   * faker.color.rgb({ format: 'binary' }) // '00110010 00001000 01110110'
-   * faker.color.rgb({ includeAlpha: true }) // '#f96efb5e'
-   * faker.color.rgb({ format: 'css', includeAlpha: true }) // 'rgba(180, 158, 24, 0.75)'
-   * faker.color.rgb({ format: 'decimal', includeAlpha: true }) // [52, 250, 209, 0.21]
+   * faker.color.rgb() // '#cfdb9e'
+   * faker.color.rgb({ prefix: '0x' }) // '0x9df8bb'
+   * faker.color.rgb({ casing: 'upper' }) // '#CE110C'
+   * faker.color.rgb({ casing: 'lower' }) // '#bdfbab'
+   * faker.color.rgb({ prefix: '#', casing: 'lower' }) // '#2e3eb9'
+   * faker.color.rgb({ format: 'hex', casing: 'lower' }) // '#5bac0d'
+   * faker.color.rgb({ format: 'decimal' }) // [ 156, 157, 241 ]
+   * faker.color.rgb({ format: 'css' }) // 'rgb(174, 92, 111)'
+   * faker.color.rgb({ format: 'binary' }) // '10110010 00001111 10101010'
+   * faker.color.rgb({ includeAlpha: true }) // '#e4268c9f'
+   * faker.color.rgb({ format: 'css', includeAlpha: true }) // 'rgba(26, 53, 41, 0.65)'
+   * faker.color.rgb({ format: 'decimal', includeAlpha: true }) // [ 64, 119, 62, 0.16 ]
    *
    * @since 7.0.0
    */
@@ -432,7 +432,7 @@ export class ColorModule extends ModuleBase {
    * Returns a CMYK color.
    *
    * @example
-   * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
+   * faker.color.cmyk() // [ 0.55, 0.72, 0.6, 0.55 ]
    *
    * @since 7.0.0
    */
@@ -444,9 +444,9 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated CMYK color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
-   * faker.color.cmyk({ format: 'css' }) // 'cmyk(35%, 39%, 68%, 60%)'
-   * faker.color.cmyk({ format: 'binary' }) // (8-32 bits) x 4
+   * faker.color.cmyk() // [ 0.55, 0.72, 0.6, 0.55 ]
+   * faker.color.cmyk({ format: 'css' }) // 'cmyk(42%, 65%, 44%, 90%)'
+   * faker.color.cmyk({ format: 'binary' }) // '00111111011110000101000111101100 00111110110000101000111101011100 00111111010010100011110101110001 00111111000001111010111000010100'
    *
    * @since 7.0.0
    */
@@ -465,8 +465,8 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated CMYK color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
-   * faker.color.cmyk({ format: 'decimal' }) // [0.31, 0.52, 0.32, 0.43]
+   * faker.color.cmyk() // [ 0.55, 0.72, 0.6, 0.55 ]
+   * faker.color.cmyk({ format: 'decimal' }) // [ 0.42, 0.65, 0.44, 0.9 ]
    *
    * @since 7.0.0
    */
@@ -485,10 +485,10 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated CMYK color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.cmyk() // [0.31, 0.52, 0.32, 0.43]
-   * faker.color.cmyk({ format: 'decimal' }) // [0.31, 0.52, 0.32, 0.43]
-   * faker.color.cmyk({ format: 'css' }) // 'cmyk(35%, 39%, 68%, 60%)'
-   * faker.color.cmyk({ format: 'binary' }) // (8-32 bits) x 4
+   * faker.color.cmyk() // [ 0.55, 0.72, 0.6, 0.55 ]
+   * faker.color.cmyk({ format: 'decimal' }) // [ 0.42, 0.65, 0.44, 0.9 ]
+   * faker.color.cmyk({ format: 'css' }) // 'cmyk(97%, 38%, 79%, 53%)'
+   * faker.color.cmyk({ format: 'binary' }) // '00111111000100011110101110000101 00111111011011100001010001111011 00111101100011110101110000101001 00111101101000111101011100001010'
    *
    * @since 7.0.0
    */
@@ -512,7 +512,7 @@ export class ColorModule extends ModuleBase {
    * Returns an HSL color.
    *
    * @example
-   * faker.color.hsl() // [201, 0.23, 0.32]
+   * faker.color.hsl() // [ 198, 0.72, 0.6 ]
    *
    * @since 7.0.0
    */
@@ -525,11 +525,11 @@ export class ColorModule extends ModuleBase {
    * @param options.includeAlpha Adds an alpha value to the color (RGBA). Defaults to `false`.
    *
    * @example
-   * faker.color.hsl() // [201, 0.23, 0.32]
-   * faker.color.hsl({ format: 'css' }) // hsl(0deg, 100%, 80%)
-   * faker.color.hsl({ format: 'css', includeAlpha: true }) // hsl(0deg 100% 50% / 0.5)
-   * faker.color.hsl({ format: 'binary' }) // (8-32 bits) x 3
-   * faker.color.hsl({ format: 'binary', includeAlpha: true }) // (8-32 bits) x 4
+   * faker.color.hsl() // [ 198, 0.72, 0.6 ]
+   * faker.color.hsl({ format: 'css' }) // 'hsl(196deg 42% 65%)'
+   * faker.color.hsl({ format: 'css', includeAlpha: true }) // 'hsl(157deg 90% 97% / 38)'
+   * faker.color.hsl({ format: 'binary' }) // '100011101 00111111000001111010111000010100 00111111000100011110101110000101'
+   * faker.color.hsl({ format: 'binary', includeAlpha: true }) // '101001110 00111101100011110101110000101001 00111101101000111101011100001010 00111100101000111101011100001010'
    *
    * @since 7.0.0
    */
@@ -555,9 +555,9 @@ export class ColorModule extends ModuleBase {
    * @param options.includeAlpha Adds an alpha value to the color (RGBA). Defaults to `false`.
    *
    * @example
-   * faker.color.hsl() // [201, 0.23, 0.32]
-   * faker.color.hsl({ format: 'decimal' }) // [300, 0.21, 0.52]
-   * faker.color.hsl({ format: 'decimal', includeAlpha: true }) // [300, 0.21, 0.52, 0.28]
+   * faker.color.hsl() // [ 198, 0.72, 0.6 ]
+   * faker.color.hsl({ format: 'decimal' }) // [ 196, 0.42, 0.65 ]
+   * faker.color.hsl({ format: 'decimal', includeAlpha: true }) // [ 157, 0.9, 0.97, 0.38 ]
    *
    * @since 7.0.0
    */
@@ -583,13 +583,13 @@ export class ColorModule extends ModuleBase {
    * @param options.includeAlpha Adds an alpha value to the color (RGBA). Defaults to `false`.
    *
    * @example
-   * faker.color.hsl() // [201, 0.23, 0.32]
-   * faker.color.hsl({ format: 'decimal' }) // [300, 0.21, 0.52]
-   * faker.color.hsl({ format: 'decimal', includeAlpha: true }) // [300, 0.21, 0.52, 0.28]
-   * faker.color.hsl({ format: 'css' }) // hsl(0deg, 100%, 80%)
-   * faker.color.hsl({ format: 'css', includeAlpha: true }) // hsl(0deg 100% 50% / 0.5)
-   * faker.color.hsl({ format: 'binary' }) // (8-32 bits) x 3
-   * faker.color.hsl({ format: 'binary', includeAlpha: true }) // (8-32 bits) x 4
+   * faker.color.hsl() // [ 198, 0.72, 0.6 ]
+   * faker.color.hsl({ format: 'decimal' }) // [ 196, 0.42, 0.65 ]
+   * faker.color.hsl({ format: 'decimal', includeAlpha: true }) // [ 157, 0.9, 0.97, 0.38 ]
+   * faker.color.hsl({ format: 'css' }) // 'hsl(285deg 53% 57%)'
+   * faker.color.hsl({ format: 'css', includeAlpha: true }) // 'hsl(334deg 7% 8% / 2)'
+   * faker.color.hsl({ format: 'binary' }) // '100101100 00111111010001111010111000010100 00111111010111101011100001010010'
+   * faker.color.hsl({ format: 'binary', includeAlpha: true }) // '101100001 00111111010011001100110011001101 00111110111010111000010100011111 00111111010001111010111000010100'
    *
    * @since 7.0.0
    */
@@ -626,7 +626,7 @@ export class ColorModule extends ModuleBase {
    * Returns an HWB color.
    *
    * @example
-   * faker.color.hwb() // [201, 0.21, 0.31]
+   * faker.color.hwb() // [ 198, 0.72, 0.6 ]
    *
    * @since 7.0.0
    */
@@ -638,9 +638,9 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.hwb() // [201, 0.21, 0.31]
-   * faker.color.hwb({ format: 'css' }) // 'hwb(354 72% 41%)'
-   * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
+   * faker.color.hwb() // [ 198, 0.72, 0.6 ]
+   * faker.color.hwb({ format: 'css' }) // 'hwb(196 42% 65%)'
+   * faker.color.hwb({ format: 'binary' }) // '10011101 00111111011001100110011001100110 00111111011110000101000111101100'
    *
    * @since 7.0.0
    */
@@ -659,8 +659,8 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.hwb() // [201, 0.21, 0.31]
-   * faker.color.hwb({ format: 'decimal' }) // [201, 0.21, 0.31]
+   * faker.color.hwb() // [ 198, 0.72, 0.6 ]
+   * faker.color.hwb({ format: 'decimal' }) // [ 196, 0.42, 0.65 ]
    *
    * @since 7.0.0
    */
@@ -679,10 +679,10 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.hwb() // [201, 0.21, 0.31]
-   * faker.color.hwb({ format: 'decimal' }) // [201, 0.21, 0.31]
-   * faker.color.hwb({ format: 'css' }) // 'hwb(354 72% 41%)'
-   * faker.color.hwb({ format: 'binary' }) // (8-32 bits x 3)
+   * faker.color.hwb() // [ 198, 0.72, 0.6 ]
+   * faker.color.hwb({ format: 'decimal' }) // [ 196, 0.42, 0.65 ]
+   * faker.color.hwb({ format: 'css' }) // 'hwb(157 90% 97%)'
+   * faker.color.hwb({ format: 'binary' }) // '10001010 00111111010010100011110101110001 00111111000001111010111000010100'
    *
    * @since 7.0.0
    */
@@ -731,7 +731,7 @@ export class ColorModule extends ModuleBase {
    * Returns a LAB (CIELAB) color.
    *
    * @example
-   * faker.color.lab() // [0.832133, -80.3245, 100.1234]
+   * faker.color.lab() // [ 0.548814, 43.0379, 20.5527 ]
    *
    * @since 7.0.0
    */
@@ -743,9 +743,9 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.lab() // [0.832133, -80.3245, 100.1234]
-   * faker.color.lab({ format: 'css' }) // 'lab(29.2345% 39.3825 20.0664)'
-   * faker.color.lab({ format: 'binary' }) // (8-32 bits x 3)
+   * faker.color.lab() // [ 0.548814, 43.0379, 20.5527 ]
+   * faker.color.lab({ format: 'css' }) // 'lab(54% -15.269 29.1788)'
+   * faker.color.lab({ format: 'binary' }) // '00111110111000000000101101100111 01000010100111001011010110001110 01000010101110010111011100010111'
    *
    * @since 7.0.0
    */
@@ -764,8 +764,8 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.lab() // [0.832133, -80.3245, 100.1234]
-   * faker.color.lab({ format: 'decimal' }) // [0.856773, -80.2345, 100.2341]
+   * faker.color.lab() // [ 0.548814, 43.0379, 20.5527 ]
+   * faker.color.lab({ format: 'decimal' }) // [ 0.544883, -15.269, 29.1788 ]
    *
    * @since 7.0.0
    */
@@ -784,10 +784,10 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.lab() // [0.832133, -80.3245, 100.1234]
-   * faker.color.lab({ format: 'decimal' }) // [0.856773, -80.2345, 100.2341]
-   * faker.color.lab({ format: 'css' }) // 'lab(29.2345% 39.3825 20.0664)'
-   * faker.color.lab({ format: 'binary' }) // (8-32 bits x 3)
+   * faker.color.lab() // [ 0.548814, 43.0379, 20.5527 ]
+   * faker.color.lab({ format: 'decimal' }) // [ 0.544883, -15.269, 29.1788 ]
+   * faker.color.lab({ format: 'css' }) // 'lab(44% 78.3546 92.7326)'
+   * faker.color.lab({ format: 'binary' }) // '00111110110001000101001001100001 01000010011010010110000101001000 01000000101110001110110110010001'
    *
    * @since 7.0.0
    */
@@ -818,7 +818,7 @@ export class ColorModule extends ModuleBase {
    * make a noticeable difference in the browser.
    *
    * @example
-   * faker.color.lch() // [0.522345, 72.2, 56.2]
+   * faker.color.lch() // [ 0.548814, 164.5, 138.6 ]
    *
    * @since 7.0.0
    */
@@ -833,9 +833,9 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.lch() // [0.522345, 72.2, 56.2]
-   * faker.color.lch({ format: 'css' }) // 'lch(52.2345% 72.2 56.2)'
-   * faker.color.lch({ format: 'binary' }) // (8-32 bits x 3)
+   * faker.color.lch() // [ 0.548814, 164.5, 138.6 ]
+   * faker.color.lch({ format: 'css' }) // 'lch(54% 97.4 148.6)'
+   * faker.color.lch({ format: 'binary' }) // '00111110111000000000101101100111 01000011010011010001100110011010 01000011010111011011001100110011'
    *
    * @since 7.0.0
    */
@@ -857,8 +857,8 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.lch() // [0.522345, 72.2, 56.2]
-   * faker.color.lch({ format: 'decimal' }) // [0.522345, 72.2, 56.2]
+   * faker.color.lch() // [ 0.548814, 164.5, 138.6 ]
+   * faker.color.lch({ format: 'decimal' }) // [ 0.544883, 97.4, 148.6 ]
    *
    * @since 7.0.0
    */
@@ -880,10 +880,10 @@ export class ColorModule extends ModuleBase {
    * @param options.format Format of generated RGB color. Defaults to `'decimal'`.
    *
    * @example
-   * faker.color.lch() // [0.522345, 72.2, 56.2]
-   * faker.color.lch({ format: 'decimal' }) // [0.522345, 72.2, 56.2]
-   * faker.color.lch({ format: 'css' }) // 'lch(52.2345% 72.2 56.2)'
-   * faker.color.lch({ format: 'binary' }) // (8-32 bits x 3)
+   * faker.color.lch() // [ 0.548814, 164.5, 138.6 ]
+   * faker.color.lch({ format: 'decimal' }) // [ 0.544883, 97.4, 148.6 ]
+   * faker.color.lch({ format: 'css' }) // 'lch(44% 205.1 221.7)'
+   * faker.color.lch({ format: 'binary' }) // '00111110110001000101001001100001 01000011001101100001100110011010 01000010111100110011001100110011'
    *
    * @since 7.0.0
    */
@@ -909,7 +909,7 @@ export class ColorModule extends ModuleBase {
    * Returns a random color based on CSS color space specified.
    *
    * @example
-   * faker.color.colorByCSSColorSpace() // [0.93, 1, 0.82]
+   * faker.color.colorByCSSColorSpace() // [ 0.5488, 0.7152, 0.6028 ]
    *
    * @since 7.0.0
    */
@@ -922,9 +922,9 @@ export class ColorModule extends ModuleBase {
    * @param options.space Color space to generate the color for. Defaults to `'sRGB'`.
    *
    * @example
-   * faker.color.colorByCSSColorSpace() // [0.93, 1, 0.82]
-   * faker.color.colorByCSSColorSpace({ format: 'css', space: 'display-p3' }) // color(display-p3 0.12 1 0.23)
-   * faker.color.colorByCSSColorSpace({ format: 'binary' }) // (8-32 bits x 3)
+   * faker.color.colorByCSSColorSpace() // [ 0.5488, 0.7152, 0.6028 ]
+   * faker.color.colorByCSSColorSpace({ format: 'css', space: 'display-p3' }) // 'color(display-p3 0.5449 0.4236 0.6459)'
+   * faker.color.colorByCSSColorSpace({ format: 'binary' }) // '00111110111000000000110100011011 00111111011001000100110100000001 00111111011101101011010100001011'
    *
    * @since 7.0.0
    */
@@ -950,8 +950,8 @@ export class ColorModule extends ModuleBase {
    * @param options.space Color space to generate the color for. Defaults to `'sRGB'`.
    *
    * @example
-   * faker.color.colorByCSSColorSpace() // [0.93, 1, 0.82]
-   * faker.color.colorByCSSColorSpace({ format: 'decimal' }) // [0.12, 0.21, 0.31]
+   * faker.color.colorByCSSColorSpace() // [ 0.5488, 0.7152, 0.6028 ]
+   * faker.color.colorByCSSColorSpace({ format: 'decimal' }) // [ 0.5449, 0.4236, 0.6459 ]
    *
    * @since 7.0.0
    */
@@ -977,10 +977,10 @@ export class ColorModule extends ModuleBase {
    * @param options.space Color space to generate the color for. Defaults to `'sRGB'`.
    *
    * @example
-   * faker.color.colorByCSSColorSpace() // [0.93, 1, 0.82]
-   * faker.color.colorByCSSColorSpace({ format: 'decimal' }) // [0.12, 0.21, 0.31]
-   * faker.color.colorByCSSColorSpace({ format: 'css', space: 'display-p3' }) // color(display-p3 0.12 1 0.23)
-   * faker.color.colorByCSSColorSpace({ format: 'binary' }) // (8-32 bits x 3)
+   * faker.color.colorByCSSColorSpace() // [ 0.5488, 0.7152, 0.6028 ]
+   * faker.color.colorByCSSColorSpace({ format: 'decimal' }) // [ 0.5449, 0.4236, 0.6459 ]
+   * faker.color.colorByCSSColorSpace({ format: 'css', space: 'display-p3' }) // 'color(display-p3 0.4376 0.8918 0.9637)'
+   * faker.color.colorByCSSColorSpace({ format: 'binary' }) // '00111110110001000100110100000001 00111111010010101011001101101000 00111111000001110110010111111110'
    *
    * @since 7.0.0
    */

--- a/src/modules/commerce/index.ts
+++ b/src/modules/commerce/index.ts
@@ -90,7 +90,7 @@ export class CommerceModule extends ModuleBase {
    * Returns a department inside a shop.
    *
    * @example
-   * faker.commerce.department() // 'Garden'
+   * faker.commerce.department() // 'Industrial'
    *
    * @since 3.0.0
    */
@@ -104,7 +104,7 @@ export class CommerceModule extends ModuleBase {
    * Generates a random descriptive product name.
    *
    * @example
-   * faker.commerce.productName() // 'Incredible Soft Gloves'
+   * faker.commerce.productName() // 'Luxurious Rubber Pants'
    *
    * @since 3.0.0
    */
@@ -129,11 +129,11 @@ export class CommerceModule extends ModuleBase {
    * @param options.symbol The currency value to use. Defaults to `''`.
    *
    * @example
-   * faker.commerce.price() // '828.07'
-   * faker.commerce.price({ min: 100 }) // '904.19'
-   * faker.commerce.price({ min: 100, max: 200 }) // '154.55'
-   * faker.commerce.price({ min: 100, max: 200, dec: 0 }) // '133'
-   * faker.commerce.price({ min: 100, max: 200, dec: 0, symbol: '$' }) // '$114'
+   * faker.commerce.price() // '549.25'
+   * faker.commerce.price({ min: 100 }) // '590.45'
+   * faker.commerce.price({ min: 100, max: 200 }) // '143.78'
+   * faker.commerce.price({ min: 100, max: 200, dec: 0 }) // '138'
+   * faker.commerce.price({ min: 100, max: 200, dec: 0, symbol: '$' }) // '$179'
    *
    * @since 3.0.0
    */
@@ -212,7 +212,7 @@ export class CommerceModule extends ModuleBase {
    * Returns an adjective describing a product.
    *
    * @example
-   * faker.commerce.productAdjective() // 'Handcrafted'
+   * faker.commerce.productAdjective() // 'Luxurious'
    *
    * @since 3.0.0
    */
@@ -226,7 +226,7 @@ export class CommerceModule extends ModuleBase {
    * Returns a material of a product.
    *
    * @example
-   * faker.commerce.productMaterial() // 'Rubber'
+   * faker.commerce.productMaterial() // 'Metal'
    *
    * @since 3.0.0
    */
@@ -240,7 +240,7 @@ export class CommerceModule extends ModuleBase {
    * Returns a short product name.
    *
    * @example
-   * faker.commerce.product() // 'Computer'
+   * faker.commerce.product() // 'Mouse'
    *
    * @since 3.0.0
    */
@@ -254,7 +254,7 @@ export class CommerceModule extends ModuleBase {
    * Returns a product description.
    *
    * @example
-   * faker.commerce.productDescription() // 'Featuring Phosphorus-enhanced technology, our Fish offers unparalleled Modern performance'
+   * faker.commerce.productDescription() // 'Our savory-inspired Mouse brings a taste of luxury to your punctual lifestyle'
    *
    * @since 5.0.0
    */
@@ -273,12 +273,12 @@ export class CommerceModule extends ModuleBase {
    * @param options.separator The separator to use in the format. Defaults to `'-'`.
    *
    * @example
-   * faker.commerce.isbn() // '978-0-692-82459-7'
-   * faker.commerce.isbn(10) // '1-155-36404-X'
-   * faker.commerce.isbn(13) // '978-1-60808-867-6'
-   * faker.commerce.isbn({ separator: ' ' }) // '978 0 452 81498 1'
-   * faker.commerce.isbn({ variant: 10, separator: ' ' }) // '0 940319 49 7'
-   * faker.commerce.isbn({ variant: 13, separator: ' ' }) // '978 1 6618 9122 0'
+   * faker.commerce.isbn() // '978-1-76546-489-4'
+   * faker.commerce.isbn(10) // '0-7559-0008-1'
+   * faker.commerce.isbn(13) // '978-1-897471-61-6'
+   * faker.commerce.isbn({ separator: ' ' }) // '978 1 5427 4506 2'
+   * faker.commerce.isbn({ variant: 10, separator: ' ' }) // '1 6963 4606 1'
+   * faker.commerce.isbn({ variant: 13, separator: ' ' }) // '978 1 213 35491 3'
    *
    * @since 8.1.0
    */

--- a/src/modules/company/index.ts
+++ b/src/modules/company/index.ts
@@ -19,7 +19,7 @@ export class CompanyModule extends ModuleBase {
    * Generates a random company name.
    *
    * @example
-   * faker.company.name() // 'Zieme, Hauck and McClure'
+   * faker.company.name() // 'Rau LLC'
    *
    * @since 7.4.0
    */
@@ -31,7 +31,7 @@ export class CompanyModule extends ModuleBase {
    * Generates a random catch phrase that can be displayed to an end user.
    *
    * @example
-   * faker.company.catchPhrase() // 'Upgradable systematic flexibility'
+   * faker.company.catchPhrase() // 'Organic optimizing methodology'
    *
    * @since 2.0.1
    */
@@ -47,7 +47,7 @@ export class CompanyModule extends ModuleBase {
    * Generates a random buzz phrase that can be used to demonstrate data being viewed by a manager.
    *
    * @example
-   * faker.company.buzzPhrase() // 'cultivate synergistic e-markets'
+   * faker.company.buzzPhrase() // 'iterate rich models'
    *
    * @since 8.0.0
    */
@@ -59,7 +59,7 @@ export class CompanyModule extends ModuleBase {
    * Returns a random catch phrase adjective that can be displayed to an end user..
    *
    * @example
-   * faker.company.catchPhraseAdjective() // 'Multi-tiered'
+   * faker.company.catchPhraseAdjective() // 'Organic'
    *
    * @since 2.0.1
    */
@@ -73,7 +73,7 @@ export class CompanyModule extends ModuleBase {
    * Returns a random catch phrase descriptor that can be displayed to an end user..
    *
    * @example
-   * faker.company.catchPhraseDescriptor() // 'composite'
+   * faker.company.catchPhraseDescriptor() // 'intermediate'
    *
    * @since 2.0.1
    */
@@ -87,7 +87,7 @@ export class CompanyModule extends ModuleBase {
    * Returns a random catch phrase noun that can be displayed to an end user..
    *
    * @example
-   * faker.company.catchPhraseNoun() // 'leverage'
+   * faker.company.catchPhraseNoun() // 'knowledge base'
    *
    * @since 2.0.1
    */
@@ -99,7 +99,7 @@ export class CompanyModule extends ModuleBase {
    * Returns a random buzz adjective that can be used to demonstrate data being viewed by a manager.
    *
    * @example
-   * faker.company.buzzAdjective() // 'one-to-one'
+   * faker.company.buzzAdjective() // 'mission-critical'
    *
    * @since 8.0.0
    */
@@ -113,7 +113,7 @@ export class CompanyModule extends ModuleBase {
    * Returns a random buzz verb that can be used to demonstrate data being viewed by a manager.
    *
    * @example
-   * faker.company.buzzVerb() // 'empower'
+   * faker.company.buzzVerb() // 'iterate'
    *
    * @since 8.0.0
    */
@@ -127,7 +127,7 @@ export class CompanyModule extends ModuleBase {
    * Returns a random buzz noun that can be used to demonstrate data being viewed by a manager.
    *
    * @example
-   * faker.company.buzzNoun() // 'paradigms'
+   * faker.company.buzzNoun() // 'metrics'
    *
    * @since 8.0.0
    */

--- a/src/modules/database/index.ts
+++ b/src/modules/database/index.ts
@@ -14,7 +14,7 @@ export class DatabaseModule extends ModuleBase {
    * Returns a random database column name.
    *
    * @example
-   * faker.database.column() // 'createdAt'
+   * faker.database.column() // 'name'
    *
    * @since 4.0.0
    */
@@ -28,7 +28,7 @@ export class DatabaseModule extends ModuleBase {
    * Returns a random database column type.
    *
    * @example
-   * faker.database.type() // 'timestamp'
+   * faker.database.type() // 'mediumint'
    *
    * @since 4.0.0
    */
@@ -42,7 +42,7 @@ export class DatabaseModule extends ModuleBase {
    * Returns a random database collation.
    *
    * @example
-   * faker.database.collation() // 'utf8_unicode_ci'
+   * faker.database.collation() // 'cp1250_general_ci'
    *
    * @since 4.0.0
    */
@@ -56,7 +56,7 @@ export class DatabaseModule extends ModuleBase {
    * Returns a random database engine.
    *
    * @example
-   * faker.database.engine() // 'ARCHIVE'
+   * faker.database.engine() // 'InnoDB'
    *
    * @since 4.0.0
    */
@@ -70,7 +70,7 @@ export class DatabaseModule extends ModuleBase {
    * Returns a MongoDB [ObjectId](https://docs.mongodb.com/manual/reference/method/ObjectId/) string.
    *
    * @example
-   * faker.database.mongodbObjectId() // 'e175cac316a79afdd0ad3afb'
+   * faker.database.mongodbObjectId() // 'cfdb9e9df8bbce110cbdfbab'
    *
    * @since 6.2.0
    */

--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -20,7 +20,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @see faker.date.future(): For generating dates explicitly in the future.
    *
    * @example
-   * faker.date.anytime() // '2022-07-31T01:33:29.567Z'
+   * faker.date.anytime() // '2025-02-05T14:12:45.320Z'
    *
    * @since 8.0.0
    */
@@ -53,9 +53,9 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @see faker.date.recent(): For generating dates in the recent past (days instead of years).
    *
    * @example
-   * faker.date.past() // '2021-12-03T05:40:44.408Z'
-   * faker.date.past({ years: 10 }) // '2017-10-25T21:34:19.488Z'
-   * faker.date.past({ years: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2017-08-18T02:59:12.350Z'
+   * faker.date.past() // '2024-07-20T06:36:22.111Z'
+   * faker.date.past({ years: 10 }) // '2022-02-26T09:35:17.864Z'
+   * faker.date.past({ years: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2016-01-12T02:04:17.675Z'
    *
    * @since 8.0.0
    */
@@ -99,9 +99,9 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @see faker.date.soon(): For generating dates in the near future (days instead of years).
    *
    * @example
-   * faker.date.future() // '2022-11-19T05:52:49.100Z'
-   * faker.date.future({ years: 10 }) // '2030-11-23T09:38:28.710Z'
-   * faker.date.future({ years: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2020-12-13T22:45:10.252Z'
+   * faker.date.future() // '2025-07-20T06:36:23.111Z'
+   * faker.date.future({ years: 10 }) // '2032-02-24T09:35:18.864Z'
+   * faker.date.future({ years: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2026-01-09T02:04:18.675Z'
    *
    * @since 8.0.0
    */
@@ -146,7 +146,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @throws If `from` is after `to`.
    *
    * @example
-   * faker.date.between({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z' }) // '2026-05-16T02:22:53.002Z'
+   * faker.date.between({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z' }) // '2025-06-27T19:34:39.059Z'
    *
    * @since 8.0.0
    */
@@ -190,20 +190,9 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @throws If `from` is after `to`.
    *
    * @example
-   * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z' })
-   * // [
-   * //   '2022-07-02T06:00:00.000Z',
-   * //   '2024-12-31T12:00:00.000Z',
-   * //   '2027-07-02T18:00:00.000Z'
-   * // ]
-   * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z', count: 2 })
-   * // [ '2023-05-02T16:00:00.000Z', '2026-09-01T08:00:00.000Z' ]
-   * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z', count: { min: 2, max: 5 }})
-   * // [
-   * //   2021-12-19T06:35:40.191Z,
-   * //   2022-09-10T08:03:51.351Z,
-   * //   2023-04-19T11:41:17.501Z
-   * // ]
+   * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z' }) // [ '2025-06-27T19:34:39.059Z', '2026-01-10T21:28:14.545Z', '2027-02-25T14:04:55.663Z' ]
+   * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z', count: 2 }) // [ '2024-03-27T14:39:48.843Z', '2025-06-13T10:59:54.311Z' ]
+   * faker.date.betweens({ from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z', count: { min: 2, max: 5 }}) // [ '2023-11-01T17:05:05.418Z', '2024-05-17T12:08:45.549Z', '2028-12-01T15:31:21.089Z', '2029-08-21T06:14:29.540Z' ]
    *
    * @since 8.0.0
    */
@@ -257,9 +246,9 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @see faker.date.past(): For generating dates further back in time (years instead of days).
    *
    * @example
-   * faker.date.recent() // '2022-02-04T02:09:35.077Z'
-   * faker.date.recent({ days: 10 }) // '2022-01-29T06:12:12.829Z'
-   * faker.date.recent({ days: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2019-12-27T18:11:19.117Z'
+   * faker.date.recent() // '2024-12-31T12:10:16.938Z'
+   * faker.date.recent({ days: 10 }) // '2024-12-29T02:38:42.898Z'
+   * faker.date.recent({ days: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2019-12-28T00:39:46.954Z'
    *
    * @since 8.0.0
    */
@@ -303,9 +292,9 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @see faker.date.future(): For generating dates further in the future (years instead of days).
    *
    * @example
-   * faker.date.soon() // '2022-02-05T09:55:39.216Z'
-   * faker.date.soon({ days: 10 }) // '2022-02-11T05:14:39.138Z'
-   * faker.date.soon({ days: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2020-01-01T02:40:44.990Z'
+   * faker.date.soon() // '2025-01-01T12:10:17.938Z'
+   * faker.date.soon({ days: 10 }) // '2025-01-08T02:38:43.898Z'
+   * faker.date.soon({ days: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2020-01-07T00:39:47.954Z'
    *
    * @since 8.0.0
    */
@@ -347,7 +336,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `faker.defaultRefDate()`.
    *
    * @example
-   * faker.date.birthdate() // '1977-07-10T01:37:30.719Z'
+   * faker.date.birthdate() // '1978-07-30T03:46:09.872Z'
    *
    * @since 7.0.0
    */
@@ -369,7 +358,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `faker.defaultRefDate()`.
    *
    * @example
-   * faker.date.birthdate({ mode: 'age', min: 18, max: 65 }) // '2003-11-02T20:03:20.116Z'
+   * faker.date.birthdate({ mode: 'age', min: 18, max: 65 }) // '1985-05-06T04:59:20.027Z'
    *
    * @since 7.0.0
    */
@@ -403,7 +392,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @param options.max The maximum year to generate a birthdate in.
    *
    * @example
-   * faker.date.birthdate({ mode: 'year', min: 1900, max: 2000 }) // '1940-08-20T08:53:07.538Z'
+   * faker.date.birthdate({ mode: 'year', min: 1900, max: 2000 }) // '1955-06-07T02:00:33.353Z'
    *
    * @since 7.0.0
    */
@@ -435,9 +424,9 @@ export class SimpleDateModule extends SimpleModuleBase {
    * Defaults to `faker.defaultRefDate()`.
    *
    * @example
-   * faker.date.birthdate() // '1977-07-10T01:37:30.719Z'
-   * faker.date.birthdate({ mode: 'age', min: 18, max: 65 }) // '2003-11-02T20:03:20.116Z'
-   * faker.date.birthdate({ mode: 'year', min: 1900, max: 2000 }) // '1940-08-20T08:53:07.538Z'
+   * faker.date.birthdate() // '1978-07-30T03:46:09.872Z'
+   * faker.date.birthdate({ mode: 'age', min: 18, max: 65 }) // '1993-04-30T22:38:05.154Z'
+   * faker.date.birthdate({ mode: 'year', min: 1900, max: 2000 }) // '1960-11-17T03:11:01.233Z'
    *
    * @since 7.0.0
    */
@@ -578,10 +567,10 @@ export class DateModule extends SimpleDateModule {
    * @param options.context Whether to return the name of a month in the context of a date. In the default `en` locale this has no effect, however, in other locales like `fr` or `ru`, this may affect grammar or capitalization, for example `'январь'` with `{ context: false }` and `'января'` with `{ context: true }` in `ru`. Defaults to `false`.
    *
    * @example
-   * faker.date.month() // 'October'
-   * faker.date.month({ abbreviated: true }) // 'Feb'
-   * faker.date.month({ context: true }) // 'June'
-   * faker.date.month({ abbreviated: true, context: true }) // 'Sep'
+   * faker.date.month() // 'June'
+   * faker.date.month({ abbreviated: true }) // 'May'
+   * faker.date.month({ context: true }) // 'March'
+   * faker.date.month({ abbreviated: true, context: true }) // 'Jun'
    *
    * @since 3.0.1
    */
@@ -630,10 +619,10 @@ export class DateModule extends SimpleDateModule {
    * @param options.context Whether to return the day of the week in the context of a date. In the default `en` locale this has no effect, however, in other locales like `fr` or `ru`, this may affect grammar or capitalization, for example `'Lundi'` with `{ context: false }` and `'lundi'` with `{ context: true }` in `fr`. Defaults to `false`.
    *
    * @example
-   * faker.date.weekday() // 'Monday'
-   * faker.date.weekday({ abbreviated: true }) // 'Thu'
+   * faker.date.weekday() // 'Sunday'
+   * faker.date.weekday({ abbreviated: true }) // 'Tue'
    * faker.date.weekday({ context: true }) // 'Thursday'
-   * faker.date.weekday({ abbreviated: true, context: true }) // 'Fri'
+   * faker.date.weekday({ abbreviated: true, context: true }) // 'Sun'
    *
    * @since 3.0.1
    */
@@ -683,7 +672,7 @@ export class DateModule extends SimpleDateModule {
    * @see faker.location.timeZone(): For generating a timezone based on the current locale.
    *
    * @example
-   * faker.location.timeZone() // 'Pacific/Guam'
+   * faker.location.timeZone() // 'Asia/Dili'
    *
    * @since 9.0.0
    */

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -65,8 +65,8 @@ export class FinanceModule extends ModuleBase {
    * @param length The length of the account number. Defaults to `8`.
    *
    * @example
-   * faker.finance.accountNumber() // '92842238'
-   * faker.finance.accountNumber(5) // '32564'
+   * faker.finance.accountNumber() // '57654648'
+   * faker.finance.accountNumber(5) // '93755'
    *
    * @since 8.0.0
    */
@@ -78,8 +78,8 @@ export class FinanceModule extends ModuleBase {
    * @param options.length The length of the account number. Defaults to `8`.
    *
    * @example
-   * faker.finance.accountNumber() // '92842238'
-   * faker.finance.accountNumber({ length: 5 }) // '32564'
+   * faker.finance.accountNumber() // '57654648'
+   * faker.finance.accountNumber({ length: 5 }) // '93755'
    *
    * @since 8.0.0
    */
@@ -98,9 +98,9 @@ export class FinanceModule extends ModuleBase {
    * @param optionsOrLength.length The length of the account number. Defaults to `8`.
    *
    * @example
-   * faker.finance.accountNumber() // '92842238'
-   * faker.finance.accountNumber(5) // '28736'
-   * faker.finance.accountNumber({ length: 5 }) // '32564'
+   * faker.finance.accountNumber() // '57654648'
+   * faker.finance.accountNumber(5) // '93755'
+   * faker.finance.accountNumber({ length: 5 }) // '90008'
    *
    * @since 8.0.0
    */
@@ -154,7 +154,7 @@ export class FinanceModule extends ModuleBase {
    * Generates a random account name.
    *
    * @example
-   * faker.finance.accountName() // 'Personal Loan Account'
+   * faker.finance.accountName() // 'Investment Account'
    *
    * @since 2.0.1
    */
@@ -171,7 +171,7 @@ export class FinanceModule extends ModuleBase {
    * Generates a random routing number.
    *
    * @example
-   * faker.finance.routingNumber() // '522814402'
+   * faker.finance.routingNumber() // '576546483'
    *
    * @since 5.0.0
    */
@@ -199,8 +199,8 @@ export class FinanceModule extends ModuleBase {
    * @param length The length of the unmasked number. Defaults to `4`.
    *
    * @example
-   * faker.finance.maskedNumber() // '(...9711)'
-   * faker.finance.maskedNumber(3) // '(...342)'
+   * faker.finance.maskedNumber() // '(...5765)'
+   * faker.finance.maskedNumber(3) // '(...464)'
    *
    * @since 8.0.0
    *
@@ -216,10 +216,10 @@ export class FinanceModule extends ModuleBase {
    * @param options.ellipsis Whether to prefix the numbers with an ellipsis. Defaults to `true`.
    *
    * @example
-   * faker.finance.maskedNumber() // '(...9711)'
-   * faker.finance.maskedNumber({ length: 3 }) // '(...342)'
-   * faker.finance.maskedNumber({ length: 3, parens: false }) // '...236'
-   * faker.finance.maskedNumber({ length: 3, parens: false, ellipsis: false }) // '298'
+   * faker.finance.maskedNumber() // '(...5765)'
+   * faker.finance.maskedNumber({ length: 3 }) // '(...464)'
+   * faker.finance.maskedNumber({ length: 3, parens: false }) // '...893'
+   * faker.finance.maskedNumber({ length: 3, parens: false, ellipsis: false }) // '755'
    *
    * @since 8.0.0
    *
@@ -254,11 +254,11 @@ export class FinanceModule extends ModuleBase {
    * @param optionsOrLength.ellipsis Whether to prefix the numbers with an ellipsis. Defaults to `true`.
    *
    * @example
-   * faker.finance.maskedNumber() // '(...9711)'
-   * faker.finance.maskedNumber(3) // '(...342)'
-   * faker.finance.maskedNumber({ length: 3 }) // '(...342)'
-   * faker.finance.maskedNumber({ length: 3, parens: false }) // '...236'
-   * faker.finance.maskedNumber({ length: 3, parens: false, ellipsis: false }) // '298'
+   * faker.finance.maskedNumber() // '(...5765)'
+   * faker.finance.maskedNumber(3) // '(...464)'
+   * faker.finance.maskedNumber({ length: 3 }) // '(...893)'
+   * faker.finance.maskedNumber({ length: 3, parens: false }) // '...755'
+   * faker.finance.maskedNumber({ length: 3, parens: false, ellipsis: false }) // '900'
    *
    * @since 8.0.0
    *
@@ -369,11 +369,11 @@ export class FinanceModule extends ModuleBase {
    * @param options.autoFormat If true this method will use `Number.toLocaleString()`. Otherwise it will use `Number.toFixed()`.
    *
    * @example
-   * faker.finance.amount() // '617.87'
-   * faker.finance.amount({ min: 5, max: 10 }) // '5.53'
+   * faker.finance.amount() // '548.81'
+   * faker.finance.amount({ min: 5, max: 10 }) // '8.58'
    * faker.finance.amount({ min: 5, max: 10, dec: 0 }) // '8'
-   * faker.finance.amount({ min: 5, max: 10, dec: 2, symbol: '$' }) // '$5.85'
-   * faker.finance.amount({ min: 5, max: 10, dec: 5, symbol: '', autoFormat: true }) // '9,75067'
+   * faker.finance.amount({ min: 5, max: 10, dec: 2, symbol: '$' }) // '$7.72'
+   * faker.finance.amount({ min: 5, max: 10, dec: 5, symbol: '', autoFormat: true }) // '7,11827'
    *
    * @since 2.0.1
    */
@@ -454,7 +454,7 @@ export class FinanceModule extends ModuleBase {
    * @see faker.finance.currencySymbol(): For generating specifically the currency symbol.
    *
    * @example
-   * faker.finance.currency() // { code: 'USD', name: 'US Dollar', symbol: '$' }
+   * faker.finance.currency() // { 'name': 'Kyat', 'code': 'MMK', 'symbol': '' }
    *
    * @since 8.0.0
    */
@@ -469,7 +469,7 @@ export class FinanceModule extends ModuleBase {
    * (The short text/abbreviation for the currency (e.g. `US Dollar` -> `USD`))
    *
    * @example
-   * faker.finance.currencyCode() // 'USD'
+   * faker.finance.currencyCode() // 'MMK'
    *
    * @since 2.0.1
    */
@@ -481,7 +481,7 @@ export class FinanceModule extends ModuleBase {
    * Returns a random currency name.
    *
    * @example
-   * faker.finance.currencyName() // 'US Dollar'
+   * faker.finance.currencyName() // 'Kyat'
    *
    * @since 2.0.1
    */
@@ -493,7 +493,7 @@ export class FinanceModule extends ModuleBase {
    * Returns a random currency symbol.
    *
    * @example
-   * faker.finance.currencySymbol() // '$'
+   * faker.finance.currencySymbol() // 'руб'
    *
    * @since 2.0.1
    */
@@ -514,9 +514,9 @@ export class FinanceModule extends ModuleBase {
    * @param options.network The bitcoin network (`'mainnet'` or `'testnet'`). Defaults to `'mainnet'`.
    *
    * @example
-   * faker.finance.bitcoinAddress() // '1TeZEFLmGPLEQrSRdAcnZLoWwYeiHwmRog'
-   * faker.finance.bitcoinAddress({ type: 'bech32' }) // 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
-   * faker.finance.bitcoinAddress({ type: 'bech32', network: 'testnet' }) // 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
+   * faker.finance.bitcoinAddress() // 'bc1qmkfngwyetjlx330usvztgs4n5yjf9sgl0mmmyp'
+   * faker.finance.bitcoinAddress({ type: 'bech32' }) // 'bc1dfq2pp75cdlgz476n9g864p57du4u4zgzmr2a4a'
+   * faker.finance.bitcoinAddress({ type: 'bech32', network: 'testnet' }) // 'tb14cf3ql9j4lxcp5qa6l0u0p9ry8lll8ygvqauewl'
    *
    * @since 3.1.0
    */
@@ -557,7 +557,7 @@ export class FinanceModule extends ModuleBase {
    * Generates a random Litecoin address.
    *
    * @example
-   * faker.finance.litecoinAddress() // 'MoQaSTGWBRXkWfyxKbNKuPrAWGELzcW'
+   * faker.finance.litecoinAddress() // '3AxqDrTXoMwyV562QMSYNsM7D9Wwqg'
    *
    * @since 5.0.0
    */
@@ -580,9 +580,9 @@ export class FinanceModule extends ModuleBase {
    * @param issuer The name of the issuer (case-insensitive) or the format used to generate one.
    *
    * @example
-   * faker.finance.creditCardNumber() // '4427163488662'
-   * faker.finance.creditCardNumber('visa') // '4882664999007'
-   * faker.finance.creditCardNumber('63[7-9]#-####-####-###L') // '6375-3265-4676-6646'
+   * faker.finance.creditCardNumber() // '3565-4648-9375-5909'
+   * faker.finance.creditCardNumber('visa') // '4087897471614'
+   * faker.finance.creditCardNumber('63[7-9]#-####-####-###L') // '6395-4274-5066-6966'
    *
    * @since 5.0.0
    */
@@ -594,9 +594,9 @@ export class FinanceModule extends ModuleBase {
    * @param options.issuer The name of the issuer (case-insensitive) or the format used to generate one. Defaults to `''`.
    *
    * @example
-   * faker.finance.creditCardNumber() // '4427163488662'
-   * faker.finance.creditCardNumber({ issuer: 'visa' }) // '4882664999007'
-   * faker.finance.creditCardNumber({ issuer: '63[7-9]#-####-####-###L' }) // '6375-3265-4676-6646'
+   * faker.finance.creditCardNumber() // '3565-4648-9375-5909'
+   * faker.finance.creditCardNumber({ issuer: 'visa' }) // '4087897471614'
+   * faker.finance.creditCardNumber({ issuer: '63[7-9]#-####-####-###L' }) // '6395-4274-5066-6966'
    *
    * @since 5.0.0
    */
@@ -615,10 +615,10 @@ export class FinanceModule extends ModuleBase {
    * @param options.issuer The name of the issuer (case-insensitive) or the format used to generate one. Defaults to `''`.
    *
    * @example
-   * faker.finance.creditCardNumber() // '4427163488662'
-   * faker.finance.creditCardNumber({ issuer: 'visa' }) // '4882664999007'
-   * faker.finance.creditCardNumber({ issuer: '63[7-9]#-####-####-###L' }) // '6375-3265-4676-6646'
-   * faker.finance.creditCardNumber('visa') // '1226423499765'
+   * faker.finance.creditCardNumber() // '3565-4648-9375-5909'
+   * faker.finance.creditCardNumber({ issuer: 'visa' }) // '4087897471614'
+   * faker.finance.creditCardNumber({ issuer: '63[7-9]#-####-####-###L' }) // '6395-4274-5066-6966'
+   * faker.finance.creditCardNumber('visa') // '4460662133547'
    *
    * @since 5.0.0
    */
@@ -689,7 +689,7 @@ export class FinanceModule extends ModuleBase {
    * Generates a random credit card CVV.
    *
    * @example
-   * faker.finance.creditCardCVV() // '506'
+   * faker.finance.creditCardCVV() // '576'
    *
    * @since 5.0.0
    */
@@ -701,7 +701,7 @@ export class FinanceModule extends ModuleBase {
    * Returns a random credit card issuer.
    *
    * @example
-   * faker.finance.creditCardIssuer() // 'discover'
+   * faker.finance.creditCardIssuer() // 'jcb'
    *
    * @since 6.3.0
    */
@@ -719,8 +719,8 @@ export class FinanceModule extends ModuleBase {
    * @throws Will throw an error if length is less than 1.
    *
    * @example
-   * faker.finance.pin() // '5067'
-   * faker.finance.pin(6) // '213789'
+   * faker.finance.pin() // '5765'
+   * faker.finance.pin(6) // '464893'
    *
    * @since 6.2.0
    */
@@ -734,8 +734,8 @@ export class FinanceModule extends ModuleBase {
    * @throws Will throw an error if length is less than 1.
    *
    * @example
-   * faker.finance.pin() // '5067'
-   * faker.finance.pin({ length: 6 }) // '213789'
+   * faker.finance.pin() // '5765'
+   * faker.finance.pin({ length: 6 }) // '464893'
    *
    * @since 6.2.0
    */
@@ -756,9 +756,9 @@ export class FinanceModule extends ModuleBase {
    * @throws Will throw an error if length is less than 1.
    *
    * @example
-   * faker.finance.pin() // '5067'
-   * faker.finance.pin({ length: 6 }) // '213789'
-   * faker.finance.pin(6) // '213789'
+   * faker.finance.pin() // '5765'
+   * faker.finance.pin({ length: 6 }) // '464893'
+   * faker.finance.pin(6) // '755900'
    *
    * @since 6.2.0
    */
@@ -820,7 +820,7 @@ export class FinanceModule extends ModuleBase {
    * To generate a checksummed Ethereum address (with specific per character casing), wrap this method in a custom method and use third-party libraries to transform the result.
    *
    * @example
-   * faker.finance.ethereumAddress() // '0xf03dfeecbafc5147241cc4c4ca20b3c9dfd04c4a'
+   * faker.finance.ethereumAddress() // '0xcfdb9e9df8bbce110cbdfbab2e3eb95bac0dddef'
    *
    * @since 5.0.0
    */
@@ -844,9 +844,9 @@ export class FinanceModule extends ModuleBase {
    * @throws Will throw an error if the passed country code is not supported.
    *
    * @example
-   * faker.finance.iban() // 'TR736918640040966092800056'
-   * faker.finance.iban({ formatted: true }) // 'FR20 8008 2330 8984 74S3 Z620 224'
-   * faker.finance.iban({ formatted: true, countryCode: 'DE' }) // 'DE84 1022 7075 0900 1170 01'
+   * faker.finance.iban() // 'LI256448975B0UZ411N24'
+   * faker.finance.iban({ formatted: true }) // 'LT33 0696 3607 0035 9002'
+   * faker.finance.iban({ formatted: true, countryCode: 'DE' }) // 'DE25 2200 6004 0046 0003 13'
    *
    * @since 4.0.0
    */
@@ -928,9 +928,9 @@ export class FinanceModule extends ModuleBase {
    * @param options.includeBranchCode Whether to include a three-digit branch code at the end of the generated code. Defaults to a random boolean value.
    *
    * @example
-   * faker.finance.bic() // 'WYAUPGX1'
-   * faker.finance.bic({ includeBranchCode: true }) // 'KCAUPGR1432'
-   * faker.finance.bic({ includeBranchCode: false }) // 'XDAFQGT7'
+   * faker.finance.bic() // 'SPOLNEFW'
+   * faker.finance.bic({ includeBranchCode: true }) // 'ZJUNMHX20TS'
+   * faker.finance.bic({ includeBranchCode: false }) // 'WZULSD4N'
    *
    * @since 4.0.0
    */
@@ -968,8 +968,7 @@ export class FinanceModule extends ModuleBase {
    * Generates a random transaction description.
    *
    * @example
-   * faker.finance.transactionDescription()
-   * // 'payment transaction at Emard LLC using card ending with ****9187 for HNL 506.57 in account ***2584.'
+   * faker.finance.transactionDescription() // 'payment at Little Inc with a card ending in ****6489 for INR 791.73 from account ***5590.'
    *
    * @since 5.1.0
    */

--- a/src/modules/food/index.ts
+++ b/src/modules/food/index.ts
@@ -26,7 +26,7 @@ export class FoodModule extends ModuleBase {
    * Generates a random dish adjective.
    *
    * @example
-   * faker.food.adjective() // 'crispy'
+   * faker.food.adjective() // 'rich'
    *
    * @since 9.0.0
    */
@@ -40,7 +40,7 @@ export class FoodModule extends ModuleBase {
    * Generates a random dish description.
    *
    * @example
-   * faker.food.description() // 'An exquisite ostrich roast, infused with the essence of longan, slow-roasted to bring out its natural flavors and served with a side of creamy red cabbage'
+   * faker.food.description() // 'Fresh mixed greens tossed with mace-rubbed kangaroo, english spinach, and a light dressing.'
    *
    * @since 9.0.0
    */
@@ -54,7 +54,7 @@ export class FoodModule extends ModuleBase {
    * Generates a random dish name.
    *
    * @example
-   * faker.food.dish() // 'Tagine-Rubbed Venison Salad'
+   * faker.food.dish() // 'Pork Sausage Roll'
    *
    * @since 9.0.0
    */
@@ -75,7 +75,7 @@ export class FoodModule extends ModuleBase {
    * Generates a random food's ethnic category.
    *
    * @example
-   * faker.food.ethnicCategory() // 'Italian'
+   * faker.food.ethnicCategory() // 'Lebanese'
    *
    * @since 9.0.0
    */
@@ -101,7 +101,7 @@ export class FoodModule extends ModuleBase {
    * Generates a random ingredient name.
    *
    * @example
-   * faker.food.ingredient() // 'butter'
+   * faker.food.ingredient() // 'mahlab'
    *
    * @since 9.0.0
    */
@@ -115,7 +115,7 @@ export class FoodModule extends ModuleBase {
    * Generates a random meat
    *
    * @example
-   * faker.food.meat() // 'venison'
+   * faker.food.meat() // 'ostrich'
    *
    * @since 9.0.0
    */
@@ -127,7 +127,7 @@ export class FoodModule extends ModuleBase {
    * Generates a random spice name.
    *
    * @example
-   * faker.food.spice() // 'chilli'
+   * faker.food.spice() // 'korma'
    *
    * @since 9.0.0
    */
@@ -139,7 +139,7 @@ export class FoodModule extends ModuleBase {
    * Generates a random vegetable name.
    *
    * @example
-   * faker.food.vegetable() // 'broccoli'
+   * faker.food.vegetable() // 'iceberg lettuce'
    *
    * @since 9.0.0
    */

--- a/src/modules/git/index.ts
+++ b/src/modules/git/index.ts
@@ -14,7 +14,7 @@ export class GitModule extends ModuleBase {
    * Generates a random branch name.
    *
    * @example
-   * faker.git.branch() // 'feed-parse'
+   * faker.git.branch() // 'matrix-parse'
    *
    * @since 5.0.0
    */
@@ -36,11 +36,12 @@ export class GitModule extends ModuleBase {
    *
    * @example
    * faker.git.commitEntry()
-   * // commit fe8c38a965d13d9794eb36918cb24cebe49a45c2
-   * // Author: Marion Becker <Marion_Becker49@gmail.com>
-   * // Date: Mon Nov 7 05:38:37 2022 -0600
-   * //
-   * //     generate open-source system
+   * // 'commit fdb9e9df8bbce110cbdfbab2e3eb95bac0dddef7
+   * // Author: Humberto Beier &lt;Humberto.Beier98@yahoo.com>
+   * // Date: Tue Dec 31 04:00:46 2024 -0800
+   * // 
+   * //     override cross-platform hard drive
+   * // '
    *
    * @since 5.0.0
    */
@@ -114,7 +115,7 @@ export class GitModule extends ModuleBase {
    * Generates a random commit message.
    *
    * @example
-   * faker.git.commitMessage() // 'reboot cross-platform driver'
+   * faker.git.commitMessage() // 'input optical microchip'
    *
    * @since 5.0.0
    */
@@ -129,8 +130,8 @@ export class GitModule extends ModuleBase {
    * @param options.refDate The date to use as reference point for the commit. Defaults to `faker.defaultRefDate()`.
    *
    * @example
-   * faker.git.commitDate() // 'Mon Nov 7 14:40:58 2022 +0600'
-   * faker.git.commitDate({ refDate: '2020-01-01' }) // 'Tue Dec 31 05:40:59 2019 -0400'
+   * faker.git.commitDate() // 'Tue Dec 31 12:10:16 2024 +0600'
+   * faker.git.commitDate({ refDate: '2020-01-01' }) // 'Tue Dec 31 14:27:58 2019 +0200'
    *
    * @since 8.0.0
    */
@@ -194,9 +195,9 @@ export class GitModule extends ModuleBase {
    * @param options.length The length of the commit sha. Defaults to `40`.
    *
    * @example
-   * faker.git.commitSha() // '2c6e3880fd94ddb7ef72d34e683cdc0c47bec6e6'
-   * faker.git.commitSha({ length: 7 }) // 'dbee57b'
-   * faker.git.commitSha({ length: 8 }) // '0e52376a'
+   * faker.git.commitSha() // 'cfdb9e9df8bbce110cbdfbab2e3eb95bac0dddef'
+   * faker.git.commitSha({ length: 7 }) // '79f1ee4'
+   * faker.git.commitSha({ length: 8 }) // '268c9f24'
    *
    * @since 5.0.0
    */

--- a/src/modules/git/index.ts
+++ b/src/modules/git/index.ts
@@ -40,7 +40,7 @@ export class GitModule extends ModuleBase {
    * // Author: Humberto Beier <Humberto.Beier98@yahoo.com>
    * // Date: Tue Dec 31 04:00:46 2024 -0800
    * //
-   * //     override cross-platform hard drive
+   * //     override cross-platform hard drive
    * // '
    *
    * @since 5.0.0

--- a/src/modules/git/index.ts
+++ b/src/modules/git/index.ts
@@ -37,7 +37,7 @@ export class GitModule extends ModuleBase {
    * @example
    * faker.git.commitEntry()
    * // 'commit fdb9e9df8bbce110cbdfbab2e3eb95bac0dddef7
-   * // Author: Humberto Beier &lt;Humberto.Beier98@yahoo.com>
+   * // Author: Humberto Beier <Humberto.Beier98@yahoo.com>
    * // Date: Tue Dec 31 04:00:46 2024 -0800
    * //
    * //     override cross-platform hard drive

--- a/src/modules/git/index.ts
+++ b/src/modules/git/index.ts
@@ -39,7 +39,7 @@ export class GitModule extends ModuleBase {
    * // 'commit fdb9e9df8bbce110cbdfbab2e3eb95bac0dddef7
    * // Author: Humberto Beier &lt;Humberto.Beier98@yahoo.com>
    * // Date: Tue Dec 31 04:00:46 2024 -0800
-   * // 
+   * //
    * //     override cross-platform hard drive
    * // '
    *

--- a/src/modules/hacker/index.ts
+++ b/src/modules/hacker/index.ts
@@ -20,7 +20,7 @@ export class HackerModule extends ModuleBase {
    * Returns a random hacker/IT abbreviation.
    *
    * @example
-   * faker.hacker.abbreviation() // 'THX'
+   * faker.hacker.abbreviation() // 'RAM'
    *
    * @since 2.0.1
    */
@@ -34,7 +34,7 @@ export class HackerModule extends ModuleBase {
    * Returns a random hacker/IT adjective.
    *
    * @example
-   * faker.hacker.adjective() // 'cross-platform'
+   * faker.hacker.adjective() // 'neural'
    *
    * @since 2.0.1
    */
@@ -48,7 +48,7 @@ export class HackerModule extends ModuleBase {
    * Returns a random hacker/IT noun.
    *
    * @example
-   * faker.hacker.noun() // 'system'
+   * faker.hacker.noun() // 'matrix'
    *
    * @since 2.0.1
    */
@@ -60,7 +60,7 @@ export class HackerModule extends ModuleBase {
    * Returns a random hacker/IT verb.
    *
    * @example
-   * faker.hacker.verb() // 'copy'
+   * faker.hacker.verb() // 'input'
    *
    * @since 2.0.1
    */
@@ -72,7 +72,7 @@ export class HackerModule extends ModuleBase {
    * Returns a random hacker/IT verb for continuous actions (en: ing suffix; e.g. hacking).
    *
    * @example
-   * faker.hacker.ingverb() // 'navigating'
+   * faker.hacker.ingverb() // 'indexing'
    *
    * @since 2.0.1
    */
@@ -86,8 +86,7 @@ export class HackerModule extends ModuleBase {
    * Generates a random hacker/IT phrase.
    *
    * @example
-   * faker.hacker.phrase()
-   * // 'If we override the card, we can get to the HDD feed through the back-end HDD sensor!'
+   * faker.hacker.phrase() // 'Use the online SQL firewall, then you can hack the neural monitor!'
    *
    * @since 2.0.1
    */

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -1002,10 +1002,10 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @example
    * enum Color { Red, Green, Blue }
    * faker.helpers.enumValue(Color) // 1
-   * 
+   *
    * enum Direction { North = 'North', South = 'South'}
    * faker.helpers.enumValue(Direction) // 'South'
-   * 
+   *
    * enum HttpStatus { Ok = 200, Created = 201, BadRequest = 400, Unauthorized = 401 }
    * faker.helpers.enumValue(HttpStatus) // 400
    *

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -234,10 +234,10 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @example
    * faker.helpers.replaceSymbols() // ''
-   * faker.helpers.replaceSymbols('#####') // '98441'
-   * faker.helpers.replaceSymbols('?????') // 'ZYRQQ'
-   * faker.helpers.replaceSymbols('*****') // '4Z3P7'
-   * faker.helpers.replaceSymbols('Your pin is: #?*#?*') // 'Your pin is: 0T85L1'
+   * faker.helpers.replaceSymbols('#####') // '57654'
+   * faker.helpers.replaceSymbols('?????') // 'QLXZJ'
+   * faker.helpers.replaceSymbols('*****') // '59CV8'
+   * faker.helpers.replaceSymbols('Your pin is: #?*#?*') // 'Your pin is: 9UU1QY'
    *
    * @since 3.0.0
    */
@@ -299,8 +299,8 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param symbol The symbol to replace with a digit. Defaults to `'#'`.
    *
    * @example
-   * faker.helpers.replaceCreditCardSymbols() // '6453-4876-8626-8995-3771'
-   * faker.helpers.replaceCreditCardSymbols('1234-[4-9]-##!!-L') // '1234-9-5298-2'
+   * faker.helpers.replaceCreditCardSymbols() // '6453-5765-4648-9375-5901'
+   * faker.helpers.replaceCreditCardSymbols('1234-[4-9]-##!!-L') // '1234-4-0888-6'
    *
    * @since 5.0.0
    */
@@ -349,19 +349,19 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @example
    * faker.helpers.fromRegExp('#{5}') // '#####'
-   * faker.helpers.fromRegExp('#{2,9}') // '#######'
-   * faker.helpers.fromRegExp('[1-7]') // '5'
-   * faker.helpers.fromRegExp('#{3}test[1-5]') // '###test3'
-   * faker.helpers.fromRegExp('[0-9a-dmno]') // '5'
+   * faker.helpers.fromRegExp('#{2,9}') // '######'
+   * faker.helpers.fromRegExp('[1-7]') // '6'
+   * faker.helpers.fromRegExp('#{3}test[1-5]') // '###test4'
+   * faker.helpers.fromRegExp('[0-9a-dmno]') // '9'
    * faker.helpers.fromRegExp('[^a-zA-Z0-8]') // '9'
-   * faker.helpers.fromRegExp('[a-d0-6]{2,8}') // 'a0dc45b0'
-   * faker.helpers.fromRegExp('[-a-z]{5}') // 'a-zab'
-   * faker.helpers.fromRegExp(/[A-Z0-9]{4}-[A-Z0-9]{4}/) // 'BS4G-485H'
-   * faker.helpers.fromRegExp(/[A-Z]{5}/i) // 'pDKfh'
-   * faker.helpers.fromRegExp(/.{5}/) // '14(#B'
+   * faker.helpers.fromRegExp('[a-d0-6]{2,8}') // '3056'
+   * faker.helpers.fromRegExp('[-a-z]{5}') // 'junox'
+   * faker.helpers.fromRegExp(/[A-Z0-9]{4}-[A-Z0-9]{4}/) // 'CDA3-2592'
+   * faker.helpers.fromRegExp(/[A-Z]{5}/i) // 'lUDqd'
+   * faker.helpers.fromRegExp(/.{5}/) // 'WwpgM'
    * faker.helpers.fromRegExp(/Joh?n/) // 'Jon'
    * faker.helpers.fromRegExp(/ABC*DE/) // 'ABDE'
-   * faker.helpers.fromRegExp(/bee+p/) // 'beeeeeeeep'
+   * faker.helpers.fromRegExp(/bee+p/) // 'beep'
    *
    * @since 8.0.0
    */
@@ -577,7 +577,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param options.inplace Whether to shuffle the array in place or return a new array. Defaults to `false`.
    *
    * @example
-   * faker.helpers.shuffle(['a', 'b', 'c'], { inplace: true }) // [ 'b', 'c', 'a' ]
+   * faker.helpers.shuffle(['a', 'b', 'c'], { inplace: true }) // [ 'a', 'c', 'b' ]
    *
    * @since 8.0.0
    */
@@ -602,8 +602,8 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param options.inplace Whether to shuffle the array in place or return a new array. Defaults to `false`.
    *
    * @example
-   * faker.helpers.shuffle(['a', 'b', 'c']) // [ 'b', 'c', 'a' ]
-   * faker.helpers.shuffle(['a', 'b', 'c'], { inplace: false }) // [ 'b', 'c', 'a' ]
+   * faker.helpers.shuffle(['a', 'b', 'c']) // [ 'a', 'c', 'b' ]
+   * faker.helpers.shuffle(['a', 'b', 'c'], { inplace: false }) // [ 'a', 'c', 'b' ]
    *
    * @since 2.0.1
    */
@@ -628,9 +628,9 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param options.inplace Whether to shuffle the array in place or return a new array. Defaults to `false`.
    *
    * @example
-   * faker.helpers.shuffle(['a', 'b', 'c']) // [ 'b', 'c', 'a' ]
-   * faker.helpers.shuffle(['a', 'b', 'c'], { inplace: true }) // [ 'b', 'c', 'a' ]
-   * faker.helpers.shuffle(['a', 'b', 'c'], { inplace: false }) // [ 'b', 'c', 'a' ]
+   * faker.helpers.shuffle(['a', 'b', 'c']) // [ 'a', 'c', 'b' ]
+   * faker.helpers.shuffle(['a', 'b', 'c'], { inplace: true }) // [ 'a', 'c', 'b' ]
+   * faker.helpers.shuffle(['a', 'b', 'c'], { inplace: false }) // [ 'a', 'c', 'b' ]
    *
    * @since 2.0.1
    */
@@ -676,9 +676,9 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param length The number of elements to generate.
    *
    * @example
-   * faker.helpers.uniqueArray(faker.word.sample, 3) // ['mob', 'junior', 'ripe']
-   * faker.helpers.uniqueArray(faker.definitions.person.first_name.generic, 6) // ['Silas', 'Montana', 'Lorenzo', 'Alayna', 'Aditya', 'Antone']
-   * faker.helpers.uniqueArray(["Hello", "World", "Goodbye"], 2) // ['World', 'Goodbye']
+   * faker.helpers.uniqueArray(faker.word.sample, 3) // [ 'jealous', 'valuable', 'wasabi' ]
+   * faker.helpers.uniqueArray(faker.definitions.person.first_name.generic, 6) // [ 'Elaina', 'Oswald', 'Maxime', 'Daren', 'Franz', 'Alisha' ]
+   * faker.helpers.uniqueArray(["Hello", "World", "Goodbye"], 2) // [ 'World', 'Hello' ]
    *
    * @since 6.0.0
    */
@@ -721,7 +721,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * faker.helpers.mustache('I found {{count}} instances of "{{word}}".', {
    *   count: () => `${faker.number.int()}`,
    *   word: "this word",
-   * }) // 'I found 57591 instances of "this word".'
+   * }) // 'I found 4943272583565992 instances of "this word".'
    *
    * @since 2.0.1
    */
@@ -758,7 +758,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param options.probability The probability (`[0.00, 1.00]`) of the callback being invoked. Defaults to `0.5`.
    *
    * @example
-   * faker.helpers.maybe(() => 'Hello World!') // 'Hello World!'
+   * faker.helpers.maybe(() => 'Hello World!') // undefined
    * faker.helpers.maybe(() => 'Hello World!', { probability: 0.1 }) // undefined
    * faker.helpers.maybe(() => 'Hello World!', { probability: 0.9 }) // 'Hello World!'
    *
@@ -830,7 +830,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @throws If the given object is empty.
    *
    * @example
-   * faker.helpers.objectEntry({ Cheetah: 120, Falcon: 390, Snail: 0.03 }) // ['Snail', 0.03]
+   * faker.helpers.objectEntry({ Cheetah: 120, Falcon: 390, Snail: 0.03 }) // [ 'Falcon', 390 ]
    *
    * @since 8.0.0
    */
@@ -881,7 +881,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param array[].value The value to pick.
    *
    * @example
-   * faker.helpers.weightedArrayElement([{ weight: 5, value: 'sunny' }, { weight: 4, value: 'rainy' }, { weight: 1, value: 'snowy' }]) // 'sunny', 50% of the time, 'rainy' 40% of the time, 'snowy' 10% of the time
+   * faker.helpers.weightedArrayElement([{ weight: 5, value: 'sunny' }, { weight: 4, value: 'rainy' }, { weight: 1, value: 'snowy' }]) // 'rainy'
    *
    * @since 8.0.0
    */
@@ -938,9 +938,9 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *    When value exceeds array boundaries, it will be limited to stay inside.
    *
    * @example
-   * faker.helpers.arrayElements(['cat', 'dog', 'mouse']) // ['mouse', 'cat']
-   * faker.helpers.arrayElements([1, 2, 3, 4, 5], 2) // [4, 2]
-   * faker.helpers.arrayElements([1, 2, 3, 4, 5], { min: 2, max: 4 }) // [3, 5, 1]
+   * faker.helpers.arrayElements(['cat', 'dog', 'mouse']) // [ 'dog', 'mouse' ]
+   * faker.helpers.arrayElements([1, 2, 3, 4, 5], 2) // [ 2, 3 ]
+   * faker.helpers.arrayElements([1, 2, 3, 4, 5], { min: 2, max: 4 }) // [ 5, 4, 3 ]
    *
    * @since 6.3.0
    */
@@ -1001,13 +1001,13 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @example
    * enum Color { Red, Green, Blue }
-   * faker.helpers.enumValue(Color) // 1 (Green)
-   *
+   * faker.helpers.enumValue(Color) // 1
+   * 
    * enum Direction { North = 'North', South = 'South'}
    * faker.helpers.enumValue(Direction) // 'South'
-   *
+   * 
    * enum HttpStatus { Ok = 200, Created = 201, BadRequest = 400, Unauthorized = 401 }
-   * faker.helpers.enumValue(HttpStatus) // 200 (Ok)
+   * faker.helpers.enumValue(HttpStatus) // 400
    *
    * @since 8.0.0
    */
@@ -1032,7 +1032,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @example
    * faker.helpers.rangeToNumber(1) // 1
-   * faker.helpers.rangeToNumber({ min: 1, max: 10 }) // 5
+   * faker.helpers.rangeToNumber({ min: 1, max: 10 }) // 6
    *
    * @since 8.0.0
    */
@@ -1068,9 +1068,9 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param options.count The number or range of elements to generate. Defaults to `3`.
    *
    * @example
-   * faker.helpers.multiple(() => faker.person.firstName()) // [ 'Aniya', 'Norval', 'Dallin' ]
-   * faker.helpers.multiple(() => faker.person.firstName(), { count: 3 }) // [ 'Santos', 'Lavinia', 'Lavinia' ]
-   * faker.helpers.multiple((_, i) => `${faker.color.human()}-${i + 1}`) // [ 'orange-1', 'orchid-2', 'sky blue-3' ]
+   * faker.helpers.multiple(() => faker.person.firstName()) // [ 'Katharina', 'Micheal', 'Leda' ]
+   * faker.helpers.multiple(() => faker.person.firstName(), { count: 3 }) // [ 'Karley', 'Henry', 'Luna' ]
+   * faker.helpers.multiple((_, i) => `${faker.color.human()}-${i + 1}`) // [ 'maroon-1', 'turquoise-2', 'white-3' ]
    *
    * @since 8.0.0
    */
@@ -1159,13 +1159,13 @@ export class HelpersModule extends SimpleHelpersModule {
    * @see faker.helpers.mustache(): For using custom functions to resolve templates.
    *
    * @example
-   * faker.helpers.fake('{{person.lastName}}') // 'Barrows'
-   * faker.helpers.fake('{{person.lastName}}, {{person.firstName}} {{person.suffix}}') // 'Durgan, Noe MD'
+   * faker.helpers.fake('{{person.lastName}}') // 'Rau'
+   * faker.helpers.fake('{{person.lastName}}, {{person.firstName}} {{person.suffix}}') // 'Little, Henry III'
    * faker.helpers.fake('This is static test.') // 'This is static test.'
-   * faker.helpers.fake('Good Morning {{person.firstName}}!') // 'Good Morning Estelle!'
-   * faker.helpers.fake('You can visit me at {{location.streetAddress(true)}}.') // 'You can visit me at 3393 Ronny Way Apt. 742.'
+   * faker.helpers.fake('Good Morning {{person.firstName}}!') // 'Good Morning Sim!'
+   * faker.helpers.fake('You can visit me at {{location.streetAddress(true)}}.') // 'You can visit me at 475 Walsh Center Apt. 187.'
    * faker.helpers.fake('I flipped the coin and got: {{helpers.arrayElement(["heads", "tails"])}}') // 'I flipped the coin and got: tails'
-   * faker.helpers.fake('Your PIN number is: {{string.numeric(4, {"exclude": ["0"]})}}') // 'Your PIN number is: 4834'
+   * faker.helpers.fake('Your PIN number is: {{string.numeric(4, {"exclude": ["0"]})}}') // 'Your PIN number is: 9747'
    *
    * @since 7.4.0
    */
@@ -1211,7 +1211,7 @@ export class HelpersModule extends SimpleHelpersModule {
    * @see faker.helpers.mustache(): For using custom functions to resolve templates.
    *
    * @example
-   * faker.helpers.fake(['A: {{person.firstName}}', 'B: {{person.lastName}}']) // 'A: Barry'
+   * faker.helpers.fake(['A: {{person.firstName}}', 'B: {{person.lastName}}']) // 'B: Mitchell'
    *
    * @since 8.0.0
    */
@@ -1254,13 +1254,13 @@ export class HelpersModule extends SimpleHelpersModule {
    * @see faker.helpers.mustache(): For using custom functions to resolve templates.
    *
    * @example
-   * faker.helpers.fake('{{person.lastName}}') // 'Barrows'
-   * faker.helpers.fake('{{person.lastName}}, {{person.firstName}} {{person.suffix}}') // 'Durgan, Noe MD'
+   * faker.helpers.fake('{{person.lastName}}') // 'Rau'
+   * faker.helpers.fake('{{person.lastName}}, {{person.firstName}} {{person.suffix}}') // 'Little, Henry III'
    * faker.helpers.fake('This is static test.') // 'This is static test.'
-   * faker.helpers.fake('Good Morning {{person.firstName}}!') // 'Good Morning Estelle!'
-   * faker.helpers.fake('You can visit me at {{location.streetAddress(true)}}.') // 'You can visit me at 3393 Ronny Way Apt. 742.'
+   * faker.helpers.fake('Good Morning {{person.firstName}}!') // 'Good Morning Sim!'
+   * faker.helpers.fake('You can visit me at {{location.streetAddress(true)}}.') // 'You can visit me at 475 Walsh Center Apt. 187.'
    * faker.helpers.fake('I flipped the coin and got: {{helpers.arrayElement(["heads", "tails"])}}') // 'I flipped the coin and got: tails'
-   * faker.helpers.fake(['A: {{person.firstName}}', 'B: {{person.lastName}}']) // 'A: Barry'
+   * faker.helpers.fake(['A: {{person.firstName}}', 'B: {{person.lastName}}']) // 'B: Koepp'
    *
    * @since 7.4.0
    */

--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -20,8 +20,7 @@ export class ImageModule extends ModuleBase {
    * Generates a random avatar image url.
    *
    * @example
-   * faker.image.avatar()
-   * // 'https://avatars.githubusercontent.com/u/97165289'
+   * faker.image.avatar() // 'https://avatars.githubusercontent.com/u/54881350'
    *
    * @since 2.0.1
    */
@@ -34,8 +33,7 @@ export class ImageModule extends ModuleBase {
    * Generates a random avatar from GitHub.
    *
    * @example
-   * faker.image.avatarGitHub()
-   * // 'https://avatars.githubusercontent.com/u/97165289'
+   * faker.image.avatarGitHub() // 'https://avatars.githubusercontent.com/u/54881350'
    *
    * @since 8.0.0
    */
@@ -49,8 +47,7 @@ export class ImageModule extends ModuleBase {
    * Generates a random avatar from `https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar`.
    *
    * @example
-   * faker.image.avatarLegacy()
-   * // 'https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/170.jpg'
+   * faker.image.avatarLegacy() // 'https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/686.jpg'
    *
    * @since 8.0.0
    *
@@ -77,7 +74,7 @@ export class ImageModule extends ModuleBase {
    * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.
    *
    * @example
-   * faker.image.url() // 'https://loremflickr.com/640/480?lock=1234'
+   * faker.image.url() // 'https://picsum.photos/seed/qErTXnNw/2195/2861'
    *
    * @since 8.0.0
    */
@@ -120,10 +117,10 @@ export class ImageModule extends ModuleBase {
    * @param options.category Category to use for the image.
    *
    * @example
-   * faker.image.urlLoremFlickr() // 'https://loremflickr.com/640/480?lock=1234'
-   * faker.image.urlLoremFlickr({ width: 128 }) // 'https://loremflickr.com/128/480?lock=1234'
-   * faker.image.urlLoremFlickr({ height: 128 }) // 'https://loremflickr.com/640/128?lock=1234'
-   * faker.image.urlLoremFlickr({ category: 'nature' }) // 'https://loremflickr.com/640/480/nature?lock=1234'
+   * faker.image.urlLoremFlickr() // 'https://loremflickr.com/2195/2861?lock=5429209831737675'
+   * faker.image.urlLoremFlickr({ width: 128 }) // 'https://loremflickr.com/128/2179?lock=3815943192872827'
+   * faker.image.urlLoremFlickr({ height: 128 }) // 'https://loremflickr.com/2583/128?lock=3941435203169513'
+   * faker.image.urlLoremFlickr({ category: 'nature' }) // 'https://loremflickr.com/3567/3854/nature?lock=3453734162604299'
    *
    * @since 8.0.0
    */
@@ -168,12 +165,12 @@ export class ImageModule extends ModuleBase {
    * @param options.blur Whether the image should be blurred. `0` disables the blur. Defaults to a random integer between `0` and `10`.
    *
    * @example
-   * faker.image.urlPicsumPhotos() // 'https://picsum.photos/seed/NWbJM2B/640/480'
-   * faker.image.urlPicsumPhotos({ width: 128 }) // 'https://picsum.photos/seed/NWbJM2B/128/480'
-   * faker.image.urlPicsumPhotos({ height: 128 }) // 'https://picsum.photos/seed/NWbJM2B/640/128'
-   * faker.image.urlPicsumPhotos({ grayscale: true }) // 'https://picsum.photos/seed/NWbJM2B/640/480?grayscale'
-   * faker.image.urlPicsumPhotos({ blur: 4 }) // 'https://picsum.photos/seed/NWbJM2B/640/480?blur=4'
-   * faker.image.urlPicsumPhotos({ blur: 4, grayscale: true }) // 'https://picsum.photos/seed/NWbJM2B/640/480?grayscale&blur=4'
+   * faker.image.urlPicsumPhotos() // 'https://picsum.photos/seed/ErTXnNw/2195/2861?blur=5'
+   * faker.image.urlPicsumPhotos({ width: 128 }) // 'https://picsum.photos/seed/1PMRY/128/2272'
+   * faker.image.urlPicsumPhotos({ height: 128 }) // 'https://picsum.photos/seed/D8Wwp/3196/128?grayscale&blur=8'
+   * faker.image.urlPicsumPhotos({ grayscale: true }) // 'https://picsum.photos/seed/1CBCWGmr/1058/3097?grayscale&blur=5'
+   * faker.image.urlPicsumPhotos({ blur: 4 }) // 'https://picsum.photos/seed/d7jmzrZ6c/2790/241?blur=4'
+   * faker.image.urlPicsumPhotos({ blur: 4, grayscale: true }) // 'https://picsum.photos/seed/sf96E8/646/2612?grayscale&blur=4'
    *
    * @since 8.0.0
    */
@@ -249,14 +246,14 @@ export class ImageModule extends ModuleBase {
    * @param options.text The text to display on the image. Defaults to a random string.
    *
    * @example
-   * faker.image.urlPlaceholder() // 'https://via.placeholder.com/150x180/FF0000/FFFFFF.webp?text=lorem'
-   * faker.image.urlPlaceholder({ width: 128 }) // 'https://via.placeholder.com/128x180/FF0000/FFFFFF.webp?text=lorem'
-   * faker.image.urlPlaceholder({ height: 128 }) // 'https://via.placeholder.com/150x128/FF0000/FFFFFF.webp?text=lorem'
-   * faker.image.urlPlaceholder({ backgroundColor: '000000' }) // 'https://via.placeholder.com/150x180/000000/FFFFFF.webp?text=lorem'
-   * faker.image.urlPlaceholder({ textColor: '000000' }) // 'https://via.placeholder.com/150x180/FF0000/000000.webp?text=lorem'
-   * faker.image.urlPlaceholder({ format: 'png' }) // 'https://via.placeholder.com/150x180/FF0000/FFFFFF.png?text=lorem'
-   * faker.image.urlPlaceholder({ text: 'lorem ipsum' }) // 'https://via.placeholder.com/150x180/FF0000/FFFFFF.webp?text=lorem+ipsum'
-   * faker.image.urlPlaceholder({ width: 128, height: 128, backgroundColor: '000000', textColor: 'FF0000', format: 'png', text: 'lorem ipsum' }) // 'https://via.placeholder.com/128x128/000000/FF0000.png?text=lorem+ipsum'
+   * faker.image.urlPlaceholder() // 'https://via.placeholder.com/1921x2504/db9e9d/f8bbce.gif?text=alias%20accusator%20tristis'
+   * faker.image.urlPlaceholder({ width: 128 }) // 'https://via.placeholder.com/128x2724/dfbab2/e3eb95.png?text=defleo%20minus%20accusamus'
+   * faker.image.urlPlaceholder({ height: 128 }) // 'https://via.placeholder.com/2162x128/ddef79/f1ee42.jpeg?text=convoco%20molestiae%20decens'
+   * faker.image.urlPlaceholder({ backgroundColor: '000000' }) // 'https://via.placeholder.com/3460x358/000000/43e5a5.gif?text=amor%20sollicito%20aptus'
+   * faker.image.urlPlaceholder({ textColor: '000000' }) // 'https://via.placeholder.com/689x1291/c2c2fa/000000.webp?text=pecco%20tactus%20adflicto'
+   * faker.image.urlPlaceholder({ format: 'png' }) // 'https://via.placeholder.com/990x421/62691f/c5b2ce.png?text=comis%20sopor%20apostolus'
+   * faker.image.urlPlaceholder({ text: 'lorem ipsum' }) // 'https://via.placeholder.com/2508x1013/4c0c0e/5af5cd.jpg?text=lorem%20ipsum'
+   * faker.image.urlPlaceholder({ width: 128, height: 128, backgroundColor: '000000', textColor: 'FF0000', format: 'png', text: 'lorem ipsum' }) // 'https://via.placeholder.com/128x128/000000/FF0000.png?text=lorem%20ipsum'
    *
    * @since 8.0.0
    *
@@ -349,8 +346,8 @@ export class ImageModule extends ModuleBase {
    * @param options.type The type of the image. Defaults to a random type.
    *
    * @example
-   * faker.image.dataUri() // 'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http...'
-   * faker.image.dataUri({ type: 'svg-base64' }) // 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3...'
+   * faker.image.dataUri() // 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgYmFzZVByb2ZpbGU9ImZ1bGwiIHdpZHRoPSIyMTk1IiBoZWlnaHQ9IjI4NjEiPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9IiNkYjllOWQiLz48dGV4dCB4PSIxMDk3LjUiIHk9IjE0MzAuNSIgZm9udC1zaXplPSIyMCIgYWxpZ25tZW50LWJhc2VsaW5lPSJtaWRkbGUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZpbGw9IndoaXRlIj4yMTk1eDI4NjE8L3RleHQ+PC9zdmc+'
+   * faker.image.dataUri({ type: 'svg-base64' }) // 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgYmFzZVByb2ZpbGU9ImZ1bGwiIHdpZHRoPSIxNTM0IiBoZWlnaHQ9IjMxNjciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9IiNiY2UxMTAiLz48dGV4dCB4PSI3NjciIHk9IjE1ODMuNSIgZm9udC1zaXplPSIyMCIgYWxpZ25tZW50LWJhc2VsaW5lPSJtaWRkbGUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZpbGw9IndoaXRlIj4xNTM0eDMxNjc8L3RleHQ+PC9zdmc+'
    *
    * @since 4.0.0
    */

--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -171,12 +171,12 @@ export class InternetModule extends ModuleBase {
    * in the email address. Defaults to `false`.
    *
    * @example
-   * faker.internet.email() // 'Kassandra4@hotmail.com'
-   * faker.internet.email({ firstName: 'Jeanne'}) // 'Jeanne63@yahoo.com'
-   * faker.internet.email({ firstName: 'Jeanne'}) // 'Jeanne_Smith63@yahoo.com'
-   * faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne.Doe63@yahoo.com'
-   * faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe', provider: 'example.fakerjs.dev' }) // 'Jeanne_Doe88@example.fakerjs.dev'
-   * faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe', provider: 'example.fakerjs.dev', allowSpecialCharacters: true }) // 'Jeanne%Doe88@example.fakerjs.dev'
+   * faker.internet.email() // 'Micheal.Little@yahoo.com'
+   * faker.internet.email({ firstName: 'Jeanne'}) // 'Jeanne56@hotmail.com'
+   * faker.internet.email({ firstName: 'Jeanne'}) // 'Jeanne77@gmail.com'
+   * faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne_Doe@hotmail.com'
+   * faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe', provider: 'example.fakerjs.dev' }) // 'Jeanne.Doe63@example.fakerjs.dev'
+   * faker.internet.email({ firstName: 'Jeanne', lastName: 'Doe', provider: 'example.fakerjs.dev', allowSpecialCharacters: true }) // 'Jeanne_Doe52@example.fakerjs.dev'
    *
    * @since 2.0.1
    */
@@ -252,11 +252,11 @@ export class InternetModule extends ModuleBase {
    * in the email address. Defaults to `false`.
    *
    * @example
-   * faker.internet.exampleEmail() // 'Helmer.Graham23@example.com'
-   * faker.internet.exampleEmail({ firstName: 'Jeanne' }) // 'Jeanne96@example.net'
-   * faker.internet.exampleEmail({ firstName: 'Jeanne' }) // 'Jeanne.Smith96@example.net'
-   * faker.internet.exampleEmail({ firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne_Doe96@example.net'
-   * faker.internet.exampleEmail({ firstName: 'Jeanne', lastName: 'Doe', allowSpecialCharacters: true }) // 'Jeanne%Doe88@example.com'
+   * faker.internet.exampleEmail() // 'Micheal.Little@example.com'
+   * faker.internet.exampleEmail({ firstName: 'Jeanne' }) // 'Jeanne56@example.net'
+   * faker.internet.exampleEmail({ firstName: 'Jeanne' }) // 'Jeanne77@example.org'
+   * faker.internet.exampleEmail({ firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne_Doe@example.net'
+   * faker.internet.exampleEmail({ firstName: 'Jeanne', lastName: 'Doe', allowSpecialCharacters: true }) // 'Jeanne+Doe@example.org'
    *
    * @since 3.1.0
    */
@@ -309,14 +309,14 @@ export class InternetModule extends ModuleBase {
    * @see faker.internet.displayName(): For generating an Unicode display name.
    *
    * @example
-   * faker.internet.userName() // 'Nettie_Zboncak40'
-   * faker.internet.userName({ firstName: 'Jeanne' }) // 'Jeanne98'
-   * faker.internet.userName({ firstName: 'Jeanne' }) // 'Jeanne.Smith98'
-   * faker.internet.userName({ firstName: 'Jeanne', lastName: 'Doe'}) // 'Jeanne_Doe98'
-   * faker.internet.userName({ firstName: 'John', lastName: 'Doe' }) // 'John.Doe'
-   * faker.internet.userName({ firstName: 'Hélene', lastName: 'Müller' }) // 'Helene_Muller11'
-   * faker.internet.userName({ firstName: 'Фёдор', lastName: 'Достоевский' }) // 'Fedor.Dostoevskii50'
-   * faker.internet.userName({ firstName: '大羽', lastName: '陳' }) // 'hlzp8d.tpv45' - note neither name is used
+   * faker.internet.userName() // 'Katharina_Mitchell'
+   * faker.internet.userName({ firstName: 'Jeanne' }) // 'Jeanne38'
+   * faker.internet.userName({ firstName: 'Jeanne' }) // 'Jeanne_Mante7'
+   * faker.internet.userName({ firstName: 'Jeanne', lastName: 'Doe'}) // 'Jeanne.Doe'
+   * faker.internet.userName({ firstName: 'John', lastName: 'Doe' }) // 'John_Doe'
+   * faker.internet.userName({ firstName: 'Hélene', lastName: 'Müller' }) // 'Helene.Muller78'
+   * faker.internet.userName({ firstName: 'Фёдор', lastName: 'Достоевский' }) // 'Fedor_Dostoevskii'
+   * faker.internet.userName({ firstName: '大羽', lastName: '陳' }) // 'hlzp8d_tpv41'
    *
    * @since 2.0.1
    *
@@ -361,14 +361,14 @@ export class InternetModule extends ModuleBase {
    * @see faker.internet.displayName(): For generating an Unicode display name.
    *
    * @example
-   * faker.internet.username() // 'Nettie_Zboncak40'
-   * faker.internet.username({ firstName: 'Jeanne' }) // 'Jeanne98'
-   * faker.internet.username({ firstName: 'Jeanne' }) // 'Jeanne.Smith98'
-   * faker.internet.username({ firstName: 'Jeanne', lastName: 'Doe'}) // 'Jeanne_Doe98'
-   * faker.internet.username({ firstName: 'John', lastName: 'Doe' }) // 'John.Doe'
-   * faker.internet.username({ firstName: 'Hélene', lastName: 'Müller' }) // 'Helene_Muller11'
-   * faker.internet.username({ firstName: 'Фёдор', lastName: 'Достоевский' }) // 'Fedor.Dostoevskii50'
-   * faker.internet.username({ firstName: '大羽', lastName: '陳' }) // 'hlzp8d.tpv45' - note neither name is used
+   * faker.internet.username() // 'Katharina_Mitchell'
+   * faker.internet.username({ firstName: 'Jeanne' }) // 'Jeanne38'
+   * faker.internet.username({ firstName: 'Jeanne' }) // 'Jeanne_Mante7'
+   * faker.internet.username({ firstName: 'Jeanne', lastName: 'Doe'}) // 'Jeanne.Doe'
+   * faker.internet.username({ firstName: 'John', lastName: 'Doe' }) // 'John_Doe'
+   * faker.internet.username({ firstName: 'Hélene', lastName: 'Müller' }) // 'Helene.Muller78'
+   * faker.internet.username({ firstName: 'Фёдор', lastName: 'Достоевский' }) // 'Fedor_Dostoevskii'
+   * faker.internet.username({ firstName: '大羽', lastName: '陳' }) // 'hlzp8d_tpv41'
    *
    * @since 9.1.0
    */
@@ -449,12 +449,12 @@ export class InternetModule extends ModuleBase {
    * @see faker.internet.username(): For generating a plain ASCII username.
    *
    * @example
-   * faker.internet.displayName() // 'Nettie_Zboncak40'
-   * faker.internet.displayName({ firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne98' - note surname not used.
+   * faker.internet.displayName() // 'Katharina_Mitchell'
+   * faker.internet.displayName({ firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne.Doe89'
    * faker.internet.displayName({ firstName: 'John', lastName: 'Doe' }) // 'John.Doe'
-   * faker.internet.displayName({ firstName: 'Hélene', lastName: 'Müller' }) // 'Hélene_Müller11'
-   * faker.internet.displayName({ firstName: 'Фёдор', lastName: 'Достоевский' }) // 'Фёдор.Достоевский50'
-   * faker.internet.displayName({ firstName: '大羽', lastName: '陳' }) // '大羽.陳'
+   * faker.internet.displayName({ firstName: 'Hélene', lastName: 'Müller' }) // 'Hélene92'
+   * faker.internet.displayName({ firstName: 'Фёдор', lastName: 'Достоевский' }) // 'Фёдор.Достоевский2'
+   * faker.internet.displayName({ firstName: '大羽', lastName: '陳' }) // '大羽_陳87'
    *
    * @since 8.0.0
    */
@@ -497,7 +497,7 @@ export class InternetModule extends ModuleBase {
    * Returns a random web protocol. Either `http` or `https`.
    *
    * @example
-   * faker.internet.protocol() // 'http'
+   * faker.internet.protocol() // 'https'
    *
    * @since 2.1.5
    */
@@ -518,7 +518,7 @@ export class InternetModule extends ModuleBase {
    * - `PATCH`
    *
    * @example
-   * faker.internet.httpMethod() // 'PATCH'
+   * faker.internet.httpMethod() // 'PUT'
    *
    * @since 5.4.0
    */
@@ -540,8 +540,8 @@ export class InternetModule extends ModuleBase {
    * @param options.types A list of the HTTP status code types that should be used.
    *
    * @example
-   * faker.internet.httpStatusCode() // 200
-   * faker.internet.httpStatusCode({ types: ['success', 'serverError'] }) // 500
+   * faker.internet.httpStatusCode() // 306
+   * faker.internet.httpStatusCode({ types: ['success', 'serverError'] }) // 505
    *
    * @since 7.0.0
    */
@@ -574,9 +574,9 @@ export class InternetModule extends ModuleBase {
    * @param options.protocol The protocol to use. Defaults to `'https'`.
    *
    * @example
-   * faker.internet.url() // 'https://remarkable-hackwork.info'
-   * faker.internet.url({ appendSlash: true }) // 'https://slow-timer.info/'
-   * faker.internet.url({ protocol: 'http', appendSlash: false }) // 'http://www.terrible-idea.com'
+   * faker.internet.url() // 'https://second-newsletter.name'
+   * faker.internet.url({ appendSlash: true }) // 'https://insignificant-parsnip.info/'
+   * faker.internet.url({ protocol: 'http', appendSlash: false }) // 'http://unique-veto.info'
    *
    * @since 2.1.5
    */
@@ -605,7 +605,7 @@ export class InternetModule extends ModuleBase {
    * Generates a random domain name.
    *
    * @example
-   * faker.internet.domainName() // 'slow-timer.info'
+   * faker.internet.domainName() // 'negligible-provider.name'
    *
    * @since 2.0.1
    */
@@ -617,8 +617,8 @@ export class InternetModule extends ModuleBase {
    * Returns a random domain suffix.
    *
    * @example
-   * faker.internet.domainSuffix() // 'com'
    * faker.internet.domainSuffix() // 'name'
+   * faker.internet.domainSuffix() // 'net'
    *
    * @since 2.0.1
    */
@@ -632,8 +632,8 @@ export class InternetModule extends ModuleBase {
    * Generates a random domain word.
    *
    * @example
-   * faker.internet.domainWord() // 'close-reality'
-   * faker.internet.domainWord() // 'weird-cytoplasm'
+   * faker.internet.domainWord() // 'negligible-provider'
+   * faker.internet.domainWord() // 'perky-making'
    *
    * @since 2.0.1
    */
@@ -653,8 +653,8 @@ export class InternetModule extends ModuleBase {
    * Generates a random IPv4 or IPv6 address.
    *
    * @example
-   * faker.internet.ip() // '245.108.222.0'
-   * faker.internet.ip() // '4e5:f9c5:4337:abfd:9caf:1135:41ad:d8d3'
+   * faker.internet.ip() // 'fdb9:e9df:8bbc:e110:cbdf:bab2:e3eb:95ba'
+   * faker.internet.ip() // '0ddd:ef79:f1ee:4268:c9f2:43e5:a532:e348'
    *
    * @since 2.0.1
    */
@@ -669,8 +669,8 @@ export class InternetModule extends ModuleBase {
    * @param options.cidrBlock The optional CIDR block to use. Must be in the format `x.x.x.x/y`. Defaults to `'0.0.0.0/0'`.
    *
    * @example
-   * faker.internet.ipv4() // '245.108.222.0'
-   * faker.internet.ipv4({ cidrBlock: '192.168.0.0/16' }) // '192.168.215.224'
+   * faker.internet.ipv4() // '140.127.10.178'
+   * faker.internet.ipv4({ cidrBlock: '192.168.0.0/16' }) // '192.168.183.22'
    *
    * @since 6.1.1
    */
@@ -689,8 +689,8 @@ export class InternetModule extends ModuleBase {
    * @param options.network The optional network to use. This is intended as an alias for well-known `cidrBlock`s. Defaults to `'any'`.
    *
    * @example
-   * faker.internet.ipv4() // '245.108.222.0'
-   * faker.internet.ipv4({ network: 'private-a' }) // '10.199.154.205'
+   * faker.internet.ipv4() // '140.127.10.178'
+   * faker.internet.ipv4({ network: 'private-a' }) // '10.183.22.166'
    *
    * @since 6.1.1
    */
@@ -710,9 +710,9 @@ export class InternetModule extends ModuleBase {
    * @param options.network The optional network to use. This is intended as an alias for well-known `cidrBlock`s. Defaults to `'any'`.
    *
    * @example
-   * faker.internet.ipv4() // '245.108.222.0'
-   * faker.internet.ipv4({ cidrBlock: '192.168.0.0/16' }) // '192.168.215.224'
-   * faker.internet.ipv4({ network: 'private-a' }) // '10.199.154.205'
+   * faker.internet.ipv4() // '140.127.10.178'
+   * faker.internet.ipv4({ cidrBlock: '192.168.0.0/16' }) // '192.168.183.22'
+   * faker.internet.ipv4({ network: 'private-a' }) // '10.154.78.179'
    *
    * @since 6.1.1
    */
@@ -765,7 +765,7 @@ export class InternetModule extends ModuleBase {
    * Generates a random IPv6 address.
    *
    * @example
-   * faker.internet.ipv6() // '269f:1230:73e3:318d:842b:daab:326d:897b'
+   * faker.internet.ipv6() // 'cfdb:9e9d:f8bb:ce11:0cbd:fbab:2e3e:b95b'
    *
    * @since 4.0.0
    */
@@ -783,7 +783,7 @@ export class InternetModule extends ModuleBase {
    * Generates a random port number.
    *
    * @example
-   * faker.internet.port() // 9414
+   * faker.internet.port() // 35967
    *
    * @since 5.4.0
    */
@@ -795,8 +795,7 @@ export class InternetModule extends ModuleBase {
    * Generates a random user agent string.
    *
    * @example
-   * faker.internet.userAgent()
-   * // 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_1 like Mac OS X) AppleWebKit/537.19.86 (KHTML, like Gecko) Version/18_3 Mobile/15E148 Safari/598.43'
+   * faker.internet.userAgent() // 'Mozilla/5.0 (X11; Linux x86_64; rv:117.0) Gecko/20100101 Firefox/110.0'
    *
    * @since 2.0.1
    */
@@ -818,8 +817,8 @@ export class InternetModule extends ModuleBase {
    * @param options.blueBase The optional base blue in range between `0` and `255`. Defaults to `0`.
    *
    * @example
-   * faker.internet.color() // '#30686e'
-   * faker.internet.color({ redBase: 100, greenBase: 100, blueBase: 100 }) // '#4e5f8b'
+   * faker.internet.color() // '#465b4d'
+   * faker.internet.color({ redBase: 100, greenBase: 100, blueBase: 100 }) // '#786884'
    *
    * @since 2.0.1
    */
@@ -861,7 +860,7 @@ export class InternetModule extends ModuleBase {
    * @param separator The optional separator to use. Can be either `':'`, `'-'` or `''`. Defaults to `':'`.
    *
    * @example
-   * faker.internet.mac() // '32:8e:2e:09:c6:05'
+   * faker.internet.mac() // '8b:98:6a:7e:f6:c8'
    *
    * @since 3.0.0
    */
@@ -879,7 +878,7 @@ export class InternetModule extends ModuleBase {
    * @param separator The optional separator to use. Can be either `':'`, `'-'` or `''`. Defaults to `':'`.
    *
    * @example
-   * faker.internet.mac() // '32:8e:2e:09:c6:05'
+   * faker.internet.mac() // '8b:98:6a:7e:f6:c8'
    *
    * @since 3.0.0
    */
@@ -891,7 +890,7 @@ export class InternetModule extends ModuleBase {
    * @param separator The optional separator to use. Can be either `':'`, `'-'` or `''`. Defaults to `':'`.
    *
    * @example
-   * faker.internet.mac() // '32:8e:2e:09:c6:05'
+   * faker.internet.mac() // '8b:98:6a:7e:f6:c8'
    *
    * @since 3.0.0
    */
@@ -955,11 +954,11 @@ export class InternetModule extends ModuleBase {
    * @param options.prefix The prefix to use. Defaults to `''`.
    *
    * @example
-   * faker.internet.password() // '89G1wJuBLbGziIs'
-   * faker.internet.password({ length: 20 }) // 'aF55c_8O9kZaPOrysFB_'
-   * faker.internet.password({ length: 20, memorable: true }) // 'lawetimufozujosodedi'
-   * faker.internet.password({ length: 20, memorable: true, pattern: /[A-Z]/ }) // 'HMAQDFFYLDDUTBKVNFVS'
-   * faker.internet.password({ length: 20, memorable: true, pattern: /[A-Z]/, prefix: 'Hello ' }) // 'Hello IREOXTDWPERQSB'
+   * faker.internet.password() // 'UdZTIJuElSVxpjs'
+   * faker.internet.password({ length: 20 }) // 'lLkzRHjLWzaCJc4CWJ40'
+   * faker.internet.password({ length: 20, memorable: true }) // 'mexofepiziwivumesayo'
+   * faker.internet.password({ length: 20, memorable: true, pattern: /[A-Z]/ }) // 'jalixosidefobihuxota'
+   * faker.internet.password({ length: 20, memorable: true, pattern: /[A-Z]/, prefix: 'Hello ' }) // 'Hello zanoqejuraceki'
    *
    * @since 2.0.1
    */
@@ -1043,8 +1042,8 @@ export class InternetModule extends ModuleBase {
    * @param options.types A list of the emoji types that should be included. Possible values are `'smiley'`, `'body'`, `'person'`, `'nature'`, `'food'`, `'travel'`, `'activity'`, `'object'`, `'symbol'`, `'flag'`. By default, emojis from any type will be included.
    *
    * @example
-   * faker.internet.emoji() // '🥰'
-   * faker.internet.emoji({ types: ['food', 'nature'] }) // '🥐'
+   * faker.internet.emoji() // '🕟'
+   * faker.internet.emoji({ types: ['food', 'nature'] }) // '🦉'
    *
    * @since 6.2.0
    */
@@ -1073,8 +1072,8 @@ export class InternetModule extends ModuleBase {
    * @see faker.internet.jwt(): For generating random JWT (JSON Web Token).
    *
    * @example
-   * faker.internet.jwtAlgorithm() // 'HS256'
-   * faker.internet.jwtAlgorithm() // 'RS512'
+   * faker.internet.jwtAlgorithm() // 'ES384'
+   * faker.internet.jwtAlgorithm() // 'PS256'
    *
    * @since 9.1.0
    */
@@ -1098,10 +1097,10 @@ export class InternetModule extends ModuleBase {
    * @see faker.internet.jwtAlgorithm(): For generating random JWT (JSON Web Token) Algorithm.
    *
    * @example
-   * faker.internet.jwt() // 'eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MzI2MzgxMDYsImV4cCI6MTczMjY5MjUwOSwibmJmIjoxNzA1MDgxNjQ4LCJpc3MiOiJHdXRrb3dza2kgYW5kIFNvbnMiLCJzdWIiOiJlMzQxZjMwNS0yM2I2LTRkYmQtOTY2ZC1iNDRiZmM0ZGIzMGUiLCJhdWQiOiI0YzMwZGE3Yi0zZDUzLTQ4OGUtYTAyZC0zOWI2MDZiZmYxMTciLCJqdGkiOiJiMGZmOTMzOC04ODMwLTRmNDgtYjA3Ny1kNDNmMjU2OGZlYzAifQ.oDLVR73M0u5SjMPlc1aruxbdK7l2titXSeo9J5M1JUd65a1X9MhCz7FOobtX8eaj'
-   * faker.internet.jwt({ header: { alg: 'HS256' }}) // 'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MTg2MTM3MTIsImV4cCI6MTcxODYzMzY3OSwibmJmIjoxNjk3MjYzNjMwLCJpc3MiOiJEb3lsZSBhbmQgU29ucyIsInN1YiI6IjYxYWRkYWFmLWY4MjktNDkzZS1iNTI1LTJjMGJkNjkzOTdjNyIsImF1ZCI6IjczNjcyMjVjLWIwMWMtNGE1My1hYzQyLTYwOWJkZmI1MzBiOCIsImp0aSI6IjU2Y2ZkZjAxLWRhMzMtNGUxNi04MzJiLTFlYTk3ZGY1MTQ2YSJ9.5iUgaCaFVPZ8d1QD0xMjoeJbmPVyUfKfoRQ6Njzm5MLp5F4UMh5REbPCrW70fAkr'
-   * faker.internet.jwt({ payload: { iss: 'Acme' }}) // 'eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJBY21lIn0.syUt0GBukNac8Cn1AGKFq2SWAXWy1YIfl0uOYiwg6TZ3omAW0c7FGWY6bC7ZOFSt'
-   * faker.internet.jwt({ refDate: '2020-01-01T00:00:00.000Z' }) // 'eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1Nzc4MDY4NDUsImV4cCI6MTU3Nzg0NjI4MCwibmJmIjoxNTgxNTQyMDYwLCJpc3MiOiJLcmVpZ2VyLCBBbHRlbndlcnRoIGFuZCBQYXVjZWsiLCJzdWIiOiI5NzVjMjMyOS02MDlhLTRjYTYtYjBkZi05ZmY4MGZiNDUwN2QiLCJhdWQiOiI0ODQxZWYwNi01OWYwLTQzMWEtYmFmZi0xMjkxZmRhZDdhNjgiLCJqdGkiOiJmNDBjZTJiYi00ZWYyLTQ1MjMtOGIxMy1kN2Q4NTA5N2M2ZTUifQ.cuClEZQ0CyPIMVS5uxrMwWXz0wcqFFdt0oNne3PMryyly0jghkxVurss2TapMC3C'
+   * faker.internet.jwt() // 'eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MzU2NDcwMTcsImV4cCI6MTczNTY5OTA5NiwibmJmIjoxNzM4NTE2ODcyLCJpc3MiOiJPJ0Nvbm5lbGwgSW5jIiwic3ViIjoiZWY2Yzg5ZTEtMTBkYy00ZGZjLWE3YzEtYTJmODY0Yzc5MDk5IiwiYXVkIjoiZmE1NmIwYWEtMzI1NS00OTdmLWIxMzItYTQ3MzIxYTIzNWQxIiwianRpIjoiMWY3ZjliMDQtMTQxNS00NjFiLTg5NDgtMTllNWEyYjQyOTBkIn0.GgJXfzAzdXrQHiOoSASGIvXDqB1iEhCq8izAzEEqTmrTNH6VIZ9RaC7QOzp4HsIR'
+   * faker.internet.jwt({ header: { alg: 'HS256' }}) // 'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MzU2ODM4ODQsImV4cCI6MTczNTc1NzgyNiwibmJmIjoxNzA0ODg4ODMxLCJpc3MiOiJSZW5uZXIgR3JvdXAiLCJzdWIiOiI4MDMwYzM1ZS1iMDI5LTQ5M2UtOTk4OS1iNDYzMmZiNzM0MDYiLCJhdWQiOiJiNjIwMWE3OC1lZjNhLTQ0MGMtODU2OS1kYWQ0YzJmYTNmYjQiLCJqdGkiOiI4MDM2NTc0OS1kMTgyLTRiNjktODIyNy01ZmNiZTE4OWY0MzEifQ.VFMhA3uYSkXeWWNDSiQC0l9YtuDm8Obvd6RYXULk5pe83I0L945FfqyRJg83igsG'
+   * faker.internet.jwt({ payload: { iss: 'Acme' }}) // 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJBY21lIn0.nbM3HMMgnAgmcs2N4wjzXE2qvxGh7oXbUxsSsIoUGHkKDe9NXsARsXzOUO9Co3qg'
+   * faker.internet.jwt({ refDate: '2020-01-01T00:00:00.000Z' }) // 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1Nzc4MjM3NTYsImV4cCI6MTU3NzkwNjYxMiwibmJmIjoxNTY4NzE0NjI0LCJpc3MiOiJBcm1zdHJvbmcgR3JvdXAiLCJzdWIiOiI2ZTFmZDc1My05MDA2LTQxNDMtODQyMC0xOWZmNjJhN2YxYzQiLCJhdWQiOiJhM2E4Njg0Yi02NWRlLTQwMzUtOWRmZi1lNGYzMWYzYjBiZTQiLCJqdGkiOiI1YjMyNzRkMy04ZmFkLTRmY2ItYmZmNy0xNDI2Mjk2ZWY4NDkifQ.pygsofvjnwKkVR3fr6lJGCIclFSxh1I0nwV5p1lChd7zHFW0EBAX1HOvkN6rwH5e'
    *
    * @since 9.1.0
    */

--- a/src/modules/location/index.ts
+++ b/src/modules/location/index.ts
@@ -47,8 +47,8 @@ export class LocationModule extends ModuleBase {
    * @see faker.helpers.replaceSymbols(): For more information about how the pattern is used.
    *
    * @example
-   * faker.location.zipCode() // '17839'
-   * faker.location.zipCode('####') // '6925'
+   * faker.location.zipCode() // '76546-4893'
+   * faker.location.zipCode('####') // '7559'
    *
    * @since 8.0.0
    */
@@ -105,8 +105,8 @@ export class LocationModule extends ModuleBase {
    * Generates a random localized city name.
    *
    * @example
-   * faker.location.city() // 'East Jarretmouth'
-   * fakerDE.location.city() // 'Bad Lilianadorf'
+   * faker.location.city() // 'Michealstead'
+   * fakerDE.location.city() // 'Mervescheid'
    *
    * @since 8.0.0
    */
@@ -120,7 +120,7 @@ export class LocationModule extends ModuleBase {
    * Generates a random building number.
    *
    * @example
-   * faker.location.buildingNumber() // '379'
+   * faker.location.buildingNumber() // '7654'
    *
    * @since 8.0.0
    */
@@ -139,7 +139,7 @@ export class LocationModule extends ModuleBase {
    * Generates a random localized street name.
    *
    * @example
-   * faker.location.street() // 'Schroeder Isle'
+   * faker.location.street() // 'Rau Parks'
    *
    * @since 8.0.0
    */
@@ -157,10 +157,10 @@ export class LocationModule extends ModuleBase {
    * Otherwise it will just generate a street address.
    *
    * @example
-   * faker.location.streetAddress() // '0917 O'Conner Estates'
-   * faker.location.streetAddress(false) // '34830 Erdman Hollow'
-   * faker.location.streetAddress(true) // '3393 Ronny Way Apt. 742'
-   * faker.location.streetAddress({ useFullAddress: true }) // '7917 Miller Park Apt. 410'
+   * faker.location.streetAddress() // '7654 Kertzmann Tunnel'
+   * faker.location.streetAddress(false) // '475 Walsh Center'
+   * faker.location.streetAddress(true) // '18789 Marsh Lane Suite 261'
+   * faker.location.streetAddress({ useFullAddress: true }) // '542 Market Place Suite 166'
    *
    * @since 8.0.0
    */
@@ -192,7 +192,7 @@ export class LocationModule extends ModuleBase {
    * such as an apartment or room number.
    *
    * @example
-   * faker.location.secondaryAddress() // 'Apt. 861'
+   * faker.location.secondaryAddress() // 'Suite 765'
    *
    * @since 8.0.0
    */
@@ -211,8 +211,8 @@ export class LocationModule extends ModuleBase {
    * Returns a random localized county, or other equivalent second-level administrative entity for the locale's country such as a district or department.
    *
    * @example
-   * fakerEN_GB.location.county() // 'Cambridgeshire'
-   * fakerEN_US.location.county() // 'Monroe County'
+   * fakerEN_GB.location.county() // 'Kent'
+   * fakerEN_US.location.county() // 'Lee County'
    *
    * @since 8.0.0
    */
@@ -226,7 +226,7 @@ export class LocationModule extends ModuleBase {
    * Returns a random country name.
    *
    * @example
-   * faker.location.country() // 'Greece'
+   * faker.location.country() // 'Mali'
    *
    * @since 8.0.0
    */
@@ -240,7 +240,7 @@ export class LocationModule extends ModuleBase {
    * Returns a random continent name.
    *
    * @example
-   * faker.location.continent() // 'Asia'
+   * faker.location.continent() // 'Australia'
    *
    * @since 9.1.0
    */
@@ -263,10 +263,10 @@ export class LocationModule extends ModuleBase {
    * Defaults to `'alpha-2'`.
    *
    * @example
-   * faker.location.countryCode() // 'SJ'
-   * faker.location.countryCode('alpha-2') // 'GA'
-   * faker.location.countryCode('alpha-3') // 'TJK'
-   * faker.location.countryCode('numeric') // '528'
+   * faker.location.countryCode() // 'MA'
+   * faker.location.countryCode('alpha-2') // 'PL'
+   * faker.location.countryCode('alpha-3') // 'MRT'
+   * faker.location.countryCode('numeric') // '434'
    *
    * @since 8.0.0
    */
@@ -324,10 +324,10 @@ export class LocationModule extends ModuleBase {
    * Otherwise this will return the long name. Defaults to `false`.
    *
    * @example
-   * faker.location.state() // 'Mississippi'
-   * fakerEN_CA.location.state() // 'Saskatchewan'
-   * fakerDE.location.state() // 'Nordrhein-Westfalen'
-   * faker.location.state({ abbreviated: true }) // 'LA'
+   * faker.location.state() // 'Nevada'
+   * fakerEN_CA.location.state() // 'Nunavut'
+   * fakerDE.location.state() // 'Niedersachsen'
+   * faker.location.state({ abbreviated: true }) // 'OK'
    *
    * @since 8.0.0
    */
@@ -359,10 +359,10 @@ export class LocationModule extends ModuleBase {
    * @param options.precision The number of decimal points of precision for the latitude. Defaults to `4`.
    *
    * @example
-   * faker.location.latitude() // -30.9501
-   * faker.location.latitude({ max: 10 }) // 5.7225
-   * faker.location.latitude({ max: 10, min: -10 }) // -9.6273
-   * faker.location.latitude({ max: 10, min: -10, precision: 5 }) // 2.68452
+   * faker.location.latitude() // 8.7864
+   * faker.location.latitude({ max: 10 }) // -18.481
+   * faker.location.latitude({ max: 10, min: -10 }) // 2.0553
+   * faker.location.latitude({ max: 10, min: -10, precision: 5 }) // 0.89766
    *
    * @since 8.0.0
    */
@@ -402,10 +402,10 @@ export class LocationModule extends ModuleBase {
    * @param options.precision The number of decimal points of precision for the longitude. Defaults to `4`.
    *
    * @example
-   * faker.location.longitude() // -30.9501
-   * faker.location.longitude({ max: 10 }) // 5.7225
-   * faker.location.longitude({ max: 10, min: -10 }) // -9.6273
-   * faker.location.longitude({ max: 10, min: -10, precision: 5 }) // 2.68452
+   * faker.location.longitude() // 17.5729
+   * faker.location.longitude({ max: 10 }) // -44.114
+   * faker.location.longitude({ max: 10, min: -10 }) // 2.0553
+   * faker.location.longitude({ max: 10, min: -10, precision: 5 }) // 0.89766
    *
    * @since 8.0.0
    */
@@ -445,7 +445,7 @@ export class LocationModule extends ModuleBase {
    *
    * @example
    * faker.location.direction() // 'Northeast'
-   * faker.location.direction({ abbreviated: true }) // 'SW'
+   * faker.location.direction({ abbreviated: true }) // 'NW'
    *
    * @since 8.0.0
    */
@@ -483,8 +483,8 @@ export class LocationModule extends ModuleBase {
    * Otherwise this will return the long name. Defaults to `false`.
    *
    * @example
-   * faker.location.cardinalDirection() // 'North'
-   * faker.location.cardinalDirection({ abbreviated: true }) // 'W'
+   * faker.location.cardinalDirection() // 'South'
+   * faker.location.cardinalDirection({ abbreviated: true }) // 'S'
    *
    * @since 8.0.0
    */
@@ -520,8 +520,8 @@ export class LocationModule extends ModuleBase {
    * Otherwise this will return the long name. Defaults to `false`.
    *
    * @example
-   * faker.location.ordinalDirection() // 'Northeast'
-   * faker.location.ordinalDirection({ abbreviated: true }) // 'SW'
+   * faker.location.ordinalDirection() // 'Southeast'
+   * faker.location.ordinalDirection({ abbreviated: true }) // 'SE'
    *
    * @since 8.0.0
    */
@@ -559,9 +559,9 @@ export class LocationModule extends ModuleBase {
    * @param options.isMetric If `true` assume the radius to be in kilometers. If `false` for miles. Defaults to `false`.
    *
    * @example
-   * faker.location.nearbyGPSCoordinate() // [ 33.8475, -170.5953 ]
-   * faker.location.nearbyGPSCoordinate({ origin: [33, -170] }) // [ 33.0165, -170.0636 ]
-   * faker.location.nearbyGPSCoordinate({ origin: [33, -170], radius: 1000, isMetric: true }) // [ 37.9163, -179.2408 ]
+   * faker.location.nearbyGPSCoordinate() // [ 8.7864, 77.4682 ]
+   * faker.location.nearbyGPSCoordinate({ origin: [33, -170] }) // [ 32.95274756100263, -170.06271843206343 ]
+   * faker.location.nearbyGPSCoordinate({ origin: [33, -170], radius: 1000, isMetric: true }) // [ 35.66934494697957, -175.13118223236756 ]
    *
    * @since 8.0.0
    */
@@ -639,7 +639,7 @@ export class LocationModule extends ModuleBase {
    * @see faker.date.timeZone(): For generating a random time zone from all available time zones.
    *
    * @example
-   * faker.location.timeZone() // 'Pacific/Guam'
+   * faker.location.timeZone() // 'Asia/Dili'
    *
    * @since 8.0.0
    */
@@ -657,10 +657,10 @@ export class LocationModule extends ModuleBase {
    * @see [ISO 639-2 Language Code List](https://www.loc.gov/standards/iso639-2/php/code_list.php)
    *
    * @example
-   * faker.location.language() // { alpha2: 'de', alpha3: 'deu', name: 'German' }
-   * faker.location.language().name // German
-   * faker.location.language().alpha2 // de
-   * faker.location.language().alpha3 // deu
+   * faker.location.language() // { 'name': 'Ukrainian', 'alpha2': 'uk', 'alpha3': 'ukr' }
+   * faker.location.language().name // 'Catalan'
+   * faker.location.language().alpha2 // 'sk'
+   * faker.location.language().alpha3 // 'ukr'
    *
    * @since 9.4.0
    */

--- a/src/modules/lorem/index.ts
+++ b/src/modules/lorem/index.ts
@@ -275,7 +275,7 @@ export class LoremModule extends ModuleBase {
    * // Ustilo ascisco possimus anser. Timor modi cum aegrus subiungo defetiscor suppono usitas voluptates. Absum contigo sustineo astrum eligendi adopto aveho accusamus textus.'
    *
    * faker.lorem.paragraphs(2, '<br/>\n')
-   * // 'Coniuratio vestrum succurro addo. Quas neque capio victus. Facilis officia sustineo color cubicularis bellum audentia.&lt;br/>
+   * // 'Coniuratio vestrum succurro addo. Quas neque capio victus. Facilis officia sustineo color cubicularis bellum audentia.<br/>
    * // Tactus depraedor calcar caterva adsuesco damno color subito crapula attero. Aegre spoliatio defetiscor. Vel vulariter bis somnus celer accusator tempora.'
    *
    * faker.lorem.paragraphs({ min: 1, max: 3 }) // 'Odio tripudio quo uter certus theologus. Viridis stips bibo vinitor. Catena benigne eaque acies beatus currus corrumpo delectus.'

--- a/src/modules/lorem/index.ts
+++ b/src/modules/lorem/index.ts
@@ -266,18 +266,18 @@ export class LoremModule extends ModuleBase {
    * // 'Sumo pax impedit curriculum sint debitis vallum. Credo textilis eveniet minus vespillo aeneus alias accusator tristis tergo. Volutabrum thermae deinde termes angustus rerum arbitro vinco enim.
    * // Celo teres defleo minus accusamus quae. Provident villa statim contigo debilito subiungo adulescens. Spargo bene aperiam comedo convoco molestiae decens voveo.
    * // Bellicus arx solitudo. Deleniti caries articulus amor sollicito. Auxilium corporis trado alter.'
-   * 
+   *
    * faker.lorem.paragraphs(5)
    * // 'Alo voluptatibus delicate voluptatibus pecco tactus adflicto cimentarius animi. Angustus cometes cupio advoco stultus. Cena eos aliquid nemo vetus comis sopor.
    * // Sumptus clam auctus occaecati. Tricesimus abeo spiritus. Tabesco vivo carpo nemo omnis.
    * // Cado viridis dedecor tyrannus subnecto coadunatio torqueo. Uxor nobis uxor stultus surgo desino. Sequi curriculum pecto accusantium cogito solutio clam quae curto appositus.
    * // Molestiae officiis natus solitudo solio. Vel corona debeo vapulus timidus succurro. Verto summopere vulticulus.
    * // Ustilo ascisco possimus anser. Timor modi cum aegrus subiungo defetiscor suppono usitas voluptates. Absum contigo sustineo astrum eligendi adopto aveho accusamus textus.'
-   * 
+   *
    * faker.lorem.paragraphs(2, '<br/>\n')
    * // 'Coniuratio vestrum succurro addo. Quas neque capio victus. Facilis officia sustineo color cubicularis bellum audentia.&lt;br/>
    * // Tactus depraedor calcar caterva adsuesco damno color subito crapula attero. Aegre spoliatio defetiscor. Vel vulariter bis somnus celer accusator tempora.'
-   * 
+   *
    * faker.lorem.paragraphs({ min: 1, max: 3 }) // 'Odio tripudio quo uter certus theologus. Viridis stips bibo vinitor. Catena benigne eaque acies beatus currus corrumpo delectus.'
    *
    * @since 2.0.1
@@ -340,17 +340,17 @@ export class LoremModule extends ModuleBase {
    * // 'Pax impedit curriculum sint debitis vallum vix credo.
    * // Eveniet minus vespillo aeneus alias accusator tristis tergo usus.
    * // Thermae deinde termes angustus rerum arbitro vinco enim cuppedia celo.'
-   * 
+   *
    * faker.lorem.lines()
    * // 'Minus accusamus quae perspiciatis provident villa.
    * // Contigo debilito subiungo adulescens sopor spargo bene aperiam.
    * // Convoco molestiae decens voveo ambitus.
    * // Arx solitudo catena deleniti.'
-   * 
+   *
    * faker.lorem.lines(2)
    * // 'Articulus amor sollicito aptus.
    * // Corporis trado alter tum.'
-   * 
+   *
    * faker.lorem.lines({ min: 1, max: 3 }) // 'Delicate voluptatibus pecco tactus adflicto cimentarius animi clementia angustus cometes.'
    *
    * @since 3.1.0

--- a/src/modules/lorem/index.ts
+++ b/src/modules/lorem/index.ts
@@ -31,10 +31,10 @@ export class LoremModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.lorem.word() // 'temporibus'
-   * faker.lorem.word(5) // 'velit'
+   * faker.lorem.word() // 'inflammatio'
+   * faker.lorem.word(5) // 'teneo'
    * faker.lorem.word({ strategy: 'shortest' }) // 'a'
-   * faker.lorem.word({ length: { min: 5, max: 7 }, strategy: 'fail' }) // 'quaerat'
+   * faker.lorem.word({ length: { min: 5, max: 7 }, strategy: 'fail' }) // 'pauci'
    *
    * @since 3.1.0
    */
@@ -95,9 +95,9 @@ export class LoremModule extends ModuleBase {
    * @param wordCount.max The maximum number of words to generate.
    *
    * @example
-   * faker.lorem.words() // 'qui praesentium pariatur'
-   * faker.lorem.words(10) // 'debitis consectetur voluptatem non doloremque ipsum autem totam eum ratione'
-   * faker.lorem.words({ min: 1, max: 3 }) // 'tenetur error cum'
+   * faker.lorem.words() // 'inflammatio sumo pax'
+   * faker.lorem.words(10) // 'impedit curriculum sint debitis vallum vix credo textilis eveniet minus'
+   * faker.lorem.words({ min: 1, max: 3 }) // 'aeneus alias accusator'
    *
    * @since 2.0.1
    */
@@ -128,9 +128,9 @@ export class LoremModule extends ModuleBase {
    * @param wordCount.max The maximum number of words to generate. Defaults to `10`.
    *
    * @example
-   * faker.lorem.sentence() // 'Voluptatum cupiditate suscipit autem eveniet aut dolorem aut officiis distinctio.'
-   * faker.lorem.sentence(5) // 'Laborum voluptatem officiis est et.'
-   * faker.lorem.sentence({ min: 3, max: 5 }) // 'Fugiat repellendus nisi.'
+   * faker.lorem.sentence() // 'Sumo pax impedit curriculum sint debitis vallum.'
+   * faker.lorem.sentence(5) // 'Vix credo textilis eveniet minus.'
+   * faker.lorem.sentence({ min: 3, max: 5 }) // 'Aeneus alias accusator tristis tergo.'
    *
    * @since 2.0.1
    */
@@ -160,9 +160,9 @@ export class LoremModule extends ModuleBase {
    * @param wordCount.max The maximum number of words to generate.
    *
    * @example
-   * faker.lorem.slug() // 'dolores-illo-est'
-   * faker.lorem.slug(5) // 'delectus-totam-iusto-itaque-placeat'
-   * faker.lorem.slug({ min: 1, max: 3 }) // 'illo-ratione'
+   * faker.lorem.slug() // 'inflammatio-sumo-pax'
+   * faker.lorem.slug(5) // 'impedit-curriculum-sint-debitis-vallum'
+   * faker.lorem.slug({ min: 1, max: 3 }) // 'credo-textilis-eveniet'
    *
    * @since 4.0.0
    */
@@ -193,12 +193,12 @@ export class LoremModule extends ModuleBase {
    * @param separator The separator to add between sentences. Defaults to `' '`.
    *
    * @example
-   * faker.lorem.sentences() // 'Iste molestiae incidunt aliquam possimus reprehenderit eum corrupti. Deleniti modi voluptatem nostrum ut esse.'
-   * faker.lorem.sentences(2) // 'Maxime vel numquam quibusdam. Dignissimos ex molestias quos aut molestiae quam nihil occaecati maiores.'
+   * faker.lorem.sentences() // 'Pax impedit curriculum sint debitis vallum vix credo. Eveniet minus vespillo aeneus alias accusator tristis tergo usus. Thermae deinde termes angustus rerum arbitro vinco enim cuppedia celo. Defleo minus accusamus quae perspiciatis provident villa statim contigo.'
+   * faker.lorem.sentences(2) // 'Subiungo adulescens sopor spargo bene aperiam. Convoco molestiae decens voveo ambitus.'
    * faker.lorem.sentences(2, '\n')
-   * // 'Et rerum a unde tempora magnam sit nisi.
-   * // Et perspiciatis ipsam omnis.'
-   * faker.lorem.sentences({ min: 1, max: 3 }) // 'Placeat ex natus tenetur repellendus repellendus iste. Optio nostrum veritatis.'
+   * // 'Arx solitudo catena deleniti.
+   * // Articulus amor sollicito aptus.'
+   * faker.lorem.sentences({ min: 1, max: 3 }) // 'Trado alter tum alo voluptatibus.'
    *
    * @since 2.0.1
    */
@@ -230,9 +230,9 @@ export class LoremModule extends ModuleBase {
    * @param sentenceCount.max The maximum number of sentences to generate.
    *
    * @example
-   * faker.lorem.paragraph() // 'Non architecto nam unde sint. Ex tenetur dolor facere optio aut consequatur. Ea laudantium reiciendis repellendus.'
-   * faker.lorem.paragraph(2) // 'Animi possimus nemo consequuntur ut ea et tempore unde qui. Quis corporis esse occaecati.'
-   * faker.lorem.paragraph({ min: 1, max: 3 }) // 'Quis doloribus necessitatibus sint. Rerum accusamus impedit corporis porro.'
+   * faker.lorem.paragraph() // 'Sumo pax impedit curriculum sint debitis vallum. Credo textilis eveniet minus vespillo aeneus alias accusator tristis tergo. Volutabrum thermae deinde termes angustus rerum arbitro vinco enim.'
+   * faker.lorem.paragraph(2) // 'Celo teres defleo minus accusamus quae. Provident villa statim contigo debilito subiungo adulescens.'
+   * faker.lorem.paragraph({ min: 1, max: 3 }) // 'Bene aperiam comedo convoco molestiae decens voveo ambitus. Arx solitudo catena deleniti. Articulus amor sollicito aptus.'
    *
    * @since 2.0.1
    */
@@ -263,25 +263,22 @@ export class LoremModule extends ModuleBase {
    *
    * @example
    * faker.lorem.paragraphs()
-   * // 'Beatae voluptatem dicta et assumenda fugit eaque quidem consequatur. Fuga unde provident. Id reprehenderit soluta facilis est laborum laborum. Illum aut non ut. Est nulla rem ipsa.
-   * // Voluptatibus quo pariatur est. Temporibus deleniti occaecati pariatur nemo est molestias voluptas. Doloribus commodi et et exercitationem vel et. Omnis inventore cum aut amet.
-   * // Sapiente deleniti et. Ducimus maiores eum. Rem dolorem itaque aliquam.'
-   *
+   * // 'Sumo pax impedit curriculum sint debitis vallum. Credo textilis eveniet minus vespillo aeneus alias accusator tristis tergo. Volutabrum thermae deinde termes angustus rerum arbitro vinco enim.
+   * // Celo teres defleo minus accusamus quae. Provident villa statim contigo debilito subiungo adulescens. Spargo bene aperiam comedo convoco molestiae decens voveo.
+   * // Bellicus arx solitudo. Deleniti caries articulus amor sollicito. Auxilium corporis trado alter.'
+   * 
    * faker.lorem.paragraphs(5)
-   * // 'Quia hic sunt ducimus expedita quo impedit soluta. Quam impedit et ipsum optio. Unde dolores nulla nobis vero et aspernatur officiis.
-   * // Aliquam dolorem temporibus dolores voluptatem voluptatem qui nostrum quia. Sit hic facilis rerum eius. Beatae doloribus nesciunt iste ipsum.
-   * // Natus nam eum nulla voluptas molestiae fuga libero nihil voluptatibus. Sed quam numquam eum ipsam temporibus eaque ut et. Enim quas debitis quasi quis. Vitae et vitae.
-   * // Repellat voluptatem est laborum illo harum sed reprehenderit aut. Quo sit et. Exercitationem blanditiis totam velit ad dicta placeat.
-   * // Rerum non eum incidunt amet quo. Eaque laborum ut. Recusandae illo ab distinctio veritatis. Cum quis architecto ad maxime a.'
-   *
+   * // 'Alo voluptatibus delicate voluptatibus pecco tactus adflicto cimentarius animi. Angustus cometes cupio advoco stultus. Cena eos aliquid nemo vetus comis sopor.
+   * // Sumptus clam auctus occaecati. Tricesimus abeo spiritus. Tabesco vivo carpo nemo omnis.
+   * // Cado viridis dedecor tyrannus subnecto coadunatio torqueo. Uxor nobis uxor stultus surgo desino. Sequi curriculum pecto accusantium cogito solutio clam quae curto appositus.
+   * // Molestiae officiis natus solitudo solio. Vel corona debeo vapulus timidus succurro. Verto summopere vulticulus.
+   * // Ustilo ascisco possimus anser. Timor modi cum aegrus subiungo defetiscor suppono usitas voluptates. Absum contigo sustineo astrum eligendi adopto aveho accusamus textus.'
+   * 
    * faker.lorem.paragraphs(2, '<br/>\n')
-   * // 'Eos magnam aut qui accusamus. Sapiente quas culpa totam excepturi. Blanditiis totam distinctio occaecati dignissimos cumque atque qui officiis.<br/>
-   * // Nihil quis vel consequatur. Blanditiis commodi deserunt sunt animi dolorum. A optio porro hic dolorum fugit aut et sint voluptas. Minima ad sed ipsa est non dolores.'
-   *
-   * faker.lorem.paragraphs({ min: 1, max: 3 })
-   * // 'Eum nam fugiat laudantium.
-   * // Dignissimos tempore porro necessitatibus commodi nam.
-   * // Veniam at commodi iste perferendis totam dolorum corporis ipsam.'
+   * // 'Coniuratio vestrum succurro addo. Quas neque capio victus. Facilis officia sustineo color cubicularis bellum audentia.&lt;br/>
+   * // Tactus depraedor calcar caterva adsuesco damno color subito crapula attero. Aegre spoliatio defetiscor. Vel vulariter bis somnus celer accusator tempora.'
+   * 
+   * faker.lorem.paragraphs({ min: 1, max: 3 }) // 'Odio tripudio quo uter certus theologus. Viridis stips bibo vinitor. Catena benigne eaque acies beatus currus corrumpo delectus.'
    *
    * @since 2.0.1
    */
@@ -309,13 +306,11 @@ export class LoremModule extends ModuleBase {
    * Generates a random text based on a random lorem method.
    *
    * @example
-   * faker.lorem.text() // 'Doloribus autem non quis vero quia.'
+   * faker.lorem.text() // 'Pax impedit curriculum sint debitis vallum vix credo. Eveniet minus vespillo aeneus alias accusator tristis tergo usus. Thermae deinde termes angustus rerum arbitro vinco enim cuppedia celo.'
    * faker.lorem.text()
-   * // 'Rerum eum reiciendis id ipsa hic dolore aut laborum provident.
-   * // Quis beatae quis corporis veritatis corrupti ratione delectus sapiente ut.
-   * // Quis ut dolor dolores facilis possimus tempore voluptates.
-   * // Iure nam officia optio cumque.
-   * // Dolor tempora iusto.'
+   * // 'Minus accusamus quae perspiciatis provident villa. Contigo debilito subiungo adulescens sopor spargo bene aperiam. Convoco molestiae decens voveo ambitus.
+   * // Arx solitudo catena deleniti. Articulus amor sollicito aptus. Corporis trado alter tum.
+   * // Voluptatibus delicate voluptatibus. Tactus adflicto cimentarius animi clementia angustus cometes. Advoco stultus minima cena eos aliquid.'
    *
    * @since 3.1.0
    */
@@ -342,21 +337,21 @@ export class LoremModule extends ModuleBase {
    *
    * @example
    * faker.lorem.lines()
-   * // 'Rerum quia aliquam pariatur explicabo sint minima eos.
-   * // Voluptatem repellat consequatur deleniti qui quibusdam harum cumque.
-   * // Enim eveniet a qui.
-   * // Consectetur velit eligendi animi nostrum veritatis.'
-   *
+   * // 'Pax impedit curriculum sint debitis vallum vix credo.
+   * // Eveniet minus vespillo aeneus alias accusator tristis tergo usus.
+   * // Thermae deinde termes angustus rerum arbitro vinco enim cuppedia celo.'
+   * 
    * faker.lorem.lines()
-   * // 'Soluta deserunt eos quam reiciendis libero autem enim nam ut.
-   * // Voluptate aut aut.'
-   *
+   * // 'Minus accusamus quae perspiciatis provident villa.
+   * // Contigo debilito subiungo adulescens sopor spargo bene aperiam.
+   * // Convoco molestiae decens voveo ambitus.
+   * // Arx solitudo catena deleniti.'
+   * 
    * faker.lorem.lines(2)
-   * // 'Quod quas nam quis impedit aut consequuntur.
-   * // Animi dolores aspernatur.'
-   *
-   * faker.lorem.lines({ min: 1, max: 3 })
-   * // 'Error dolorem natus quos eum consequatur necessitatibus.'
+   * // 'Articulus amor sollicito aptus.
+   * // Corporis trado alter tum.'
+   * 
+   * faker.lorem.lines({ min: 1, max: 3 }) // 'Delicate voluptatibus pecco tactus adflicto cimentarius animi clementia angustus cometes.'
    *
    * @since 3.1.0
    */

--- a/src/modules/music/index.ts
+++ b/src/modules/music/index.ts
@@ -22,7 +22,7 @@ export class MusicModule extends ModuleBase {
    * Returns a random album name.
    *
    * @example
-   * faker.music.album() // '1989'
+   * faker.music.album() // 'Meet The Orphans'
    *
    * @since 9.0.0
    */
@@ -34,7 +34,7 @@ export class MusicModule extends ModuleBase {
    * Returns a random artist name.
    *
    * @example
-   * faker.music.artist() // 'The Beatles'
+   * faker.music.artist() // 'Mario Lanza'
    *
    * @since 9.0.0
    */
@@ -46,7 +46,7 @@ export class MusicModule extends ModuleBase {
    * Returns a random music genre.
    *
    * @example
-   * faker.music.genre() // 'Reggae'
+   * faker.music.genre() // 'Kitsch'
    *
    * @since 5.2.0
    */
@@ -58,7 +58,7 @@ export class MusicModule extends ModuleBase {
    * Returns a random song name.
    *
    * @example
-   * faker.music.songName() // 'White Christmas'
+   * faker.music.songName() // 'Mony Mony'
    *
    * @since 7.1.0
    */

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -32,12 +32,12 @@ export class NumberModule extends SimpleModuleBase {
    * @see faker.string.numeric(): For generating a `string` of digits with a given length (range).
    *
    * @example
-   * faker.number.int() // 2900970162509863
-   * faker.number.int(100) // 52
-   * faker.number.int({ min: 1000000 }) // 2900970162509863
-   * faker.number.int({ max: 100 }) // 42
-   * faker.number.int({ min: 10, max: 100 }) // 57
-   * faker.number.int({ min: 10, max: 100, multipleOf: 10 }) // 50
+   * faker.number.int() // 4943272583565992
+   * faker.number.int(100) // 72
+   * faker.number.int({ min: 1000000 }) // 5429209832134912
+   * faker.number.int({ max: 100 }) // 55
+   * faker.number.int({ min: 10, max: 100 }) // 48
+   * faker.number.int({ min: 10, max: 100, multipleOf: 10 }) // 70
    *
    * @since 8.0.0
    */
@@ -118,15 +118,15 @@ export class NumberModule extends SimpleModuleBase {
    * @throws When `fractionDigits` and `multipleOf` is passed in the same options object.
    *
    * @example
-   * faker.number.float() // 0.5688541042618454
-   * faker.number.float(3) // 2.367973240558058
-   * faker.number.float({ max: 100 }) // 17.3687307164073
-   * faker.number.float({ min: 20, max: 30 }) // 23.94764115102589
-   * faker.number.float({ multipleOf: 0.25, min: 0, max:10 }) // 7.75
-   * faker.number.float({ fractionDigits: 1 }) // 0.9
-   * faker.number.float({ min: 10, max: 100, multipleOf: 0.02 }) // 35.42
-   * faker.number.float({ min: 10, max: 100, fractionDigits: 3 }) // 65.716
-   * faker.number.float({ min: 10, max: 100, multipleOf: 0.001 }) // 65.716 - same as above
+   * faker.number.float() // 0.5488135039273248
+   * faker.number.float(3) // 2.1455680991172583
+   * faker.number.float({ max: 100 }) // 60.276337607164386
+   * faker.number.float({ min: 20, max: 30 }) // 25.448831829968967
+   * faker.number.float({ multipleOf: 0.25, min: 0, max:10 }) // 4.25
+   * faker.number.float({ fractionDigits: 1 }) // 0.7
+   * faker.number.float({ min: 10, max: 100, multipleOf: 0.02 }) // 49.38
+   * faker.number.float({ min: 10, max: 100, fractionDigits: 3 }) // 90.26
+   * faker.number.float({ min: 10, max: 100, multipleOf: 0.001 }) // 96.73
    *
    * @since 8.0.0
    */
@@ -235,8 +235,8 @@ export class NumberModule extends SimpleModuleBase {
    *
    * @example
    * faker.number.binary() // '1'
-   * faker.number.binary(255) // '110101'
-   * faker.number.binary({ min: 0, max: 65535 }) // '10110101'
+   * faker.number.binary(255) // '10110111'
+   * faker.number.binary({ min: 0, max: 65535 }) // '1001101001001110'
    *
    * @since 8.0.0
    */
@@ -284,9 +284,9 @@ export class NumberModule extends SimpleModuleBase {
    * @see faker.string.octal(): For generating an `octal string` with a given length (range).
    *
    * @example
-   * faker.number.octal() // '5'
-   * faker.number.octal(255) // '377'
-   * faker.number.octal({ min: 0, max: 65535 }) // '4766'
+   * faker.number.octal() // '4'
+   * faker.number.octal(255) // '267'
+   * faker.number.octal({ min: 0, max: 65535 }) // '115116'
    *
    * @since 8.0.0
    */
@@ -332,9 +332,9 @@ export class NumberModule extends SimpleModuleBase {
    * @throws When there are no integers between `min` and `max`.
    *
    * @example
-   * faker.number.hex() // 'b'
-   * faker.number.hex(255) // '9d'
-   * faker.number.hex({ min: 0, max: 65535 }) // 'af17'
+   * faker.number.hex() // '8'
+   * faker.number.hex(255) // 'b7'
+   * faker.number.hex({ min: 0, max: 65535 }) // '9a4e'
    *
    * @since 8.0.0
    */
@@ -379,11 +379,11 @@ export class NumberModule extends SimpleModuleBase {
    * @throws When `min` is greater than `max`.
    *
    * @example
-   * faker.number.bigInt() // 55422n
-   * faker.number.bigInt(100n) // 52n
-   * faker.number.bigInt({ min: 1000000n }) // 431433n
-   * faker.number.bigInt({ max: 100n }) // 42n
-   * faker.number.bigInt({ min: 10n, max: 100n }) // 36n
+   * faker.number.bigInt() // 576546489375590n
+   * faker.number.bigInt(100n) // 8n
+   * faker.number.bigInt({ min: 1000000n }) // 789747162954274n
+   * faker.number.bigInt({ max: 100n }) // 1n
+   * faker.number.bigInt({ min: 10n, max: 100n }) // 76n
    *
    * @since 8.0.0
    */
@@ -458,11 +458,11 @@ export class NumberModule extends SimpleModuleBase {
    * @throws When `max` is greater than `3999`.
    *
    * @example
-   * faker.number.romanNumeral() // "CMXCIII"
-   * faker.number.romanNumeral(5) // "III"
-   * faker.number.romanNumeral({ min: 10 }) // "XCIX"
-   * faker.number.romanNumeral({ max: 20 }) // "XVII"
-   * faker.number.romanNumeral({ min: 5, max: 10 }) // "VII"
+   * faker.number.romanNumeral() // 'MMCXCV'
+   * faker.number.romanNumeral(5) // 'IV'
+   * faker.number.romanNumeral({ min: 10 }) // 'MMCDXV'
+   * faker.number.romanNumeral({ max: 20 }) // 'XI'
+   * faker.number.romanNumeral({ min: 5, max: 10 }) // 'VII'
    *
    * @since 9.2.0
    */

--- a/src/modules/person/index.ts
+++ b/src/modules/person/index.ts
@@ -73,9 +73,9 @@ export class PersonModule extends ModuleBase {
    * Can be either `'female'` or `'male'`.
    *
    * @example
-   * faker.person.firstName() // 'Antwan'
-   * faker.person.firstName('female') // 'Victoria'
-   * faker.person.firstName('male') // 'Tom'
+   * faker.person.firstName() // 'Katharina'
+   * faker.person.firstName('female') // 'Misty'
+   * faker.person.firstName('male') // 'Leroy'
    *
    * @since 8.0.0
    */
@@ -96,9 +96,9 @@ export class PersonModule extends ModuleBase {
    * Can be either `'female'` or `'male'`.
    *
    * @example
-   * faker.person.lastName() // 'Hauck'
-   * faker.person.lastName('female') // 'Grady'
-   * faker.person.lastName('male') // 'Barton'
+   * faker.person.lastName() // 'Rau'
+   * faker.person.lastName('female') // 'Little'
+   * faker.person.lastName('male') // "O'Connell"
    *
    * @since 8.0.0
    */
@@ -126,9 +126,9 @@ export class PersonModule extends ModuleBase {
    * Can be either `'female'` or `'male'`.
    *
    * @example
-   * faker.person.middleName() // 'James'
-   * faker.person.middleName('female') // 'Eloise'
-   * faker.person.middleName('male') // 'Asher'
+   * faker.person.middleName() // 'Kyle'
+   * faker.person.middleName('female') // 'Monroe'
+   * faker.person.middleName('male') // 'Levi'
    *
    * @since 8.0.0
    */
@@ -151,11 +151,11 @@ export class PersonModule extends ModuleBase {
    * @param options.sex The optional sex to use. Can be either `'female'` or `'male'`.
    *
    * @example
-   * faker.person.fullName() // 'Allen Brown'
-   * faker.person.fullName({ firstName: 'Joann' }) // 'Joann Osinski'
-   * faker.person.fullName({ firstName: 'Marcella', sex: 'female' }) // 'Mrs. Marcella Huels'
-   * faker.person.fullName({ lastName: 'Beer' }) // 'Mr. Alfonso Beer'
-   * faker.person.fullName({ sex: 'male' }) // 'Fernando Schaefer'
+   * faker.person.fullName() // 'Nicolas Little'
+   * faker.person.fullName({ firstName: 'Joann' }) // 'Joann Toy III'
+   * faker.person.fullName({ firstName: 'Marcella', sex: 'female' }) // 'Marcella Lehner'
+   * faker.person.fullName({ lastName: 'Beer' }) // 'Austin Beer'
+   * faker.person.fullName({ sex: 'male' }) // 'Mr. Alex Satterfield'
    *
    * @since 8.0.0
    */
@@ -207,7 +207,7 @@ export class PersonModule extends ModuleBase {
    * @see faker.person.sex(): For generating a binary-gender value.
    *
    * @example
-   * faker.person.gender() // 'Trans*Man'
+   * faker.person.gender() // 'Male to female transgender woman'
    *
    * @since 8.0.0
    */
@@ -227,7 +227,7 @@ export class PersonModule extends ModuleBase {
    * @see faker.person.sexType(): For generating a sex value to be used as a parameter.
    *
    * @example
-   * faker.person.sex() // 'female'
+   * faker.person.sex() // 'male'
    *
    * @since 8.0.0
    */
@@ -242,7 +242,7 @@ export class PersonModule extends ModuleBase {
    * @see faker.person.sex(): For generating a binary-gender value in forms.
    *
    * @example
-   * faker.person.sexType() // Sex.Female
+   * faker.person.sexType() // 'male'
    *
    * @since 8.0.0
    */
@@ -254,7 +254,7 @@ export class PersonModule extends ModuleBase {
    * Returns a random short biography
    *
    * @example
-   * faker.person.bio() // 'oatmeal advocate, veteran 🐠'
+   * faker.person.bio() // 'newsletter fan'
    *
    * @since 8.0.0
    */
@@ -270,8 +270,8 @@ export class PersonModule extends ModuleBase {
    * @param sex The optional sex to use. Can be either `'female'` or `'male'`.
    *
    * @example
-   * faker.person.prefix() // 'Miss'
-   * faker.person.prefix('female') // 'Ms.'
+   * faker.person.prefix() // 'Mr.'
+   * faker.person.prefix('female') // 'Mrs.'
    * faker.person.prefix('male') // 'Mr.'
    *
    * @since 8.0.0
@@ -286,7 +286,7 @@ export class PersonModule extends ModuleBase {
    * Returns a random person suffix.
    *
    * @example
-   * faker.person.suffix() // 'DDS'
+   * faker.person.suffix() // 'V'
    *
    * @since 8.0.0
    */
@@ -301,7 +301,7 @@ export class PersonModule extends ModuleBase {
    * Generates a random job title.
    *
    * @example
-   * faker.person.jobTitle() // 'Global Accounts Engineer'
+   * faker.person.jobTitle() // 'Global Assurance Orchestrator'
    *
    * @since 8.0.0
    */
@@ -315,7 +315,7 @@ export class PersonModule extends ModuleBase {
    * Generates a random job descriptor.
    *
    * @example
-   * faker.person.jobDescriptor() // 'Customer'
+   * faker.person.jobDescriptor() // 'Global'
    *
    * @since 8.0.0
    */
@@ -329,7 +329,7 @@ export class PersonModule extends ModuleBase {
    * Generates a random job area.
    *
    * @example
-   * faker.person.jobArea() // 'Brand'
+   * faker.person.jobArea() // 'Infrastructure'
    *
    * @since 8.0.0
    */
@@ -343,7 +343,7 @@ export class PersonModule extends ModuleBase {
    * Generates a random job type.
    *
    * @example
-   * faker.person.jobType() // 'Assistant'
+   * faker.person.jobType() // 'Designer'
    *
    * @since 8.0.0
    */
@@ -357,7 +357,7 @@ export class PersonModule extends ModuleBase {
    * Returns a random zodiac sign.
    *
    * @example
-   * faker.person.zodiacSign() // 'Pisces'
+   * faker.person.zodiacSign() // 'Leo'
    *
    * @since 8.0.0
    */

--- a/src/modules/phone/index.ts
+++ b/src/modules/phone/index.ts
@@ -19,10 +19,10 @@ export class PhoneModule extends ModuleBase {
    * @see faker.helpers.fromRegExp(): For generating a phone number matching a regular expression.
    *
    * @example
-   * faker.phone.number() // '961-770-7727'
-   * faker.phone.number({ style: 'human' }) // '555.770.7727 x1234'
-   * faker.phone.number({ style: 'national' }) // '(961) 770-7727'
-   * faker.phone.number({ style: 'international' }) // '+15551234567'
+   * faker.phone.number() // '765-564-8937 x5590'
+   * faker.phone.number({ style: 'human' }) // '(287) 897-4716'
+   * faker.phone.number({ style: 'national' }) // '(395) 527-4506'
+   * faker.phone.number({ style: 'international' }) // '+16697346066'
    *
    * @since 7.3.0
    */
@@ -55,7 +55,7 @@ export class PhoneModule extends ModuleBase {
    * Generates IMEI number.
    *
    * @example
-   * faker.phone.imei() // '13-850175-913761-7'
+   * faker.phone.imei() // '57-654648-937559-8'
    *
    * @since 6.2.0
    */

--- a/src/modules/science/index.ts
+++ b/src/modules/science/index.ts
@@ -41,9 +41,9 @@ export class ScienceModule extends ModuleBase {
    * Returns a random periodic table element.
    *
    * @example
-   * faker.science.chemicalElement() // { symbol: 'H', name: 'Hydrogen', atomicNumber: 1 }
-   * faker.science.chemicalElement() // { symbol: 'Xe', name: 'Xenon', atomicNumber: 54 }
-   * faker.science.chemicalElement() // { symbol: 'Ce', name: 'Cerium', atomicNumber: 58 }
+   * faker.science.chemicalElement() // { 'symbol': 'Tb', 'name': 'Terbium', 'atomicNumber': 65 }
+   * faker.science.chemicalElement() // { 'symbol': 'At', 'name': 'Astatine', 'atomicNumber': 85 }
+   * faker.science.chemicalElement() // { 'symbol': 'Hf', 'name': 'Hafnium', 'atomicNumber': 72 }
    *
    * @since 7.2.0
    */
@@ -57,9 +57,9 @@ export class ScienceModule extends ModuleBase {
    * Returns a random scientific unit.
    *
    * @example
-   * faker.science.unit() // { name: 'meter', symbol: 'm' }
-   * faker.science.unit() // { name: 'second', symbol: 's' }
-   * faker.science.unit() // { name: 'mole', symbol: 'mol' }
+   * faker.science.unit() // { 'name': 'ohm', 'symbol': 'Ω' }
+   * faker.science.unit() // { 'name': 'gray', 'symbol': 'Gy' }
+   * faker.science.unit() // { 'name': 'degree Celsius', 'symbol': '°C' }
    *
    * @since 7.2.0
    */

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -108,10 +108,10 @@ export class StringModule extends SimpleModuleBase {
    * @param length.max The maximum length of the string to generate.
    *
    * @example
-   * faker.string.fromCharacters('abc') // 'c'
-   * faker.string.fromCharacters(['a', 'b', 'c']) // 'a'
-   * faker.string.fromCharacters('abc', 10) // 'cbbbacbacb'
-   * faker.string.fromCharacters('abc', { min: 5, max: 10 }) // 'abcaaaba'
+   * faker.string.fromCharacters('abc') // 'b'
+   * faker.string.fromCharacters(['a', 'b', 'c']) // 'c'
+   * faker.string.fromCharacters('abc', 10) // 'bbbbbccbcb'
+   * faker.string.fromCharacters('abc', { min: 5, max: 10 }) // 'caaacccc'
    *
    * @since 8.0.0
    */
@@ -161,12 +161,12 @@ export class StringModule extends SimpleModuleBase {
    * @param options.exclude An array with characters which should be excluded in the generated string. Defaults to `[]`.
    *
    * @example
-   * faker.string.alpha() // 'b'
-   * faker.string.alpha(10) // 'fEcAaCVbaR'
-   * faker.string.alpha({ length: { min: 5, max: 10 } }) // 'HcVrCf'
-   * faker.string.alpha({ casing: 'lower' }) // 'r'
-   * faker.string.alpha({ exclude: ['W'] }) // 'Z'
-   * faker.string.alpha({ length: 5, casing: 'upper', exclude: ['A'] }) // 'DTCIC'
+   * faker.string.alpha() // 'C'
+   * faker.string.alpha(10) // 'LFCwHwUYtP'
+   * faker.string.alpha({ length: { min: 5, max: 10 } }) // 'DWdebROT'
+   * faker.string.alpha({ casing: 'lower' }) // 'z'
+   * faker.string.alpha({ exclude: ['W'] }) // 'O'
+   * faker.string.alpha({ length: 5, casing: 'upper', exclude: ['A'] }) // 'MUDQE'
    *
    * @since 8.0.0
    */
@@ -255,12 +255,12 @@ export class StringModule extends SimpleModuleBase {
    * @param options.exclude An array of characters and digits which should be excluded in the generated string. Defaults to `[]`.
    *
    * @example
-   * faker.string.alphanumeric() // '2'
-   * faker.string.alphanumeric(5) // '3e5V7'
-   * faker.string.alphanumeric({ length: { min: 5, max: 10 } }) // 'muaApG'
-   * faker.string.alphanumeric({ casing: 'upper' }) // 'A'
-   * faker.string.alphanumeric({ exclude: ['W'] }) // 'r'
-   * faker.string.alphanumeric({ length: 5, exclude: ["a"] }) // 'x1Z7f'
+   * faker.string.alphanumeric() // 'y'
+   * faker.string.alphanumeric(5) // 'IBxqE'
+   * faker.string.alphanumeric({ length: { min: 5, max: 10 } }) // 'TXnNwzV'
+   * faker.string.alphanumeric({ casing: 'upper' }) // '2'
+   * faker.string.alphanumeric({ exclude: ['W'] }) // '5'
+   * faker.string.alphanumeric({ length: 5, exclude: ["a"] }) // '1PMSY'
    *
    * @since 8.0.0
    */
@@ -352,10 +352,10 @@ export class StringModule extends SimpleModuleBase {
    *
    * @example
    * faker.string.binary() // '0b1'
-   * faker.string.binary({ length: 10 }) // '0b1101011011'
-   * faker.string.binary({ length: { min: 5, max: 10 } }) // '0b11101011'
+   * faker.string.binary({ length: 10 }) // '0b1110101101'
+   * faker.string.binary({ length: { min: 5, max: 10 } }) // '0b11000111'
    * faker.string.binary({ prefix: '0b' }) // '0b1'
-   * faker.string.binary({ length: 10, prefix: 'bin_' }) // 'bin_1101011011'
+   * faker.string.binary({ length: 10, prefix: 'bin_' }) // 'bin_1010101100'
    *
    * @since 8.0.0
    */
@@ -403,11 +403,11 @@ export class StringModule extends SimpleModuleBase {
    * @see faker.number.octal(): For generating an octal number (within a range).
    *
    * @example
-   * faker.string.octal() // '0o3'
-   * faker.string.octal({ length: 10 }) // '0o1526216210'
-   * faker.string.octal({ length: { min: 5, max: 10 } }) // '0o15263214'
+   * faker.string.octal() // '0o4'
+   * faker.string.octal({ length: 10 }) // '0o5443537736'
+   * faker.string.octal({ length: { min: 5, max: 10 } }) // '0o47000666'
    * faker.string.octal({ prefix: '0o' }) // '0o7'
-   * faker.string.octal({ length: 10, prefix: 'oct_' }) // 'oct_1542153414'
+   * faker.string.octal({ length: 10, prefix: 'oct_' }) // 'oct_6360517432'
    *
    * @since 8.0.0
    */
@@ -457,15 +457,15 @@ export class StringModule extends SimpleModuleBase {
    * @param options.prefix Prefix for the generated number. Defaults to `'0x'`.
    *
    * @example
-   * faker.string.hexadecimal() // '0xB'
-   * faker.string.hexadecimal({ length: 10 }) // '0xaE13d044cB'
-   * faker.string.hexadecimal({ length: { min: 5, max: 10 } }) // '0x7dEf7FCD'
-   * faker.string.hexadecimal({ prefix: '0x' }) // '0xE'
-   * faker.string.hexadecimal({ casing: 'lower' }) // '0xf'
-   * faker.string.hexadecimal({ length: 10, prefix: '#' }) // '#f12a974eB1'
-   * faker.string.hexadecimal({ length: 10, casing: 'upper' }) // '0xE3F38014FB'
-   * faker.string.hexadecimal({ casing: 'lower', prefix: '' }) // 'd'
-   * faker.string.hexadecimal({ length: 10, casing: 'mixed', prefix: '0x' }) // '0xAdE330a4D1'
+   * faker.string.hexadecimal() // '0xc'
+   * faker.string.hexadecimal({ length: 10 }) // '0xfdb9e9DF8B'
+   * faker.string.hexadecimal({ length: { min: 5, max: 10 } }) // '0xcE110CBD'
+   * faker.string.hexadecimal({ prefix: '0x' }) // '0xF'
+   * faker.string.hexadecimal({ casing: 'lower' }) // '0xb'
+   * faker.string.hexadecimal({ length: 10, prefix: '#' }) // '#aB2e3Eb95B'
+   * faker.string.hexadecimal({ length: 10, casing: 'upper' }) // '0xAC0DDDEF79'
+   * faker.string.hexadecimal({ casing: 'lower', prefix: '' }) // 'f'
+   * faker.string.hexadecimal({ length: 10, casing: 'mixed', prefix: '0x' }) // '0x1ee4268c9F'
    *
    * @since 8.0.0
    */
@@ -556,12 +556,12 @@ export class StringModule extends SimpleModuleBase {
    * @see faker.number.int(): For generating a number (within a range).
    *
    * @example
-   * faker.string.numeric() // '2'
-   * faker.string.numeric(5) // '31507'
-   * faker.string.numeric(42) // '06434563150765416546479875435481513188548'
-   * faker.string.numeric({ length: { min: 5, max: 10 } }) // '197089478'
-   * faker.string.numeric({ length: 42, allowLeadingZeros: false }) // '72564846278453876543517840713421451546115'
-   * faker.string.numeric({ length: 6, exclude: ['0'] }) // '943228'
+   * faker.string.numeric() // '5'
+   * faker.string.numeric(5) // '76546'
+   * faker.string.numeric(42) // '489375590008789747161954274506669634606621'
+   * faker.string.numeric({ length: { min: 5, max: 10 } }) // '354912'
+   * faker.string.numeric({ length: 42, allowLeadingZeros: false }) // '262421161138080949670212134065250593617215'
+   * faker.string.numeric({ length: 6, exclude: ['0'] }) // '181737'
    *
    * @since 8.0.0
    */
@@ -654,9 +654,9 @@ export class StringModule extends SimpleModuleBase {
    * @param length.max The maximum length of the string to generate.
    *
    * @example
-   * faker.string.sample() // 'Zo!.:*e>wR'
-   * faker.string.sample(5) // '6Bye8'
-   * faker.string.sample({ min: 5, max: 10 }) // 'FeKunG'
+   * faker.string.sample() // 'TcYSH]IszD'
+   * faker.string.sample(5) // "jRUw'"
+   * faker.string.sample({ min: 5, max: 10 }) // '"niq|'
    *
    * @since 8.0.0
    */
@@ -696,7 +696,7 @@ export class StringModule extends SimpleModuleBase {
    * Returns a UUID v4 ([Universally Unique Identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier)).
    *
    * @example
-   * faker.string.uuid() // '4136cd0b-d90b-4af7-b485-5d1ded8db252'
+   * faker.string.uuid() // '8b986a7e-f6c8-49e1-910d-cdfc7c1a2f86'
    *
    * @since 8.0.0
    */
@@ -715,8 +715,8 @@ export class StringModule extends SimpleModuleBase {
    * Defaults to `faker.defaultRefDate()`.
    *
    * @example
-   * faker.string.ulid() // '01ARZ3NDEKTSV4RRFFQ69G5FAV'
-   * faker.string.ulid({ refDate: '2020-01-01T00:00:00.000Z' }) // '01DXF6DT00CX9QNNW7PNXQ3YR8'
+   * faker.string.ulid() // '01JGFF53C0HPKHDMEWYCSGJX22'
+   * faker.string.ulid({ refDate: '2020-01-01T00:00:00.000Z' }) // '01DXF6DT000TRVZSER3M4YGD8R'
    *
    * @since 9.1.0
    */
@@ -745,9 +745,9 @@ export class StringModule extends SimpleModuleBase {
    * @param length.max The maximum length of the Nano ID to generate.
    *
    * @example
-   * faker.string.nanoid() // ptL0KpX_yRMI98JFr6B3n
-   * faker.string.nanoid(10) // VsvwSdm_Am
-   * faker.string.nanoid({ min: 13, max: 37 }) // KIRsdEL9jxVgqhBDlm
+   * faker.string.nanoid() // 'IxETnwV5PR-MDWpMzCCGr'
+   * faker.string.nanoid(10) // '3F7mr_aff6'
+   * faker.string.nanoid({ min: 13, max: 37 }) // 'cOPYYJhij3zwzj8hAPGJfAdrHOSSI'
    *
    * @since 8.0.0
    */
@@ -804,9 +804,9 @@ export class StringModule extends SimpleModuleBase {
    * @param length.max The maximum length of the string to generate.
    *
    * @example
-   * faker.string.symbol() // '$'
-   * faker.string.symbol(5) // '#*!.~'
-   * faker.string.symbol({ min: 5, max: 10 }) // ')|@*>^+'
+   * faker.string.symbol() // '&lt;'
+   * faker.string.symbol(5) // '[>&lt;.?'
+   * faker.string.symbol({ min: 5, max: 10 }) // '{}-^;=|'
    *
    * @since 8.0.0
    */

--- a/src/modules/string/index.ts
+++ b/src/modules/string/index.ts
@@ -804,8 +804,8 @@ export class StringModule extends SimpleModuleBase {
    * @param length.max The maximum length of the string to generate.
    *
    * @example
-   * faker.string.symbol() // '&lt;'
-   * faker.string.symbol(5) // '[>&lt;.?'
+   * faker.string.symbol() // '<'
+   * faker.string.symbol(5) // '[><.?'
    * faker.string.symbol({ min: 5, max: 10 }) // '{}-^;=|'
    *
    * @since 8.0.0

--- a/src/modules/system/index.ts
+++ b/src/modules/system/index.ts
@@ -43,9 +43,9 @@ export class SystemModule extends ModuleBase {
    * @param options.extensionCount Define how many extensions the file name should have. Defaults to `1`.
    *
    * @example
-   * faker.system.fileName() // 'faithfully_calculating.u8mdn'
-   * faker.system.fileName({ extensionCount: 2 }) // 'times_after.swf.ntf'
-   * faker.system.fileName({ extensionCount: { min: 1, max: 2 } }) // 'jaywalk_like_ill.osfpvg'
+   * faker.system.fileName() // 'tapioca_blaring.lrf'
+   * faker.system.fileName({ extensionCount: 2 }) // 'successfully.distz.ogg'
+   * faker.system.fileName({ extensionCount: { min: 1, max: 2 } }) // 'midst.m2a'
    *
    * @since 3.1.0
    */
@@ -94,8 +94,8 @@ export class SystemModule extends ModuleBase {
    * @param extension The file extension to use. Empty string is considered to be not set.
    *
    * @example
-   * faker.system.commonFileName() // 'dollar.jpg'
-   * faker.system.commonFileName('txt') // 'global_borders_wyoming.txt'
+   * faker.system.commonFileName() // 'tapioca_blaring.pdf'
+   * faker.system.commonFileName('txt') // 'successfully.txt'
    *
    * @since 3.1.0
    */
@@ -109,7 +109,7 @@ export class SystemModule extends ModuleBase {
    * Returns a mime-type.
    *
    * @example
-   * faker.system.mimeType() // 'video/vnd.vivo'
+   * faker.system.mimeType() // 'audio/midi'
    *
    * @since 3.1.0
    */
@@ -123,7 +123,7 @@ export class SystemModule extends ModuleBase {
    * Returns a commonly used file type.
    *
    * @example
-   * faker.system.commonFileType() // 'audio'
+   * faker.system.commonFileType() // 'image'
    *
    * @since 3.1.0
    */
@@ -135,7 +135,7 @@ export class SystemModule extends ModuleBase {
    * Returns a commonly used file extension.
    *
    * @example
-   * faker.system.commonFileExt() // 'gif'
+   * faker.system.commonFileExt() // 'jpe'
    *
    * @since 3.1.0
    */
@@ -147,7 +147,7 @@ export class SystemModule extends ModuleBase {
    * Returns a file type.
    *
    * @example
-   * faker.system.fileType() // 'message'
+   * faker.system.fileType() // 'image'
    *
    * @since 3.1.0
    */
@@ -166,8 +166,8 @@ export class SystemModule extends ModuleBase {
    * @param mimeType Valid [mime-type](https://github.com/jshttp/mime-db/blob/master/db.json)
    *
    * @example
-   * faker.system.fileExt() // 'emf'
-   * faker.system.fileExt('application/json') // 'json'
+   * faker.system.fileExt() // '3g2'
+   * faker.system.fileExt('application/json') // 'map'
    *
    * @since 3.1.0
    */
@@ -188,7 +188,7 @@ export class SystemModule extends ModuleBase {
    * Returns a directory path.
    *
    * @example
-   * faker.system.directoryPath() // '/etc/mail'
+   * faker.system.directoryPath() // '/root'
    *
    * @since 3.1.0
    */
@@ -201,7 +201,7 @@ export class SystemModule extends ModuleBase {
    * Returns a file path.
    *
    * @example
-   * faker.system.filePath() // '/usr/local/src/money.dotx'
+   * faker.system.filePath() // '/root/whole_busily_jive.ico'
    *
    * @since 3.1.0
    */
@@ -213,7 +213,7 @@ export class SystemModule extends ModuleBase {
    * Returns a [semantic version](https://semver.org).
    *
    * @example
-   * faker.system.semver() // '1.15.2'
+   * faker.system.semver() // '5.15.12'
    *
    * @since 3.1.0
    */
@@ -233,10 +233,10 @@ export class SystemModule extends ModuleBase {
    * @param options.interfaceSchema The interface schema. Can be one of `index`, `slot`, `mac`, `pci`.
    *
    * @example
-   * faker.system.networkInterface() // 'enp0s3'
-   * faker.system.networkInterface({ interfaceType: 'wl' }) // 'wlo1'
-   * faker.system.networkInterface({ interfaceSchema: 'mac' }) // 'enx000c29c00000'
-   * faker.system.networkInterface({ interfaceType: 'en', interfaceSchema: 'pci' }) // 'enp5s0f1d0'
+   * faker.system.networkInterface() // 'wlx986a7ef6c89e'
+   * faker.system.networkInterface({ interfaceType: 'wl' }) // 'wlo0'
+   * faker.system.networkInterface({ interfaceSchema: 'mac' }) // 'enxdcdfc7c1a2f8'
+   * faker.system.networkInterface({ interfaceType: 'en', interfaceSchema: 'pci' }) // 'P2enp7s4d6'
    *
    * @since 7.4.0
    */
@@ -305,11 +305,11 @@ export class SystemModule extends ModuleBase {
    * @param options.includeNonStandard Whether to include a `@yearly`, `@monthly`, `@daily`, etc text labels in the generated expression. Defaults to `false`.
    *
    * @example
-   * faker.system.cron() // '45 23 * * 6'
-   * faker.system.cron({ includeYear: true }) // '45 23 * * 6 2067'
-   * faker.system.cron({ includeYear: false }) // '45 23 * * 6'
-   * faker.system.cron({ includeNonStandard: false }) // '45 23 * * 6'
-   * faker.system.cron({ includeNonStandard: true }) // '@yearly'
+   * faker.system.cron() // '* * * * *'
+   * faker.system.cron({ includeYear: true }) // '* * * * 5 *'
+   * faker.system.cron({ includeYear: false }) // '* 22 * * *'
+   * faker.system.cron({ includeNonStandard: false }) // '40 8 14 9 *'
+   * faker.system.cron({ includeNonStandard: true }) // '59 2 7 * 4'
    *
    * @since 7.5.0
    */

--- a/src/modules/vehicle/index.ts
+++ b/src/modules/vehicle/index.ts
@@ -14,7 +14,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a random vehicle.
    *
    * @example
-   * faker.vehicle.vehicle() // 'BMW Explorer'
+   * faker.vehicle.vehicle() // 'Mazda Model S'
    *
    * @since 5.0.0
    */
@@ -26,7 +26,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a manufacturer name.
    *
    * @example
-   * faker.vehicle.manufacturer() // 'Ford'
+   * faker.vehicle.manufacturer() // 'Mazda'
    *
    * @since 5.0.0
    */
@@ -40,7 +40,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a vehicle model.
    *
    * @example
-   * faker.vehicle.model() // 'Explorer'
+   * faker.vehicle.model() // 'Golf'
    *
    * @since 5.0.0
    */
@@ -54,7 +54,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a vehicle type.
    *
    * @example
-   * faker.vehicle.type() // 'Coupe'
+   * faker.vehicle.type() // 'Minivan'
    *
    * @since 5.0.0
    */
@@ -66,7 +66,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a fuel type.
    *
    * @example
-   * faker.vehicle.fuel() // 'Electric'
+   * faker.vehicle.fuel() // 'Gasoline'
    *
    * @since 5.0.0
    */
@@ -78,7 +78,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a vehicle identification number (VIN).
    *
    * @example
-   * faker.vehicle.vin() // 'YV1MH682762184654'
+   * faker.vehicle.vin() // 'JPKHDMEWYCVH59000'
    *
    * @since 5.0.0
    */
@@ -103,7 +103,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a vehicle color.
    *
    * @example
-   * faker.vehicle.color() // 'red'
+   * faker.vehicle.color() // 'orchid'
    *
    * @since 5.0.0
    */
@@ -115,7 +115,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a vehicle registration number (Vehicle Registration Mark - VRM)
    *
    * @example
-   * faker.vehicle.vrm() // 'MF56UPA'
+   * faker.vehicle.vrm() // 'OS65LQL'
    *
    * @since 5.4.0
    */
@@ -136,7 +136,7 @@ export class VehicleModule extends ModuleBase {
    * Returns a type of bicycle.
    *
    * @example
-   * faker.vehicle.bicycle() // 'Adventure Road Bicycle'
+   * faker.vehicle.bicycle() // 'Hybrid Bicycle'
    *
    * @since 5.5.0
    */

--- a/src/modules/word/index.ts
+++ b/src/modules/word/index.ts
@@ -24,11 +24,11 @@ export class WordModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.word.adjective() // 'pungent'
-   * faker.word.adjective(5) // 'slimy'
-   * faker.word.adjective(100) // 'complete'
-   * faker.word.adjective({ strategy: 'shortest' }) // 'icy'
-   * faker.word.adjective({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'distant'
+   * faker.word.adjective() // 'negligible'
+   * faker.word.adjective(5) // 'short'
+   * faker.word.adjective(100) // 'perky'
+   * faker.word.adjective({ strategy: 'shortest' }) // 'mad'
+   * faker.word.adjective({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'likable'
    *
    * @since 6.0.0
    */
@@ -97,11 +97,11 @@ export class WordModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.word.adverb() // 'quarrelsomely'
-   * faker.word.adverb(5) // 'madly'
-   * faker.word.adverb(100) // 'sadly'
-   * faker.word.adverb({ strategy: 'shortest' }) // 'too'
-   * faker.word.adverb({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'sweetly'
+   * faker.word.adverb() // 'often'
+   * faker.word.adverb(5) // 'sadly'
+   * faker.word.adverb(100) // 'promptly'
+   * faker.word.adverb({ strategy: 'shortest' }) // 'not'
+   * faker.word.adverb({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'likely'
    *
    * @since 6.0.0
    */
@@ -170,11 +170,11 @@ export class WordModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.word.conjunction() // 'in order that'
-   * faker.word.conjunction(5) // 'since'
-   * faker.word.conjunction(100) // 'as long as'
+   * faker.word.conjunction() // 'provided'
+   * faker.word.conjunction(5) // 'which'
+   * faker.word.conjunction(100) // 'supposing'
    * faker.word.conjunction({ strategy: 'shortest' }) // 'or'
-   * faker.word.conjunction({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'hence'
+   * faker.word.conjunction({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'since'
    *
    * @since 6.0.0
    */
@@ -243,10 +243,10 @@ export class WordModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.word.interjection() // 'gah'
-   * faker.word.interjection(5) // 'fooey'
-   * faker.word.interjection(100) // 'yowza'
-   * faker.word.interjection({ strategy: 'shortest' }) // 'hm'
+   * faker.word.interjection() // 'ugh'
+   * faker.word.interjection(5) // 'yahoo'
+   * faker.word.interjection(100) // 'eek'
+   * faker.word.interjection({ strategy: 'shortest' }) // 'aw'
    * faker.word.interjection({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'boohoo'
    *
    * @since 6.0.0
@@ -316,11 +316,11 @@ export class WordModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.word.noun() // 'external'
-   * faker.word.noun(5) // 'front'
-   * faker.word.noun(100) // 'care'
+   * faker.word.noun() // 'mantua'
+   * faker.word.noun(5) // 'slide'
+   * faker.word.noun(100) // 'newsletter'
    * faker.word.noun({ strategy: 'shortest' }) // 'ad'
-   * faker.word.noun({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'average'
+   * faker.word.noun({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'jungle'
    *
    * @since 6.0.0
    */
@@ -389,11 +389,11 @@ export class WordModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.word.preposition() // 'without'
-   * faker.word.preposition(5) // 'abaft'
-   * faker.word.preposition(100) // 'an'
+   * faker.word.preposition() // 'like'
+   * faker.word.preposition(5) // 'round'
+   * faker.word.preposition(100) // 'next'
    * faker.word.preposition({ strategy: 'shortest' }) // 'a'
-   * faker.word.preposition({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'given'
+   * faker.word.preposition({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'circa'
    *
    * @since 6.0.0
    */
@@ -462,11 +462,11 @@ export class WordModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.word.verb() // 'act'
-   * faker.word.verb(5) // 'tinge'
-   * faker.word.verb(100) // 'mess'
-   * faker.word.verb({ strategy: 'shortest' }) // 'do'
-   * faker.word.verb({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'vault'
+   * faker.word.verb() // 'nauseate'
+   * faker.word.verb(5) // 'slump'
+   * faker.word.verb(100) // 'pause'
+   * faker.word.verb({ strategy: 'shortest' }) // 'pip'
+   * faker.word.verb({ length: { min: 5, max: 7 }, strategy: "fail" }) // 'implode'
    *
    * @since 6.0.0
    */
@@ -535,8 +535,8 @@ export class WordModule extends ModuleBase {
    * Defaults to `'any-length'`.
    *
    * @example
-   * faker.word.sample() // 'incidentally'
-   * faker.word.sample(5) // 'fruit'
+   * faker.word.sample() // 'jealous'
+   * faker.word.sample(5) // 'weird'
    *
    * @since 8.0.0
    */
@@ -606,10 +606,10 @@ export class WordModule extends ModuleBase {
    * @param options.count The number of words to return. Defaults to a random value between `1` and `3`.
    *
    * @example
-   * faker.word.words() // 'almost'
-   * faker.word.words(5) // 'before hourly patiently dribble equal'
-   * faker.word.words({ count: 5 }) // 'whoever edible um kissingly faraway'
-   * faker.word.words({ count: { min: 5, max: 10 } }) // 'vice buoyant through apropos poised total wary boohoo'
+   * faker.word.words() // 'tapioca blaring'
+   * faker.word.words(5) // 'the mismatch plagiarise past interestingly'
+   * faker.word.words({ count: 5 }) // 'reassuringly amongst wedge colorfully orientate'
+   * faker.word.words({ count: { min: 5, max: 10 } }) // 'ceramic yuck supposing friendly serpentine if'
    *
    * @since 8.0.0
    */

--- a/src/simple-faker.ts
+++ b/src/simple-faker.ts
@@ -47,25 +47,25 @@ export class SimpleFaker {
    * @see faker.seed(): For generating reproducible values.
    *
    * @example
-   * faker.seed(1234);
-   *
+   * faker.seed(1234); // 1234
+   * 
    * // Default behavior
    * // faker.setDefaultRefDate();
-   * faker.date.past(); // Changes based on the current date/time
-   *
+   * faker.date.past(); // '2024-03-11T20:42:37.195Z'
+   * 
    * // Use a static ref date
-   * faker.setDefaultRefDate(new Date('2020-01-01'));
-   * faker.date.past(); // Reproducible '2019-07-03T08:27:58.118Z'
-   *
+   * faker.setDefaultRefDate(new Date('2020-01-01')); // undefined
+   * faker.date.past(); // '2019-08-16T01:40:21.582Z'
+   * 
    * // Use a ref date that changes every time it is used
    * let clock = new Date("2020-01-01").getTime();
    * faker.setDefaultRefDate(() => {
    *   clock += 1000; // +1s
    *   return new Date(clock);
-   * });
-   *
-   * faker.defaultRefDate() // 2020-01-01T00:00:01Z
-   * faker.defaultRefDate() // 2020-01-01T00:00:02Z
+   * }); // undefined
+   * 
+   * faker.defaultRefDate() // '2020-01-01T00:00:01.000Z'
+   * faker.defaultRefDate() // '2020-01-01T00:00:02.000Z'
    *
    * @since 8.0.0
    */
@@ -168,14 +168,14 @@ export class SimpleFaker {
    *
    * @example
    * // Consistent values for tests:
-   * faker.seed(42)
+   * faker.seed(42) // 42
    * faker.number.int(10); // 4
-   * faker.number.int(10); // 8
-   *
-   * faker.seed(42)
+   * faker.number.int(10); // 10
+   * 
+   * faker.seed(42) // 42
    * faker.number.int(10); // 4
-   * faker.number.int(10); // 8
-   *
+   * faker.number.int(10); // 10
+   * 
    * // Random but reproducible tests:
    * // Simply log the seed, and if you need to reproduce it, insert the seed here
    * console.log('Running test with seed:', faker.seed());
@@ -205,14 +205,14 @@ export class SimpleFaker {
    *
    * @example
    * // Consistent values for tests:
-   * faker.seed([42, 13, 17])
-   * faker.number.int(10); // 4
-   * faker.number.int(10); // 8
-   *
-   * faker.seed([42, 13, 17])
-   * faker.number.int(10); // 4
-   * faker.number.int(10); // 8
-   *
+   * faker.seed([42, 13, 17]) // [ 42, 13, 17 ]
+   * faker.number.int(10); // 3
+   * faker.number.int(10); // 10
+   * 
+   * faker.seed([42, 13, 17]) // [ 42, 13, 17 ]
+   * faker.number.int(10); // 3
+   * faker.number.int(10); // 10
+   * 
    * // Random but reproducible tests:
    * // Simply log the seed, and if you need to reproduce it, insert the seed here
    * console.log('Running test with seed:', faker.seed());
@@ -242,23 +242,23 @@ export class SimpleFaker {
    *
    * @example
    * // Consistent values for tests (using a number):
-   * faker.seed(42)
+   * faker.seed(42) // 42
    * faker.number.int(10); // 4
-   * faker.number.int(10); // 8
-   *
-   * faker.seed(42)
+   * faker.number.int(10); // 10
+   * 
+   * faker.seed(42) // 42
    * faker.number.int(10); // 4
-   * faker.number.int(10); // 8
-   *
+   * faker.number.int(10); // 10
+   * 
    * // Consistent values for tests (using an array):
-   * faker.seed([42, 13, 17])
-   * faker.number.int(10); // 4
-   * faker.number.int(10); // 8
-   *
-   * faker.seed([42, 13, 17])
-   * faker.number.int(10); // 4
-   * faker.number.int(10); // 8
-   *
+   * faker.seed([42, 13, 17]) // [ 42, 13, 17 ]
+   * faker.number.int(10); // 3
+   * faker.number.int(10); // 10
+   * 
+   * faker.seed([42, 13, 17]) // [ 42, 13, 17 ]
+   * faker.number.int(10); // 3
+   * faker.number.int(10); // 10
+   * 
    * // Random but reproducible tests:
    * // Simply log the seed, and if you need to reproduce it, insert the seed here
    * console.log('Running test with seed:', faker.seed());

--- a/src/simple-faker.ts
+++ b/src/simple-faker.ts
@@ -48,22 +48,22 @@ export class SimpleFaker {
    *
    * @example
    * faker.seed(1234); // 1234
-   * 
+   *
    * // Default behavior
    * // faker.setDefaultRefDate();
    * faker.date.past(); // '2024-03-11T20:42:37.195Z'
-   * 
+   *
    * // Use a static ref date
    * faker.setDefaultRefDate(new Date('2020-01-01')); // undefined
    * faker.date.past(); // '2019-08-16T01:40:21.582Z'
-   * 
+   *
    * // Use a ref date that changes every time it is used
    * let clock = new Date("2020-01-01").getTime();
    * faker.setDefaultRefDate(() => {
    *   clock += 1000; // +1s
    *   return new Date(clock);
    * }); // undefined
-   * 
+   *
    * faker.defaultRefDate() // '2020-01-01T00:00:01.000Z'
    * faker.defaultRefDate() // '2020-01-01T00:00:02.000Z'
    *
@@ -171,11 +171,11 @@ export class SimpleFaker {
    * faker.seed(42) // 42
    * faker.number.int(10); // 4
    * faker.number.int(10); // 10
-   * 
+   *
    * faker.seed(42) // 42
    * faker.number.int(10); // 4
    * faker.number.int(10); // 10
-   * 
+   *
    * // Random but reproducible tests:
    * // Simply log the seed, and if you need to reproduce it, insert the seed here
    * console.log('Running test with seed:', faker.seed());
@@ -208,11 +208,11 @@ export class SimpleFaker {
    * faker.seed([42, 13, 17]) // [ 42, 13, 17 ]
    * faker.number.int(10); // 3
    * faker.number.int(10); // 10
-   * 
+   *
    * faker.seed([42, 13, 17]) // [ 42, 13, 17 ]
    * faker.number.int(10); // 3
    * faker.number.int(10); // 10
-   * 
+   *
    * // Random but reproducible tests:
    * // Simply log the seed, and if you need to reproduce it, insert the seed here
    * console.log('Running test with seed:', faker.seed());
@@ -245,20 +245,20 @@ export class SimpleFaker {
    * faker.seed(42) // 42
    * faker.number.int(10); // 4
    * faker.number.int(10); // 10
-   * 
+   *
    * faker.seed(42) // 42
    * faker.number.int(10); // 4
    * faker.number.int(10); // 10
-   * 
+   *
    * // Consistent values for tests (using an array):
    * faker.seed([42, 13, 17]) // [ 42, 13, 17 ]
    * faker.number.int(10); // 3
    * faker.number.int(10); // 10
-   * 
+   *
    * faker.seed([42, 13, 17]) // [ 42, 13, 17 ]
    * faker.number.int(10); // 3
    * faker.number.int(10); // 10
-   * 
+   *
    * // Random but reproducible tests:
    * // Simply log the seed, and if you need to reproduce it, insert the seed here
    * console.log('Running test with seed:', faker.seed());


### PR DESCRIPTION
Continuation of #3287

- #3287

Fixes #3345

- #3345

Related to #3335

- #3335

---

Adds a script to re-generate all examples' results:

````sh
pnpm run generate:examples
````