### PR TITLE
chore: reformat person.bio

### DIFF
--- a/src/modules/person/index.ts
+++ b/src/modules/person/index.ts
@@ -312,9 +312,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   bio(): string {
-    const { bio_pattern } = this.faker.definitions.person;
-
-    return this.faker.helpers.fake(bio_pattern);
+    return this.faker.helpers.fake(this.faker.definitions.person.bio_pattern);
   }
 
   /**


### PR DESCRIPTION
PersonModule's `bio`function is the only method that uses a deconstructor to access the local data on the entry level.
This causes issues for #3748 and #3189.

This PR reformats/refactors the method to use plain property access instead.

