### PR TITLE
feat(locale): add Norwegian (nb_NO) continent definitions

### DIFF
--- a/src/locales/nb_NO/location/continent.ts
+++ b/src/locales/nb_NO/location/continent.ts
@@ -1,3 +1,4 @@
+// Source: https://no.wikipedia.org/w/index.php?title=Kontinent&oldid=25437662
 export default [
   'Afrika',
   'Antarktis',

--- a/src/locales/nb_NO/location/continent.ts
+++ b/src/locales/nb_NO/location/continent.ts
@@ -1,0 +1,9 @@
+export default [
+  'Afrika',
+  'Antarktis',
+  'Asia',
+  'Australia',
+  'Europa',
+  'Nord-Amerika',
+  'Sør-Amerika',
+];

--- a/src/locales/nb_NO/location/index.ts
+++ b/src/locales/nb_NO/location/index.ts
@@ -8,6 +8,7 @@ import city_name from './city_name';
 import city_pattern from './city_pattern';
 import city_suffix from './city_suffix';
 import common_street_suffix from './common_street_suffix';
+import continent from './continent';
 import county from './county';
 import postcode from './postcode';
 import secondary_address from './secondary_address';
@@ -24,6 +25,7 @@ const location: LocationDefinition = {
   city_pattern,
   city_suffix,
   common_street_suffix,
+  continent,
   county,
   postcode,
   secondary_address,


### PR DESCRIPTION
In this PR, I add the continent definitions for the Norwegian (nb_NO) locale.

Like the _en_ locale, I used the seven-continent model for the translations.

Source: https://no.wikipedia.org/w/index.php?title=Kontinent&oldid=25437662


