### PR TITLE
docs: fix lack of contrast in developer console log message in light mode

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -151,7 +151,7 @@ const config = defineConfig({
       'script',
       { id: 'browser-console-faker' },
       `
-const logStyle = 'background: rgba(16, 183, 127, 0.14); color: rgba(255, 255, 245, 0.86); padding: 0.5rem; display: inline-block;';
+const logStyle = 'background: rgba(16, 183, 127, 0.14); padding: 0.5rem; display: inline-block;';
 console.log(\`%cIf you would like to test Faker in the browser console, you can do so using 'await enableFaker()'.
 If you would like to test Faker in a playground, visit https://new.fakerjs.dev.\`, logStyle);
 async function enableFaker() {


### PR DESCRIPTION
fix #3672

light mode
<img width="544" height="116" alt="Screenshot 2025-12-14 at 20 21 28" src="https://github.com/user-attachments/assets/1d75d356-e354-4466-8250-b1a829bff7f9" />

dark mode
<img width="547" height="113" alt="Screenshot 2025-12-14 at 20 21 51" src="https://github.com/user-attachments/assets/c62a8203-61d1-4be0-a1d5-fd3a6846bf1e" />
