### PR TITLE
docs: fix contribution git commands

### DIFF
--- a/docs/contributing/set-up-a-development-environment.md
+++ b/docs/contributing/set-up-a-development-environment.md
@@ -18,7 +18,7 @@ If you are unfamiliar with Forks, check out [GitHub Forking Guide](https://docs.
 1. Go to the [Faker GitHub repository](https://github.com/faker-js/faker) and click the **Fork** button.
 1. Open a terminal and clone your fork:
    ```sh
-   git clone https://github.com/<Your_GitHub_Username>/faker
+   git clone https://github.com/<Your_GitHub_Username>/faker.git
    ```
 1. Navigate into the cloned directory:
    ```sh
@@ -27,6 +27,7 @@ If you are unfamiliar with Forks, check out [GitHub Forking Guide](https://docs.
 1. Add the upstream source to keep your fork updated:
    ```sh
    git remote add upstream https://github.com/faker-js/faker.git
+   git fetch upstream
    ```
 
 ## Step 2: Choose Your Development Setup

--- a/docs/contributing/submit-a-pull-request.md
+++ b/docs/contributing/submit-a-pull-request.md
@@ -10,7 +10,8 @@ Before making changes, ensure your fork is synchronized with Faker’s latest up
 
 ```sh
 git fetch upstream
-git merge upstream/next origin/next
+git switch next
+git merge upstream/next
 ```
 
 ## Step 2: Create a New Branch


### PR DESCRIPTION
## Summary
fix the branch sync instructions in the pull request guide
- make the clone example explicitly use the fork URL with the  suffix
- fetch upstream right after adding the upstream remote in the setup guide

## Why
The previous Already up to date. example is not a valid merge workflow for keeping a local branch up to date and can confuse first-time contributors. The updated steps match the common fork-based contribution flow described by the surrounding docs.

## Testing
- verified markdown formatting with Prettier