### PR TITLE
docs(image): remove deprecated urlLoremFlickr from module overview

### DIFF
--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -14,7 +14,7 @@ import type { SexType } from '../person';
  *
  * For a random user avatar image, use [`avatar()`](https://fakerjs.dev/api/image.html#avatar), or [`personPortrait()`](https://fakerjs.dev/api/image.html#personportrait) which has more control over the size and sex of the person.
  *
- * For additional image options like grayscale, blur, and seed control, use [`urlPicsumPhotos()`](https://fakerjs.dev/api/image.html#urlpicsumphotos). Alternatively, use [`faker.helpers.arrayElement()`](https://fakerjs.dev/api/helpers.html#arrayelement) with your own array of image URLs.
+ * For full control over the returned image URL, use [`faker.helpers.arrayElement()`](https://fakerjs.dev/api/helpers.html#arrayelement) with your own array of image URLs.
  */
 export class ImageModule extends ModuleBase {
   /**

--- a/src/modules/image/index.ts
+++ b/src/modules/image/index.ts
@@ -14,7 +14,7 @@ import type { SexType } from '../person';
  *
  * For a random user avatar image, use [`avatar()`](https://fakerjs.dev/api/image.html#avatar), or [`personPortrait()`](https://fakerjs.dev/api/image.html#personportrait) which has more control over the size and sex of the person.
  *
- * If you need more control over the content of the images, you can pass a `category` parameter e.g. `'cat'` or `'nature'` to [`urlLoremFlickr()`](https://fakerjs.dev/api/image.html#urlloremflickr) or simply use [`faker.helpers.arrayElement()`](https://fakerjs.dev/api/helpers.html#arrayelement) with your own array of image URLs.
+ * For additional image options like grayscale, blur, and seed control, use [`urlPicsumPhotos()`](https://fakerjs.dev/api/image.html#urlpicsumphotos). Alternatively, use [`faker.helpers.arrayElement()`](https://fakerjs.dev/api/helpers.html#arrayelement) with your own array of image URLs.
  */
 export class ImageModule extends ModuleBase {
   /**


### PR DESCRIPTION
The `ImageModule` overview JSDoc still referenced `urlLoremFlickr()` which has been deprecated because LoremFlickr is no longer available.

This PR replaces the outdated recommendation with a reference to `urlPicsumPhotos()` for additional image options like grayscale, blur, and seed control.

A small but necessary documentation cleanup to avoid confusing users who follow the module overview guidance.