### PR TITLE
fix: test before using Buffers

### DIFF
--- a/src/internal/base64.ts
+++ b/src/internal/base64.ts
@@ -14,7 +14,7 @@
  * @example const encodedHeader = toBase64(JSON.stringify(header));
  */
 export const toBase64: (input: string) => string =
-  typeof Buffer === 'undefined'
+  typeof Buffer === 'undefined' || !bufferFeatureCheck('base64')
     ? (input) => {
         const utf8Bytes = new TextEncoder().encode(input);
         const binaryString = Array.from(utf8Bytes, (byte) =>
@@ -39,10 +39,24 @@ export const toBase64: (input: string) => string =
  * @example const encodedHeader = toBase64Url(JSON.stringify(header));
  */
 export const toBase64Url: (input: string) => string =
-  typeof Buffer === 'undefined'
+  typeof Buffer === 'undefined' || !bufferFeatureCheck('base64url')
     ? (input) =>
         toBase64(input)
           .replaceAll('+', '-')
           .replaceAll('/', '_')
           .replaceAll(/=+$/g, '')
     : (input) => Buffer.from(input).toString('base64url');
+
+/**
+ * Checks whether the environment supports the given encoding on the `Buffer` class.
+ * This is required because some `Buffer` polyfills do not support all encodings.
+ *
+ * @param encoding The encoding to check.
+ */
+function bufferFeatureCheck(encoding: 'base64' | 'base64url'): boolean {
+  try {
+    return typeof Buffer.from('test').toString(encoding) === 'string';
+  } catch {
+    return false;
+  }
+}

--- a/src/internal/base64.ts
+++ b/src/internal/base64.ts
@@ -53,7 +53,7 @@ export const toBase64Url: (input: string) => string =
  *
  * @param encoding The encoding to check.
  */
-function bufferFeatureCheck(encoding: 'base64' | 'base64url'): boolean {
+function bufferFeatureCheck(encoding: BufferEncoding): boolean {
   try {
     return typeof Buffer.from('test').toString(encoding) === 'string';
   } catch {

--- a/src/internal/base64.ts
+++ b/src/internal/base64.ts
@@ -53,6 +53,7 @@ export const toBase64Url: (input: string) => string =
  *
  * @param encoding The encoding to check.
  *
+ * @see https://www.npmjs.com/package/buffer
  * @see https://github.com/feross/buffer/issues/309
  */
 function bufferFeatureCheck(encoding: BufferEncoding): boolean {

--- a/src/internal/base64.ts
+++ b/src/internal/base64.ts
@@ -52,6 +52,8 @@ export const toBase64Url: (input: string) => string =
  * This is required because some `Buffer` polyfills do not support all encodings.
  *
  * @param encoding The encoding to check.
+ *
+ * @see https://github.com/feross/buffer/issues/309
  */
 function bufferFeatureCheck(encoding: BufferEncoding): boolean {
   try {


### PR DESCRIPTION
Fixes #3285

---

Adds a feature check before committing to use the Buffer methods.

## Alternative

Remove the Buffer "shortcut" check and usage from the base64url method.