### PR TITLE
test: add custom matcher "toStartWith"

### DIFF
--- a/test/integration/modules/image.spec.ts
+++ b/test/integration/modules/image.spec.ts
@@ -22,7 +22,7 @@ import { faker } from '../../../src';
  */
 async function assertWorkingUrl(address: string): Promise<void> {
   expect(address).toBeTypeOf('string');
-  expect(address).toMatch(/^https:\/\//);
+  expect(address).toStartWith('https://');
   expect(() => new URL(address)).not.toThrowError();
 
   await expect(

--- a/test/locale-data.spec.ts
+++ b/test/locale-data.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { allLocales } from '../src';
-import './vitest-extensions';
 
 function checkLocaleData(data: unknown) {
   if (Array.isArray(data)) {

--- a/test/modules/finance-iban.spec.ts
+++ b/test/modules/finance-iban.spec.ts
@@ -16,7 +16,7 @@ describe('finance_iban', () => {
         countryCode: country,
       });
 
-      expect(actual).toMatch(new RegExp(`^${country}`));
+      expect(actual).toStartWith(country);
       expect(actual).toSatisfy(isIBAN);
     });
   });

--- a/test/modules/git.spec.ts
+++ b/test/modules/git.spec.ts
@@ -67,16 +67,16 @@ describe('git', () => {
 
           expect(parts[0]).toMatch(/^commit [a-f0-9]+$/);
 
-          const authorRegex = /^Author: .*$/;
+          const authorPrefix = 'Author: ';
           if (parts.length === 7) {
             expect(parts[1]).toMatch(/^Merge: [a-f0-9]+ [a-f0-9]+$/);
-            expect(parts[2]).toMatch(authorRegex);
+            expect(parts[2]).toStartWith(authorPrefix);
             expect(parts[2].substring(8)).toSatisfy(isValidCommitAuthor);
             expect(parts[3]).toMatch(/^Date: .+$/);
             expect(parts[4]).toBe('');
             expect(parts[5]).toMatch(/^\s{4}.+$/);
           } else {
-            expect(parts[1]).toMatch(authorRegex);
+            expect(parts[1]).toStartWith(authorPrefix);
             expect(parts[1].substring(8)).toSatisfy(isValidCommitAuthor);
             expect(parts[2]).toMatch(/^Date: .+$/);
             expect(parts[3]).toBe('');

--- a/test/modules/helpers.spec.ts
+++ b/test/modules/helpers.spec.ts
@@ -3,7 +3,6 @@ import { FakerError, faker } from '../../src';
 import { luhnCheck } from '../../src/modules/helpers/luhn-check';
 import { seededTests } from '../support/seeded-runs';
 import { times } from './../support/times';
-import './../vitest-extensions';
 
 const NON_SEEDED_BASED_RUN = 5;
 

--- a/test/modules/internet.spec.ts
+++ b/test/modules/internet.spec.ts
@@ -864,7 +864,7 @@ describe('internet', () => {
           expect(password).toBeTruthy();
           expect(password).toBeTypeOf('string');
           expect(password).toHaveLength(32);
-          expect(password).toMatch(/^a!G6/);
+          expect(password).toStartWith('a!G6');
           expect(password).toSatisfy(isStrongPassword);
         });
       });

--- a/test/modules/location.spec.ts
+++ b/test/modules/location.spec.ts
@@ -246,7 +246,7 @@ describe('location', () => {
       describe('buildingNumber()', () => {
         it('never starts with a zero', () => {
           const buildingNumber = faker.location.buildingNumber();
-          expect(buildingNumber).not.toMatch(/^0/);
+          expect(buildingNumber).not.toStartWith('0');
         });
       });
 

--- a/test/scripts/apidocs/verify-jsdoc-tags.spec.ts
+++ b/test/scripts/apidocs/verify-jsdoc-tags.spec.ts
@@ -61,7 +61,7 @@ function assertDescription(description: string): void {
   const links = [...description.matchAll(linkRegexp)].map((m) => m[2]);
 
   for (const link of links) {
-    expect(link).toMatch(/^https?:\/\//);
+    expect(link).toStartWith('https://');
     expect(link).toSatisfy(isURL);
 
     if (link.includes('fakerjs.dev/api/')) {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,3 +1,4 @@
 import { chai } from 'vitest';
+import './vitest-extensions';
 
 chai.config.truncateThreshold = 10000;

--- a/test/vitest-extensions.ts
+++ b/test/vitest-extensions.ts
@@ -17,10 +17,33 @@ expect.extend({
           : `No duplicate values in [${received.join(', ')}]`,
     };
   },
+  toStartWith(actual: unknown, prefix: string) {
+    const { isNot } = this;
+
+    return {
+      pass: typeof actual === 'string' && actual.startsWith(prefix),
+      actual,
+      expected: `${prefix}...`,
+      message: () =>
+        isNot
+          ? `String did start with the "${prefix}".`
+          : `String did not start with the "${prefix}".`,
+    };
+  },
 });
 
 interface CustomMatchers {
+  /**
+   * Expects that a list of elements does not contain any duplicate entries.
+   */
   toContainDuplicates(): void;
+
+  /**
+   * Expects that a string has the provided prefix.
+   *
+   * @param prefix The prefix to check for.
+   */
+  toStartWith(prefix: string): void;
 }
 
 declare module 'vitest' {


### PR DESCRIPTION
# Description

This PR adds a new custom matcher "toStartWith" to vitest "expect" namespace.
This matcher enables developers to test strings for a specific prefix match on any value. This keeping the test code itself as well as potential error messages more clean, compared to using regular expressions.

Additionally, the vitest custom matcher initialization has been moved to the "setup"-file, to ensure that theses are available in all test files.

> [!NOTE]
> This PR is in preparation for the implementation of #3699. I required an easy to grasp api to validate the epoch bytes there, landed on the api present in this PR and found that other tests can benefit from it as well.