### PR TITLE
feat(locale): add Norwegian (nb_NO) direction definition

### DIFF
--- a/src/locales/nb_NO/location/direction.ts
+++ b/src/locales/nb_NO/location/direction.ts
@@ -1,0 +1,6 @@
+export default {
+  cardinal: ['Nord', 'Øst', 'Sør', 'Vest'],
+  cardinal_abbr: ['N', 'Ø', 'S', 'V'],
+  ordinal: ['Nordøst', 'Nordvest', 'Sørøst', 'Sørvest'],
+  ordinal_abbr: ['NØ', 'NV', 'SØ', 'SV'],
+};

--- a/src/locales/nb_NO/location/index.ts
+++ b/src/locales/nb_NO/location/index.ts
@@ -9,6 +9,7 @@ import city_pattern from './city_pattern';
 import city_suffix from './city_suffix';
 import common_street_suffix from './common_street_suffix';
 import county from './county';
+import direction from './direction';
 import postcode from './postcode';
 import secondary_address from './secondary_address';
 import state from './state';
@@ -25,6 +26,7 @@ const location: LocationDefinition = {
   city_suffix,
   common_street_suffix,
   county,
+  direction,
   postcode,
   secondary_address,
   state,


### PR DESCRIPTION
In this PR, I add the direction definitions for the Norwegian (nb_NO) locale.

Source: https://no.wikipedia.org/w/index.php?title=Himmelretning&oldid=23182716