### PR TITLE
test: use validator@13.15.0 with isULID, isISO31661Numeric, isISO15924

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/node": "22.14.1",
     "@types/sanitize-html": "2.15.0",
     "@types/semver": "7.7.0",
-    "@types/validator": "13.12.3",
+    "@types/validator": "13.15.0",
     "@vitest/coverage-v8": "3.1.1",
     "@vitest/eslint-plugin": "1.1.42",
     "@vitest/ui": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: 7.7.0
         version: 7.7.0
       '@types/validator':
-        specifier: 13.12.3
-        version: 13.12.3
+        specifier: 13.15.0
+        version: 13.15.0
       '@vitest/coverage-v8':
         specifier: 3.1.1
         version: 3.1.1(vitest@3.1.1)
@@ -892,8 +892,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/validator@13.12.3':
-    resolution: {integrity: sha512-2ipwZ2NydGQJImne+FhNdhgRM37e9lCev99KnqkbFHd94Xn/mErARWI1RSLem1QA19ch5kOhzIZd7e8CA2FI8g==}
+  '@types/validator@13.15.0':
+    resolution: {integrity: sha512-nh7nrWhLr6CBq9ldtw0wx+z9wKnnv/uTVLA9g/3/TcOYxbpOSZE+MhKPmWqU+K0NvThjhv12uD8MuqijB0WzEA==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
@@ -4340,7 +4340,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/validator@13.12.3': {}
+  '@types/validator@13.15.0': {}
 
   '@types/web-bluetooth@0.0.21': {}
 

--- a/test/locale-imports.spec.ts
+++ b/test/locale-imports.spec.ts
@@ -1,8 +1,8 @@
+import isISO15924 from 'validator/lib/isISO15924';
 import { describe, expect, it } from 'vitest';
 import type { Faker } from '../src';
 import { allLocales } from '../src';
 import { keys } from '../src/internal/keys';
-import isISO15924 from 'validator/lib/isISO15924';
 
 describe.each(keys(allLocales))('locale imports', (locale) => {
   it(`should be possible to directly require('@faker-js/faker/locale/${locale}')`, () => {

--- a/test/locale-imports.spec.ts
+++ b/test/locale-imports.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Faker } from '../src';
 import { allLocales } from '../src';
 import { keys } from '../src/internal/keys';
+import isISO15924 from 'validator/lib/isISO15924';
 
 describe.each(keys(allLocales))('locale imports', (locale) => {
   it(`should be possible to directly require('@faker-js/faker/locale/${locale}')`, () => {
@@ -43,24 +44,7 @@ describe.each(keys(allLocales))('locale imports', (locale) => {
       expect(metadata.language).toBeTypeOf('string');
       expect(metadata.language).toMatch(/^[a-z]{2}$/);
       expect(metadata.script).toBeTypeOf('string');
-      expect([
-        'Arab',
-        'Armn',
-        'Beng',
-        'Cyrl',
-        'Deva',
-        'Geor',
-        'Grek',
-        'Hans',
-        'Hant',
-        'Hebr',
-        'Jpan',
-        'Kore',
-        'Latn',
-        'Taml',
-        'Thaa',
-        'Thai',
-      ]).toContain(metadata.script);
+      expect(metadata.script).toSatisfy(isISO15924);
       expect(metadata.endonym).toBeTypeOf('string');
       expect(metadata.dir).toBeTypeOf('string');
       expect(['ltr', 'rtl']).toContain(metadata.dir);

--- a/test/modules/location.spec.ts
+++ b/test/modules/location.spec.ts
@@ -1,3 +1,6 @@
+import isISO31661Alpha2 from 'validator/lib/isISO31661Alpha2';
+import isISO31661Alpha3 from 'validator/lib/isISO31661Alpha3';
+import isISO31661Numeric from 'validator/lib/isISO31661Numeric';
 import { describe, expect, it } from 'vitest';
 import {
   FakerError,
@@ -165,6 +168,7 @@ describe('location', () => {
 
           expect(countryCode).toBeTruthy();
           expect(countryCode).toMatch(/^[A-Z]{2}$/);
+          expect(countryCode).toSatisfy(isISO31661Alpha2);
         });
 
         it('returns random alpha-3 countryCode', () => {
@@ -172,6 +176,7 @@ describe('location', () => {
 
           expect(countryCode).toBeTruthy();
           expect(countryCode).toMatch(/^[A-Z]{3}$/);
+          expect(countryCode).toSatisfy(isISO31661Alpha3);
         });
 
         it('returns random numeric countryCode', () => {
@@ -179,6 +184,7 @@ describe('location', () => {
 
           expect(countryCode).toBeTruthy();
           expect(countryCode).toMatch(/^\d{3}$/);
+          expect(countryCode).toSatisfy(isISO31661Numeric);
         });
       });
 

--- a/test/modules/string.spec.ts
+++ b/test/modules/string.spec.ts
@@ -1,3 +1,4 @@
+import isULID from 'validator/lib/isULID';
 import { describe, expect, it } from 'vitest';
 import { FakerError, faker } from '../../src';
 import { seededTests } from '../support/seeded-runs';
@@ -774,6 +775,7 @@ describe('string', () => {
           const ulid = faker.string.ulid();
           const regex = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/;
           expect(ulid).toMatch(regex);
+          expect(ulid).toSatisfy(isULID);
         });
       });
 


### PR DESCRIPTION
By upgrading @types/validator to @13.15.0 we can take advantage of the new functions isULID, isISO31661Numeric and isISO15924 from validator to improve and simplify tests.