### PR TITLE
feat(locales): add Norwegian (nb_NO) zodiac sign definitions

### DIFF
--- a/src/locales/nb_NO/person/index.ts
+++ b/src/locales/nb_NO/person/index.ts
@@ -9,6 +9,7 @@ import last_name_pattern from './last_name_pattern';
 import name_ from './name';
 import prefix from './prefix';
 import suffix from './suffix';
+import western_zodiac_sign from './western_zodiac_sign';
 
 const person: PersonDefinition = {
   first_name,
@@ -17,6 +18,7 @@ const person: PersonDefinition = {
   name: name_,
   prefix,
   suffix,
+  western_zodiac_sign,
 };
 
 export default person;

--- a/src/locales/nb_NO/person/western_zodiac_sign.ts
+++ b/src/locales/nb_NO/person/western_zodiac_sign.ts
@@ -1,0 +1,14 @@
+export default [
+  'Fiskene',
+  'Jomfruen',
+  'Krepsen',
+  'Løven',
+  'Skorpionen',
+  'Skytten',
+  'Steinbukken',
+  'Tvillingene',
+  'Tyren',
+  'Vannmannen',
+  'Vekten',
+  'Væren',
+];


### PR DESCRIPTION
In this PR, I add the zodiac sign definitions for the Norwegian (nb_NO) locale.

I used the following table as the source for the translations:

<img width="349" height="443" alt="Skjermbilde 2026-01-28 kl  18 32 23" src="https://github.com/user-attachments/assets/049cb7a0-8dc5-45f1-8128-d6e0a13ff03f" />

Taken from: https://snl.no/stjerneteikn