### PR TITLE
chore: import types from the source file directly

### DIFF
--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -1,6 +1,6 @@
-import type { Faker } from '../..';
 import type { DateEntryDefinition } from '../../definitions';
 import { FakerError } from '../../errors/faker-error';
+import type { Faker } from '../../faker';
 import { toDate } from '../../internal/date';
 import { assertLocaleData } from '../../internal/locale-proxy';
 import { SimpleModuleBase } from '../../internal/module-base';

--- a/src/modules/location/index.ts
+++ b/src/modules/location/index.ts
@@ -1,5 +1,5 @@
-import type { Faker } from '../..';
 import { FakerError } from '../../errors/faker-error';
+import type { Faker } from '../../faker';
 import { SimpleModuleBase } from '../../internal/module-base';
 
 /**

--- a/src/modules/person/index.ts
+++ b/src/modules/person/index.ts
@@ -1,5 +1,5 @@
-import type { Faker } from '../..';
 import type { PersonEntryDefinition } from '../../definitions/person';
+import type { Faker } from '../../faker';
 import { ModuleBase } from '../../internal/module-base';
 
 /**


### PR DESCRIPTION
Import directly from the source file to avoid automatically adding new imports to it, causing side effects.