### PR TITLE
test: enable test to generate Number.MAX_SAFE_INTEGER

### DIFF
--- a/test/modules/number.spec.ts
+++ b/test/modules/number.spec.ts
@@ -710,8 +710,7 @@ describe('number', () => {
         expect(actual).toBe(0);
       });
 
-      // TODO @ST-DDT 2023-10-12: This requires a randomizer with 53 bits of precision
-      it.todo('should be able to return MAX_SAFE_INTEGER', () => {
+      it('should be able to return MAX_SAFE_INTEGER', () => {
         randomizer.next = () => MERSENNE_MAX_VALUE;
         const actual = customFaker.number.int();
         expect(actual).toBe(Number.MAX_SAFE_INTEGER);

--- a/test/utils/mersenne-test-utils.ts
+++ b/test/utils/mersenne-test-utils.ts
@@ -14,4 +14,4 @@ export const TWISTER_53CO_MAX_VALUE = 0.9999999999999999;
 /**
  * The maximum value that can be returned by `next()`.
  */
-export const MERSENNE_MAX_VALUE = TWISTER_32CO_MAX_VALUE;
+export const MERSENNE_MAX_VALUE = TWISTER_53CO_MAX_VALUE;


### PR DESCRIPTION
I checked the codebase for todos and found this disabled test, so I fixed and enabled it.

The tests have been added in v8.4.0

- #2470

And should have been enabled in v9.0.0-alpha.0 two months later

- #2357