### PR TITLE
fix(locale): phone numbers for en_AU

### DIFF
--- a/src/locales/en_AU/phone_number/format/human.ts
+++ b/src/locales/en_AU/phone_number/format/human.ts
@@ -1,6 +1,18 @@
+// Australian phone numbers:
+// - Mobile: 04XX XXX XXX / +61 4XX XXX XXX
+// - Landline: 0X XXXX XXXX / +61 X XXXX XXXX (area codes: 2, 3, 7, 8)
+// See: https://en.wikipedia.org/wiki/Telephone_numbers_in_Australia
 export default [
-  '0# #### ####',
-  '+61 # #### ####',
+  // Landline with area code: 0 + 1-digit area code (2,3,7,8) + 8 digits
+  '02 #### ####',
+  '03 #### ####',
+  '07 #### ####',
+  '08 #### ####',
+  '+61 2 #### ####',
+  '+61 3 #### ####',
+  '+61 7 #### ####',
+  '+61 8 #### ####',
+  // Mobile: 04XX XXX XXX / +61 4XX XXX XXX
   '04## ### ###',
   '+61 4## ### ###',
 ];

--- a/src/locales/en_AU/phone_number/format/international.ts
+++ b/src/locales/en_AU/phone_number/format/international.ts
@@ -1,1 +1,14 @@
-export default ['+61#########', '+614########'];
+// Australian phone numbers:
+// - Mobile: +614XXXXXXXX (10 digits total after +61)
+// - Landline: +61XYYYYYYYY where X is area code 2-9 (1-digit area code + 8 digits)
+// See: https://en.wikipedia.org/wiki/Telephone_numbers_in_Australia
+// Area codes: 2 (NSW/ACT), 3 (VIC/TAS), 7 (QLD), 8 (SA/NT/WA)
+export default [
+  // Landline with area code: +61 + 1-digit area code (2-9) + 8-digit number
+  '+612########',
+  '+613########',
+  '+617########',
+  '+618########',
+  // Mobile: +614 + 8 digits
+  '+614########',
+];

--- a/src/locales/en_AU/phone_number/format/national.ts
+++ b/src/locales/en_AU/phone_number/format/national.ts
@@ -1,1 +1,12 @@
-export default ['(0#) #### ####', '04## ### ###'];
+// Australian phone numbers:
+// - Landline: (0X) XXXX XXXX (area codes: 2, 3, 7, 8)
+// - Mobile: 04XX XXX XXX
+export default [
+  // Landline with area code
+  '(02) #### ####',
+  '(03) #### ####',
+  '(07) #### ####',
+  '(08) #### ####',
+  // Mobile
+  '04## ### ###',
+];


### PR DESCRIPTION
## Description

Australian phone numbers were generating invalid numbers because the area code was left as a wildcard (`#`) allowing `0` and `1` as the first digit, producing numbers like `+61018806128` which are not valid Australian phone numbers.

## Changes

- **International format**: Replace `+61#########` with explicit area codes
  - Landlines: `+612`, `+613`, `+617`, `+618` (NSW/ACT, VIC/TAS, QLD, SA/NT/WA)
  - Mobile: `+614`
- **National format**: Replace `(0#) #### ####` with explicit area codes
  - Landlines: `02`, `03`, `07`, `08`
  - Mobile: `04`
- **Human readable format**: Replace `0# #### ####` and `+61 # #### ####` with explicit area codes

Reference: [Telephone numbers in Australia (Wikipedia)](https://en.wikipedia.org/wiki/Telephone_numbers_in_Australia)

## Related Issue

Closes #3574
