### PR TITLE
refactor(image): mark loremflickr as deprecated, use only picsum photos in url()

### DIFF
--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -176,6 +176,13 @@ export class ImageModule extends ModuleBase {
       category?: string;
     } = {}
   ): string {
+    deprecated({
+      deprecated: 'faker.image.urlLoremFlickr()',
+      proposed: 'faker.image.url()',
+      since: '10.1.0',
+      until: '11.0.0',
+    });
+
     const {
       width = this.faker.number.int({ min: 1, max: 3999 }),
       height = this.faker.number.int({ min: 1, max: 3999 }),

--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -1,4 +1,5 @@
 import { toBase64 } from '../../internal/base64';
+import { deprecated } from '../../internal/deprecated';
 import { ModuleBase } from '../../internal/module-base';
 import type { SexType } from '../person';
 

--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -7,7 +7,7 @@ import type { SexType } from '../person';
  *
  * ### Overview
  *
- * For a random image, use [`url()`](https://fakerjs.dev/api/image.html#url). This will not return the image directly but a URL pointing to an image from an image provider "Picsum".  Other providers may be added in future versions. You can request an image specifically from this provider, with additional options using [`urlPicsumPhotos()`](https://fakerjs.dev/api/image.html#urlpicsumphotos).
+ * For a random image, use [`url()`](https://fakerjs.dev/api/image.html#url). This will not return the image directly but an URL pointing to an image from an image provider like "Picsum". Other providers may be added in future versions. You can request an image specifically from this provider, with additional options using [`urlPicsumPhotos()`](https://fakerjs.dev/api/image.html#urlpicsumphotos).
  *
  * For a random placeholder image containing only solid color and text, use [`dataUri()`](https://fakerjs.dev/api/image.html#datauri) (returns a SVG string).
  *

--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -7,7 +7,7 @@ import type { SexType } from '../person';
  *
  * ### Overview
  *
- * For a random image, use [`url()`](https://fakerjs.dev/api/image.html#url). This will not return the image directly but a URL pointing to an image from one of two demo image providers "Picsum" and "LoremFlickr". You can request an image specifically from one of two providers using [`urlLoremFlickr()`](https://fakerjs.dev/api/image.html#urlloremflickr) or [`urlPicsumPhotos()`](https://fakerjs.dev/api/image.html#urlpicsumphotos).
+ * For a random image, use [`url()`](https://fakerjs.dev/api/image.html#url). This will not return the image directly but a URL pointing to an image from an image provider "Picsum".  Other providers may be added in future versions. You can request an image specifically from this provider, with additional options using [`urlPicsumPhotos()`](https://fakerjs.dev/api/image.html#urlpicsumphotos).
  *
  * For a random placeholder image containing only solid color and text, use [`dataUri()`](https://fakerjs.dev/api/image.html#datauri) (returns a SVG string).
  *
@@ -95,14 +95,14 @@ export class ImageModule extends ModuleBase {
   /**
    * Generates a random image url.
    *
-   * @remark This method generates a random string representing an URL from loremflickr. Faker is not responsible for the content of the image or the service providing it.
+   * @remark This method generates a random string representing an URL from an external provider. Faker is not responsible for the content of the image or the service providing it.
    *
    * @param options Options for generating a URL for an image.
    * @param options.width The width of the image. Defaults to a random integer between `1` and `3999`.
    * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.
    *
    * @example
-   * faker.image.url() // 'https://loremflickr.com/640/480?lock=1234'
+   * faker.image.url() // 'https://picsum.photos/seed/NWbJM2B/640/480'
    *
    * @since 8.0.0
    */
@@ -128,9 +128,9 @@ export class ImageModule extends ModuleBase {
     } = options;
 
     const urlMethod = this.faker.helpers.arrayElement([
-      this.urlLoremFlickr,
       ({ width, height }: { width?: number; height?: number }) =>
         this.urlPicsumPhotos({ width, height, grayscale: false, blur: 0 }),
+      // Other providers may be added back here in future versions.
     ]);
 
     return urlMethod({ width, height });
@@ -153,6 +153,8 @@ export class ImageModule extends ModuleBase {
    * faker.image.urlLoremFlickr({ category: 'nature' }) // 'https://loremflickr.com/640/480/nature?lock=1234'
    *
    * @since 8.0.0
+   *
+   * @deprecated LoremFlickr is no longer available, and image links will be broken. Use `faker.image.url()` instead.
    */
   urlLoremFlickr(
     options: {

--- a/test/modules/__snapshots__/image.spec.ts.snap
+++ b/test/modules/__snapshots__/image.spec.ts.snap
@@ -28,13 +28,13 @@ exports[`image > 42 > personPortrait > with sex and size 1`] = `"https://cdn.jsd
 
 exports[`image > 42 > personPortrait > with size 1`] = `"https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/female/128/95.jpg"`;
 
-exports[`image > 42 > url > noArgs 1`] = `"https://picsum.photos/seed/993RBH1Y/1498/3802"`;
+exports[`image > 42 > url > noArgs 1`] = `"https://picsum.photos/seed/B993RBH1Y/1498/3802"`;
 
-exports[`image > 42 > url > with height 1`] = `"https://picsum.photos/seed/B993RBH1Y/1498/128"`;
+exports[`image > 42 > url > with height 1`] = `"https://picsum.photos/seed/JB993RBH1Y/1498/128"`;
 
-exports[`image > 42 > url > with width 1`] = `"https://picsum.photos/seed/B993RBH1Y/128/1498"`;
+exports[`image > 42 > url > with width 1`] = `"https://picsum.photos/seed/JB993RBH1Y/128/1498"`;
 
-exports[`image > 42 > url > with width and height 1`] = `"https://loremflickr.com/128/128?lock=8563273192166996"`;
+exports[`image > 42 > url > with width and height 1`] = `"https://picsum.photos/seed/WJB993R/128/128"`;
 
 exports[`image > 42 > urlLoremFlickr > noArgs 1`] = `"https://loremflickr.com/1498/3802?lock=6593215287158609"`;
 
@@ -90,13 +90,13 @@ exports[`image > 1211 > personPortrait > with sex and size 1`] = `"https://cdn.j
 
 exports[`image > 1211 > personPortrait > with size 1`] = `"https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/male/128/89.jpg"`;
 
-exports[`image > 1211 > url > noArgs 1`] = `"https://loremflickr.com/3714/3573?lock=8982492793493979"`;
+exports[`image > 1211 > url > noArgs 1`] = `"https://picsum.photos/seed/ZFGLlH/3714/3573"`;
 
-exports[`image > 1211 > url > with height 1`] = `"https://picsum.photos/seed/ZFGLlH/3714/128"`;
+exports[`image > 1211 > url > with height 1`] = `"https://picsum.photos/seed/dZFGLlHOLE/3714/128"`;
 
-exports[`image > 1211 > url > with width 1`] = `"https://picsum.photos/seed/ZFGLlH/128/3714"`;
+exports[`image > 1211 > url > with width 1`] = `"https://picsum.photos/seed/dZFGLlHOLE/128/3714"`;
 
-exports[`image > 1211 > url > with width and height 1`] = `"https://picsum.photos/seed/dZFGLlHOLE/128/128"`;
+exports[`image > 1211 > url > with width and height 1`] = `"https://picsum.photos/seed/TdZFGLlHOL/128/128"`;
 
 exports[`image > 1211 > urlLoremFlickr > noArgs 1`] = `"https://loremflickr.com/3714/3573?lock=2031760796090808"`;
 
@@ -152,13 +152,13 @@ exports[`image > 1337 > personPortrait > with sex and size 1`] = `"https://cdn.j
 
 exports[`image > 1337 > personPortrait > with size 1`] = `"https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/female/128/15.jpg"`;
 
-exports[`image > 1337 > url > noArgs 1`] = `"https://loremflickr.com/1048/635?lock=4137158724208997"`;
+exports[`image > 1337 > url > noArgs 1`] = `"https://picsum.photos/seed/sjwgYJ/1048/635"`;
 
-exports[`image > 1337 > url > with height 1`] = `"https://loremflickr.com/1048/128?lock=2505140979113303"`;
+exports[`image > 1337 > url > with height 1`] = `"https://picsum.photos/seed/hsjwg/1048/128"`;
 
-exports[`image > 1337 > url > with width 1`] = `"https://loremflickr.com/128/1048?lock=2505140979113303"`;
+exports[`image > 1337 > url > with width 1`] = `"https://picsum.photos/seed/hsjwg/128/1048"`;
 
-exports[`image > 1337 > url > with width and height 1`] = `"https://loremflickr.com/128/128?lock=1429298155729043"`;
+exports[`image > 1337 > url > with width and height 1`] = `"https://picsum.photos/seed/9hsjwg/128/128"`;
 
 exports[`image > 1337 > urlLoremFlickr > noArgs 1`] = `"https://loremflickr.com/1048/635?lock=2505140979113303"`;
 


### PR DESCRIPTION
fix #3443
