### PR TITLE
test(person): cleanup tests

### DIFF
--- a/test/modules/person.spec.ts
+++ b/test/modules/person.spec.ts
@@ -114,16 +114,24 @@ describe('person', () => {
           } = faker.definitions.person.last_name;
 
           const name = faker.person.lastName();
-          expect([...generic, ...female, ...male]).toContain(name);
+          for (const part of name.split(/[ -]/)) {
+            expect([...generic, ...female, ...male]).toContain(part);
+          }
 
           const genericName = faker.person.lastName('generic');
-          expect(generic).toContain(genericName);
+          for (const part of genericName.split(/[ -]/)) {
+            expect(generic).toContain(part);
+          }
 
           const femaleName = faker.person.lastName('female');
-          expect([...generic, ...female]).toContain(femaleName);
+          for (const part of femaleName.split(/[ -]/)) {
+            expect([...generic, ...female]).toContain(part);
+          }
 
           const maleName = faker.person.lastName('male');
-          expect([...generic, ...male]).toContain(maleName);
+          for (const part of maleName.split(/[ -]/)) {
+            expect([...generic, ...male]).toContain(part);
+          }
         });
 
         it('should return a sex-specific last name when no sex-generic last name was defined', () => {
@@ -136,13 +144,19 @@ describe('person', () => {
           expect(generic).toBeUndefined();
 
           const name = fakerAZ.person.lastName();
-          expect([...female, ...male]).toContain(name);
+          for (const part of name.split(/[ -]/)) {
+            expect([...female, ...male]).toContain(part);
+          }
 
           const femaleName = fakerAZ.person.lastName('female');
-          expect(female).toContain(femaleName);
+          for (const part of femaleName.split(/[ -]/)) {
+            expect(female).toContain(part);
+          }
 
           const maleName = fakerAZ.person.lastName('male');
-          expect(male).toContain(maleName);
+          for (const part of maleName.split(/[ -]/)) {
+            expect(male).toContain(part);
+          }
         });
       });
 

--- a/test/modules/person.spec.ts
+++ b/test/modules/person.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { Sex, faker, fakerAZ, fakerMK, fakerUK } from '../../src';
+import { Sex, faker, fakerAZ, fakerUK } from '../../src';
 import { seededTests } from '../support/seeded-runs';
 import { times } from './../support/times';
 
@@ -52,186 +52,239 @@ describe('person', () => {
     () => {
       describe('firstName()', () => {
         it('should return a random first name', () => {
-          const first_name = faker.person.firstName();
+          const name = faker.person.firstName();
 
-          expect(first_name).toBeTypeOf('string');
-          expect(first_name.length).toBeGreaterThan(0);
+          expect(name).toBeTypeOf('string');
+          expect(name.length).toBeGreaterThan(0);
         });
 
         it('should return a sex-specific first name', () => {
-          let name = faker.person.firstName('generic');
-          expect(faker.definitions.person.first_name.generic).toContain(name);
+          const {
+            generic = [],
+            female = [],
+            male = [],
+          } = faker.definitions.person.first_name;
 
-          name = faker.person.firstName('female');
-          const female_applicable = [
-            ...(faker.definitions.person.first_name.generic ?? []),
-            ...(faker.definitions.person.first_name.female ?? []),
-          ];
-          expect(female_applicable).toContain(name);
+          const name = faker.person.firstName();
+          expect([...generic, ...female, ...male]).toContain(name);
 
-          name = faker.person.firstName('male');
-          const male_applicable = [
-            ...(faker.definitions.person.first_name.generic ?? []),
-            ...(faker.definitions.person.first_name.male ?? []),
-          ];
-          expect(male_applicable).toContain(name);
+          const genericName = faker.person.firstName('generic');
+          expect(generic).toContain(genericName);
+
+          const femaleName = faker.person.firstName('female');
+          expect([...generic, ...female]).toContain(femaleName);
+
+          const maleName = faker.person.firstName('male');
+          expect([...generic, ...male]).toContain(maleName);
         });
 
-        it('should return a sex-specific first name when no sex-specific first name was defined', () => {
+        it('should return a sex-specific last name when no sex-generic last name was defined', () => {
+          const {
+            generic,
+            female = [],
+            male = [],
+          } = fakerAZ.definitions.person.first_name;
+
+          expect(generic).toBeUndefined();
+
           const name = fakerAZ.person.firstName();
-          expect([
-            ...(fakerAZ.definitions.person.first_name.female ?? []),
-            ...(fakerAZ.definitions.person.first_name.male ?? []),
-          ]).toContain(name);
+          expect([...female, ...male]).toContain(name);
+
+          const femaleName = fakerAZ.person.firstName('female');
+          expect(female).toContain(femaleName);
+
+          const maleName = fakerAZ.person.firstName('male');
+          expect(male).toContain(maleName);
         });
       });
 
       describe('lastName()', () => {
         it('should return a random last name', () => {
-          const last_name = faker.person.lastName();
+          const name = faker.person.lastName();
 
-          expect(last_name).toBeTypeOf('string');
-          expect(last_name.length).toBeGreaterThan(0);
+          expect(name).toBeTypeOf('string');
+          expect(name.length).toBeGreaterThan(0);
         });
 
         it('should return a sex-specific last name', () => {
-          let name = fakerAZ.person.lastName('female');
-          expect(fakerAZ.definitions.person.last_name.female).toContain(name);
+          const {
+            generic = [],
+            female = [],
+            male = [],
+          } = faker.definitions.person.last_name;
 
-          name = fakerAZ.person.lastName('male');
-          expect(fakerAZ.definitions.person.last_name.male).toContain(name);
+          const name = faker.person.lastName();
+          expect([...generic, ...female, ...male]).toContain(name);
+
+          const genericName = faker.person.lastName('generic');
+          expect(generic).toContain(genericName);
+
+          const femaleName = faker.person.lastName('female');
+          expect([...generic, ...female]).toContain(femaleName);
+
+          const maleName = faker.person.lastName('male');
+          expect([...generic, ...male]).toContain(maleName);
+        });
+
+        it('should return a sex-specific last name when no sex-generic last name was defined', () => {
+          const {
+            generic,
+            female = [],
+            male = [],
+          } = fakerAZ.definitions.person.last_name;
+
+          expect(generic).toBeUndefined();
+
+          const name = fakerAZ.person.lastName();
+          expect([...female, ...male]).toContain(name);
+
+          const femaleName = fakerAZ.person.lastName('female');
+          expect(female).toContain(femaleName);
+
+          const maleName = fakerAZ.person.lastName('male');
+          expect(male).toContain(maleName);
         });
       });
 
       describe('middleName()', () => {
         it('should return a random middle name', () => {
-          const middle_name = faker.person.middleName();
+          const name = faker.person.middleName();
 
-          expect(middle_name).toBeTypeOf('string');
-          expect(middle_name.length).toBeGreaterThan(0);
-        });
-
-        it('should return a middle name when passed en locale', () => {
-          let name = faker.person.middleName();
-          const allApplicable = [
-            ...(faker.definitions.person.middle_name.generic ?? []),
-            ...(faker.definitions.person.middle_name.female ?? []),
-            ...(faker.definitions.person.middle_name.male ?? []),
-          ];
-          expect(allApplicable).toContain(name);
-
-          name = faker.person.middleName('generic');
-          expect(faker.definitions.person.middle_name.generic).toContain(name);
-
-          name = faker.person.middleName('female');
-          const female_applicable = [
-            ...(faker.definitions.person.middle_name.generic ?? []),
-            ...(faker.definitions.person.middle_name.female ?? []),
-          ];
-          expect(female_applicable).toContain(name);
-
-          name = faker.person.middleName('male');
-          const male_applicable = [
-            ...(faker.definitions.person.middle_name.generic ?? []),
-            ...(faker.definitions.person.middle_name.male ?? []),
-          ];
-          expect(male_applicable).toContain(name);
+          expect(name).toBeTypeOf('string');
+          expect(name.length).toBeGreaterThan(0);
         });
 
         it('should return a sex-specific middle name', () => {
-          let name = fakerUK.person.middleName('female');
-          expect(fakerUK.definitions.person.middle_name.female).toContain(name);
+          const {
+            generic = [],
+            female = [],
+            male = [],
+          } = faker.definitions.person.middle_name;
 
-          name = fakerUK.person.middleName('male');
-          expect(fakerUK.definitions.person.middle_name.male).toContain(name);
+          const name = faker.person.middleName();
+          expect([...generic, ...female, ...male]).toContain(name);
+
+          const genericName = faker.person.middleName('generic');
+          expect(generic).toContain(genericName);
+
+          const femaleName = faker.person.middleName('female');
+          expect([...generic, ...female]).toContain(femaleName);
+
+          const maleName = faker.person.middleName('male');
+          expect([...generic, ...male]).toContain(maleName);
+        });
+
+        it('should return a sex-specific middle name when no sex-generic middle name was defined', () => {
+          const {
+            generic,
+            female = [],
+            male = [],
+          } = fakerUK.definitions.person.middle_name;
+
+          expect(generic).toBeUndefined();
+
+          const femaleName = fakerUK.person.middleName('female');
+          expect(female).toContain(femaleName);
+
+          const maleName = fakerUK.person.middleName('male');
+          expect(male).toContain(maleName);
         });
       });
 
       describe('fullName()', () => {
         it('should return a name with firstName and lastName', () => {
-          const fullName = faker.person.fullName();
+          const name = faker.person.fullName();
 
-          expect(fullName).toBeTypeOf('string');
-          expect(fullName).toContain(' ');
+          expect(name).toBeTypeOf('string');
+          expect(name).toContain(' ');
         });
 
-        it('should return a female applicable name without firstName and lastName', () => {
-          const female_applicable = [
-            ...(fakerMK.fakerCore.locale.person?.prefix?.female ?? []),
-            ...(fakerMK.fakerCore.locale.person?.first_name?.female ?? []),
-            ...(fakerMK.fakerCore.locale.person?.last_name?.female ?? []),
-            ...(fakerMK.fakerCore.locale.person?.prefix?.generic ?? []),
-            ...(fakerMK.fakerCore.locale.person?.first_name?.generic ?? []),
-            ...(fakerMK.fakerCore.locale.person?.last_name?.generic ?? []),
-            // ...(fakerMK.fakerCore.locale.person?.suffix ?? []), Not applicable
+        it('should return a sex-specific full name', () => {
+          const { prefix, first_name, last_name, suffix } =
+            faker.definitions.person;
+
+          const generic = [
+            ...(prefix?.generic ?? []),
+            ...(first_name?.generic ?? []),
+            ...(last_name?.generic ?? []),
+            ...(suffix ?? []),
+          ];
+          const female = [
+            ...(prefix?.female ?? []),
+            ...(first_name?.female ?? []),
+            ...(last_name?.female ?? []),
+          ];
+          const male = [
+            ...(prefix?.male ?? []),
+            ...(first_name?.male ?? []),
+            ...(last_name?.male ?? []),
           ];
 
-          const fullName = fakerMK.person.fullName({ sex: 'female' });
+          const name = faker.person.fullName();
+          for (const part of name.split(/[ -]/)) {
+            expect([...generic, ...female, ...male]).toContain(part);
+          }
 
-          const parts = fullName.split(' ');
-          for (const part of parts) {
-            expect(female_applicable).toContain(part);
+          const genericName = faker.person.fullName({ sex: 'generic' });
+          for (const part of genericName.split(/[ -]/)) {
+            expect(generic).toContain(part);
+          }
+
+          const femaleName = faker.person.fullName({ sex: 'female' });
+          for (const part of femaleName.split(/[ -]/)) {
+            expect([...generic, ...female]).toContain(part);
+          }
+
+          const maleName = faker.person.fullName({ sex: 'male' });
+          for (const part of maleName.split(/[ -]/)) {
+            expect([...generic, ...male]).toContain(part);
           }
         });
 
-        it('should return a male applicable name without firstName and lastName', () => {
-          const male_applicable = [
-            ...(fakerMK.fakerCore.locale.person?.prefix?.male ?? []),
-            ...(fakerMK.fakerCore.locale.person?.first_name?.male ?? []),
-            ...(fakerMK.fakerCore.locale.person?.last_name?.male ?? []),
-            ...(fakerMK.fakerCore.locale.person?.prefix?.generic ?? []),
-            ...(fakerMK.fakerCore.locale.person?.first_name?.generic ?? []),
-            ...(fakerMK.fakerCore.locale.person?.last_name?.generic ?? []),
-            // ...(fakerMK.fakerCore.locale.person?.suffix ?? []), Not applicable
-          ];
+        it('should return a sex-specific full name with given firstName and lastName', () => {
+          const { prefix, suffix } = faker.definitions.person;
 
-          const fullName = fakerMK.person.fullName({ sex: 'male' });
-
-          const parts = fullName.split(' ');
-          for (const part of parts) {
-            expect(male_applicable).toContain(part);
-          }
-        });
-
-        it('should return a female applicable name with given firstName and lastName', () => {
-          const female_applicable = [
-            ...(fakerMK.fakerCore.locale.person?.prefix?.female ?? []),
-            ...(fakerMK.fakerCore.locale.person?.prefix?.generic ?? []),
+          const generic = [
+            ...(prefix?.generic ?? []),
             'firstName',
             'lastName',
-            // ...(fakerMK.fakerCore.locale.person?.suffix ?? []), Not applicable
+            ...(suffix ?? []),
           ];
+          const { female = [], male = [] } = prefix ?? {};
 
-          const fullName = fakerMK.person.fullName({
+          const name = faker.person.fullName({
             firstName: 'firstName',
             lastName: 'lastName',
+          });
+          for (const part of name.split(/[ -]/)) {
+            expect([...generic, ...female, ...male]).toContain(part);
+          }
+
+          const genericName = faker.person.fullName({
+            sex: 'generic',
+            firstName: 'firstName',
+            lastName: 'lastName',
+          });
+          for (const part of genericName.split(/[ -]/)) {
+            expect(generic).toContain(part);
+          }
+
+          const femaleName = faker.person.fullName({
             sex: 'female',
-          });
-
-          const parts = fullName.split(' ');
-          for (const part of parts) {
-            expect(female_applicable).toContain(part);
-          }
-        });
-
-        it('should return a male applicable name with given firstName and lastName', () => {
-          const male_applicable = [
-            ...(fakerMK.fakerCore.locale.person?.prefix?.male ?? []),
-            ...(fakerMK.fakerCore.locale.person?.prefix?.generic ?? []),
-            'firstName',
-            'lastName',
-            // ...(fakerMK.fakerCore.locale.person?.suffix ?? []), Not applicable
-          ];
-
-          const fullName = fakerMK.person.fullName({
             firstName: 'firstName',
             lastName: 'lastName',
-            sex: 'male',
           });
+          for (const part of femaleName.split(/[ -]/)) {
+            expect([...generic, ...female]).toContain(part);
+          }
 
-          const parts = fullName.split(' ');
-          for (const part of parts) {
-            expect(male_applicable).toContain(part);
+          const maleName = faker.person.fullName({
+            sex: 'male',
+            firstName: 'firstName',
+            lastName: 'lastName',
+          });
+          for (const part of maleName.split(/[ -]/)) {
+            expect([...generic, ...male]).toContain(part);
           }
         });
       });
@@ -282,41 +335,27 @@ describe('person', () => {
           const prefix = faker.person.prefix();
 
           expect(prefix).toBeTypeOf('string');
-          const all_applicable = [
-            ...(faker.fakerCore.locale.person?.prefix?.generic ?? []),
-            ...(faker.fakerCore.locale.person?.prefix?.female ?? []),
-            ...(faker.fakerCore.locale.person?.prefix?.male ?? []),
-          ];
-          expect(all_applicable).toContain(prefix);
+          expect(prefix.length).toBeGreaterThan(0);
         });
 
-        it('should return a generic prefix with given string', () => {
-          const prefix = fakerMK.person.prefix('generic');
+        it('should return a sex-specific prefix', () => {
+          const {
+            generic = [],
+            female = [],
+            male = [],
+          } = faker.definitions.person.prefix;
 
-          expect(prefix).toBeTypeOf('string');
-          expect(fakerMK.definitions.person.prefix.generic).toContain(prefix);
-        });
+          const name = faker.person.prefix();
+          expect([...generic, ...female, ...male]).toContain(name);
 
-        it('should return a female prefix with given string', () => {
-          const prefix = fakerMK.person.prefix('female');
+          const genericName = faker.person.prefix('generic');
+          expect(generic).toContain(genericName);
 
-          expect(prefix).toBeTypeOf('string');
-          const female_applicable = [
-            ...(fakerMK.definitions.person.prefix.generic ?? []),
-            ...(fakerMK.definitions.person.prefix.female ?? []),
-          ];
-          expect(female_applicable).toContain(prefix);
-        });
+          const femaleName = faker.person.prefix('female');
+          expect([...generic, ...female]).toContain(femaleName);
 
-        it('should return a male prefix with given string', () => {
-          const prefix = fakerMK.person.prefix('male');
-
-          expect(prefix).toBeTypeOf('string');
-          const male_applicable = [
-            ...(fakerMK.definitions.person.prefix.generic ?? []),
-            ...(fakerMK.definitions.person.prefix.male ?? []),
-          ];
-          expect(male_applicable).toContain(prefix);
+          const maleName = faker.person.prefix('male');
+          expect([...generic, ...male]).toContain(maleName);
         });
       });
 
@@ -331,15 +370,19 @@ describe('person', () => {
 
       describe('jobTitle()', () => {
         it('should return a job title consisting of a descriptor, area, and type', () => {
+          const { job_descriptor, job_area, job_type } =
+            faker.definitions.person;
+
           const jobTitle = faker.person.jobTitle();
 
           expect(jobTitle).toBeTypeOf('string');
+          expect(jobTitle.length).toBeGreaterThan(0);
 
           const [descriptor, level, job] = jobTitle.split(' ');
 
-          expect(faker.definitions.person.job_descriptor).toContain(descriptor);
-          expect(faker.definitions.person.job_area).toContain(level);
-          expect(faker.definitions.person.job_type).toContain(job);
+          expect(job_descriptor).toContain(descriptor);
+          expect(job_area).toContain(level);
+          expect(job_type).toContain(job);
         });
       });
 
@@ -348,6 +391,7 @@ describe('person', () => {
           const descriptor = faker.person.jobDescriptor();
 
           expect(descriptor).toBeTypeOf('string');
+          expect(descriptor.length).toBeGreaterThan(0);
 
           expect(faker.definitions.person.job_descriptor).toContain(descriptor);
         });
@@ -358,6 +402,7 @@ describe('person', () => {
           const level = faker.person.jobArea();
 
           expect(level).toBeTypeOf('string');
+          expect(level.length).toBeGreaterThan(0);
 
           expect(faker.definitions.person.job_area).toContain(level);
         });
@@ -368,6 +413,7 @@ describe('person', () => {
           const job = faker.person.jobType();
 
           expect(job).toBeTypeOf('string');
+          expect(job.length).toBeGreaterThan(0);
 
           expect(faker.definitions.person.job_type).toContain(job);
         });
@@ -378,6 +424,7 @@ describe('person', () => {
           const sign = faker.person.zodiacSign();
 
           expect(sign).toBeTypeOf('string');
+          expect(sign.length).toBeGreaterThan(0);
 
           expect(faker.definitions.person.western_zodiac_sign).toContain(sign);
         });

--- a/test/modules/person.spec.ts
+++ b/test/modules/person.spec.ts
@@ -78,7 +78,7 @@ describe('person', () => {
           expect([...generic, ...male]).toContain(maleName);
         });
 
-        it('should return a sex-specific last name when no sex-generic last name was defined', () => {
+        it('should return a sex-specific first name when no sex-generic first name was defined', () => {
           const {
             generic,
             female = [],


### PR DESCRIPTION
Simplifies and standardizes the person tests.
This reduces the diff for https://github.com/faker-js/faker/pull/3748 and https://github.com/faker-js/faker/pull/3189.

