### PR TITLE
infra: stop using node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node_version: [18, 20, 22, 24]
+        node_version: [20, 22, 24]
       fail-fast: false
     timeout-minutes: 10
 


### PR DESCRIPTION
<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md#committing -->

This PR does not touch user facing code, but only removes node 18 pipelines and allows to update the rimraf package which is only internally used anyway.
~~The only prepared used facing change was made to the guide and tells the user to use at least node 20~~, but this PR does not yet remove node 18 support, as tsup still targets node 18.