### PR TITLE
infra: trusted publishing via OIDC token

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,16 +46,9 @@ jobs:
           echo -e "$(grep -P '## 📙 API Documentation' -B 10000 README.md)\n\n- [Getting Started Guide](https://fakerjs.dev/guide/)\n- [API Reference](https://fakerjs.dev/api/)\n\n$(grep -P '## 🚀 Features' -A 10000 README.md)" > README.md
           sed -i "s|/fakerjs.dev/|/v$RELEASE_MAJOR.fakerjs.dev/|g" README.md
 
-      - name: Set publishing config
-        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_AUTH_TOKEN}"
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
       - name: Publish
         run: |
-          pnpm publish --tag next --no-git-checks
-        env:
-          NPM_CONFIG_PROVENANCE: true
+          pnpm publish --access public --tag next --no-git-checks --provenance
 
       - name: Set latest/next dist-tag
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,8 +38,6 @@ jobs:
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
           RELEASE_MAJOR=$(jq -r '.version | split(".")[0]' package.json)
           echo "RELEASE_MAJOR=$RELEASE_MAJOR" >> $GITHUB_ENV
-          DIST_TAG=$(jq -r '.version | if split("-")[1] == null then "latest" else "next" end' package.json)
-          echo "DIST_TAG=$DIST_TAG" >> $GITHUB_ENV
 
       - name: Prepare README
         run: |
@@ -49,10 +47,6 @@ jobs:
       - name: Publish
         run: |
           pnpm publish --access public --tag next --no-git-checks --provenance
-
-      - name: Set latest/next dist-tag
-        run: |
-          pnpm dist-tag add @faker-js/faker@$RELEASE_VERSION $DIST_TAG
 
       - name: Push to Release Branch
         run: |


### PR DESCRIPTION
Remove manual token, switch to real OIDC token

⚠️ We need to find out if dist-tag still works 🤔 

> Edit @xDivisionByZerox => it doesn't

if this really works, we can remove the npm token completely