### PR TITLE
test: disable summary for local

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,9 @@ export default defineConfig({
       reporter: ['clover', 'cobertura', 'lcov', 'text'],
       include: ['src'],
     },
-    reporters: CI_PREFLIGHT ? ['default', 'github-actions'] : ['default'],
+    reporters: CI_PREFLIGHT
+      ? ['default', 'github-actions']
+      : [['default', { summary: false }]],
     sequence: {
       seed: VITEST_SEQUENCE_SEED,
       shuffle: true,


### PR DESCRIPTION
This sets the `summary` prop to false for local / non-ci, because we are logging stuff while tests are running, and this makes putting out the summary only once at the end instead of refreshing the terminal-screen.