### PR TITLE
fix(locale): fix the Spring Airlines IATA Code

### DIFF
--- a/src/locales/en/airline/airline.ts
+++ b/src/locales/en/airline/airline.ts
@@ -101,7 +101,7 @@ export default [
   { name: 'Southwest Airlines', iataCode: 'WN' },
   { name: 'SpiceJet', iataCode: 'SG' },
   { name: 'Spirit Airlines', iataCode: 'NK' },
-  { name: 'Spring Airlines', iataCode: '9S' },
+  { name: 'Spring Airlines', iataCode: '9C' },
   { name: 'SriLankan Airlines', iataCode: 'UL' },
   { name: 'Star Peru', iataCode: '2I' },
   { name: 'Sun Country Airlines', iataCode: 'SY' },

--- a/src/locales/zh_CN/airline/airline.ts
+++ b/src/locales/zh_CN/airline/airline.ts
@@ -94,7 +94,7 @@ export default [
   { name: '西南航空公司', iataCode: 'WN' },
   { name: '香料航空公司', iataCode: 'SG' },
   { name: '精神航空公司', iataCode: 'NK' },
-  { name: '春秋航空公司', iataCode: '9S' },
+  { name: '春秋航空公司', iataCode: '9C' },
   { name: '斯里兰卡航空公司', iataCode: 'UL' },
   { name: '秘鲁星航空公司', iataCode: '2I' },
   { name: '太阳城航空公司', iataCode: 'SY' },


### PR DESCRIPTION
The IATA Code of Spring Airlines is '9C' instead of '9S'

Reference: https://en.wikipedia.org/wiki/Spring_Airlines