### PR TITLE
infra: more precise engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,12 @@
     "type": "git",
     "url": "git+https://github.com/faker-js/faker.git"
   },
-  "funding": [{
-    "type": "opencollective",
-    "url": "https://opencollective.com/fakerjs"
-  }],
+  "funding": [
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/fakerjs"
+    }
+  ],
   "license": "MIT",
   "sideEffects": false,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -56,12 +56,10 @@
     "type": "git",
     "url": "git+https://github.com/faker-js/faker.git"
   },
-  "funding": [
-    {
-      "type": "opencollective",
-      "url": "https://opencollective.com/fakerjs"
-    }
-  ],
+  "funding": [{
+    "type": "opencollective",
+    "url": "https://opencollective.com/fakerjs"
+  }],
   "license": "MIT",
   "sideEffects": false,
   "type": "module",
@@ -137,7 +135,7 @@
   },
   "packageManager": "pnpm@10.12.4",
   "engines": {
-    "node": ">=20.19",
+    "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
     "npm": ">=10"
   },
   "pnpm": {


### PR DESCRIPTION
Adds a more precise engines field

https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require

This ensures, for example, that a developer using Node 22.0.0 will receive a warning if they attempt to install v10 so they can bump their version to v22.13+
