### PR TITLE
infra(comment-issue): fix display of thumbs up emoji

### DIFF
--- a/.github/workflows/comment-issue.yml
+++ b/.github/workflows/comment-issue.yml
@@ -31,7 +31,7 @@ jobs:
 
               We will start the implementation based on:
 
-              - the number of votes (:+1:) and comments
+              - the number of votes ( :+1: ) and comments
               - the relevance for the ecosystem
               - availability of alternatives and workarounds
               - and the complexity of the requested feature


### PR DESCRIPTION
# Description

I noticed that the thumbs up emoji on out automatic feature replies were not rendered correctly anymore:

Here are some references:

- [#416](https://github.com/faker-js/faker/issues/416#issuecomment-1535810786)
- [#2623](https://github.com/faker-js/faker/issues/2623#issuecomment-1909489510)
- [#2839](https://github.com/faker-js/faker/issues/2839#issuecomment-2068032044)
- [#878](https://github.com/faker-js/faker/issues/878#issuecomment-2081516434)
- basically any issue with "s: waiting for user interest"

Apparently, the Markdown render requires a space in front and after a emoji reference:

|          | Before   | After      |
| -------- | -------- | ---------- |
| Text     | `(:+1:)` | `( :+1: )` |
| Rendered | (:+1:)   | ( :+1: )   |

This have to have changed during the last years, since it worked as expected when we introduced the automatic reply: https://github.com/faker-js/faker/pull/2041#issuecomment-1518702023