### PR TITLE
docs: revert npm download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p>Generate massive amounts of fake (but realistic) data for testing and development.</p>
   
   [![npm version](https://badgen.net/npm/v/@faker-js/faker)](https://www.npmjs.com/package/@faker-js/faker)
-  [![npm downloads](https://badgen.net/npm/dm/@faker-js/faker)](https://npm-compare.com/@faker-js/faker/#timeRange=ALL)
+  [![npm downloads](https://badgen.net/npm/dm/@faker-js/faker)](https://www.npmjs.com/package/@faker-js/faker)
   [![Continuous Integration](https://github.com/faker-js/faker/actions/workflows/ci.yml/badge.svg)](https://github.com/faker-js/faker/actions/workflows/ci.yml)
   [![codecov](https://codecov.io/gh/faker-js/faker/branch/next/graph/badge.svg?token=N61U168G08)](https://codecov.io/gh/faker-js/faker)
   [![Chat on Discord](https://img.shields.io/badge/chat-discord-blue?style=flat&logo=discord)](https://chat.fakerjs.dev)


### PR DESCRIPTION
See https://github.com/community/maintainers/discussions/442#discussioncomment-12401989

The `npm-compare.com` is a fake site of `npmcompare.com`. This user has been terminated, and the GitHub staff has deleted all `npm-compare.com` PRs.