### PR TITLE
feat: introduce resolveLocaleData utility function

### DIFF
--- a/src/definitions/definitions.ts
+++ b/src/definitions/definitions.ts
@@ -29,29 +29,49 @@ export type LocaleEntry<TCategoryDefinition extends Record<string, unknown>> = {
 } & Record<string, unknown>; // Unsupported & custom entries
 
 /**
- * The definitions as used by the translations/locales.
+ * The internal types for the definitions.
  */
-export type LocaleDefinition = {
-  metadata?: MetadataDefinition;
-  airline?: AirlineDefinition;
-  animal?: AnimalDefinition;
-  book?: BookDefinition;
-  color?: ColorDefinition;
-  commerce?: CommerceDefinition;
-  company?: CompanyDefinition;
-  database?: DatabaseDefinition;
-  date?: DateDefinition;
-  finance?: FinanceDefinition;
-  food?: FoodDefinition;
-  hacker?: HackerDefinition;
-  internet?: InternetDefinition;
-  location?: LocationDefinition;
-  lorem?: LoremDefinition;
-  music?: MusicDefinition;
-  person?: PersonDefinition;
-  phone_number?: PhoneNumberDefinition;
-  science?: ScienceDefinition;
-  system?: SystemDefinition;
-  vehicle?: VehicleDefinition;
-  word?: WordDefinition;
-} & Record<string, Record<string, unknown>>;
+type RawLocaleDefinition = {
+  metadata: MetadataDefinition;
+  airline: AirlineDefinition;
+  animal: AnimalDefinition;
+  book: BookDefinition;
+  color: ColorDefinition;
+  commerce: CommerceDefinition;
+  company: CompanyDefinition;
+  database: DatabaseDefinition;
+  date: DateDefinition;
+  finance: FinanceDefinition;
+  food: FoodDefinition;
+  hacker: HackerDefinition;
+  internet: InternetDefinition;
+  location: LocationDefinition;
+  lorem: LoremDefinition;
+  music: MusicDefinition;
+  person: PersonDefinition;
+  phone_number: PhoneNumberDefinition;
+  science: ScienceDefinition;
+  system: SystemDefinition;
+  vehicle: VehicleDefinition;
+  word: WordDefinition;
+};
+
+/**
+ * Helper type to undo `LocaleEntry<T>` wrapping.
+ */
+type DefinedLocaleEntry<T> = T extends LocaleEntry<infer U> ? U : never;
+
+/**
+ * Helper type containing the well known locale definitions as used by the Faker library, assuming all values are present.
+ *
+ * This type is mainly used for `resolveLocaleData()` to enable auto completion.
+ */
+export type DefinedLocaleDefinition = {
+  [K in keyof RawLocaleDefinition]: DefinedLocaleEntry<RawLocaleDefinition[K]>;
+};
+
+/**
+ * The extensible definitions as used by the translations/locales.
+ */
+export type LocaleDefinition = Partial<RawLocaleDefinition> &
+  Record<string, Record<string, unknown>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,3 +94,4 @@ export {
   generateMersenne32Randomizer,
   generateMersenne53Randomizer,
 } from './utils/mersenne';
+export { resolveLocaleData } from './utils/resolve-locale-data';

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -1,4 +1,5 @@
 import { getDefaultRefDate } from './get-default-ref-date';
+import { resolveLocaleData } from './resolve-locale-data';
 import { setDefaultRefDate } from './set-default-ref-date';
 
 /**
@@ -6,5 +7,6 @@ import { setDefaultRefDate } from './set-default-ref-date';
  */
 export const utilsModule = {
   getDefaultRefDate,
+  resolveLocaleData,
   setDefaultRefDate,
 };

--- a/src/utils/resolve-locale-data.ts
+++ b/src/utils/resolve-locale-data.ts
@@ -1,0 +1,59 @@
+import type { FakerCore } from '../core';
+import type { DefinedLocaleDefinition } from '../definitions/definitions';
+import { assertLocaleData } from '../internal/locale-proxy';
+
+/**
+ * Returns the locale data for the given category and entry.
+ *
+ * If the category or entry is missing or explicitly absent, an error is thrown.
+ *
+ * @template TCategory The category to get the locale data from.
+ * @template TEntry The entry to get the locale data from.
+ *
+ * @param core The core to get the locale data from.
+ * @param category  The category to get the locale data from.
+ * @param entry The entry to get the locale data from.
+ *
+ * @example
+ * resolveLocaleData(fakerCore, 'food', 'fruit'); // ['apple', 'apricot', ...]
+ * faker.helpers.arrayElement(resolveLocaleData(fakerCore, 'food', 'fruit')); // 'cherry'
+ *
+ * @since 10.5.0
+ */
+export function resolveLocaleData<
+  const TCategory extends keyof DefinedLocaleDefinition,
+  const TEntry extends keyof DefinedLocaleDefinition[TCategory],
+>(
+  core: FakerCore,
+  category: TCategory,
+  entry: TEntry
+): DefinedLocaleDefinition[TCategory][TEntry];
+/**
+ * Returns the locale data for the given category and entry.
+ *
+ * If the category or entry is missing or explicitly absent, an error is thrown.
+ *
+ * @param core The core to get the locale data from.
+ * @param category  The category to get the locale data from.
+ * @param entry The entry to get the locale data from.
+ *
+ * @example
+ * resolveLocaleData(fakerCore, 'food', 'fruit'); // ['apple', 'apricot', ...]
+ * faker.helpers.arrayElement(resolveLocaleData(fakerCore, 'food', 'fruit')); // 'cherry'
+ *
+ * @since 10.5.0
+ */
+export function resolveLocaleData(
+  core: FakerCore,
+  category: string,
+  entry: string
+): unknown;
+export function resolveLocaleData(
+  core: FakerCore,
+  category: string,
+  entry: string
+): unknown {
+  const value = core.locale[category]?.[entry];
+  assertLocaleData(value, category, entry);
+  return value;
+}

--- a/test/locale-imports.spec.ts
+++ b/test/locale-imports.spec.ts
@@ -1,7 +1,7 @@
 import isISO15924 from 'validator/lib/isISO15924';
 import { describe, expect, it } from 'vitest';
 import type { Faker } from '../src';
-import { allLocales } from '../src';
+import { allLocales, resolveLocaleData } from '../src';
 import { keys } from '../src/internal/keys';
 
 describe.each(keys(allLocales))('locale imports', (locale) => {
@@ -13,6 +13,9 @@ describe.each(keys(allLocales))('locale imports', (locale) => {
     expect(faker).toBeDefined();
     expect(faker.string.alpha()).toBeTypeOf('string');
     expect(faker.definitions.metadata.title).toBe(
+      allLocales[locale].metadata?.title
+    );
+    expect(resolveLocaleData(faker.fakerCore, 'metadata', 'title')).toBe(
       allLocales[locale].metadata?.title
     );
   });

--- a/test/require.spec.cts
+++ b/test/require.spec.cts
@@ -1,5 +1,9 @@
 const { describe, expect, it, vi } = await import('vitest');
-const { allLocales, SimpleFaker } = require('../dist/index.js');
+const {
+  allLocales,
+  SimpleFaker,
+  resolveLocaleData,
+} = require('../dist/index.js');
 
 describe('require (cjs)', () => {
   describe.each(
@@ -14,6 +18,9 @@ describe('require (cjs)', () => {
       expect(faker).toBeDefined();
       expect(faker.string.alpha()).toBeTypeOf('string');
       expect(faker.definitions.metadata.title).toBe(
+        allLocales[locale].metadata?.title
+      );
+      expect(resolveLocaleData(faker.fakerCore, 'metadata', 'title')).toBe(
         allLocales[locale].metadata?.title
       );
     });

--- a/test/scripts/apidocs/__snapshots__/verify-jsdoc-tags.spec.ts.snap
+++ b/test/scripts/apidocs/__snapshots__/verify-jsdoc-tags.spec.ts.snap
@@ -40,6 +40,7 @@ exports[`check docs completeness > all modules and methods are present 1`] = `
       "generateMersenne53Randomizer",
       "getDefaultRefDate",
       "mergeLocales",
+      "resolveLocaleData",
       "setDefaultRefDate",
     ],
   ],


### PR DESCRIPTION
Extracted from #3189 for future discussion
Blocked by #3818 

- #3189
- #3818

---

Adds the `resolveLocaleData` utility function.

Intended for users of our library to check whether their custom data are present.

````ts
@example
resolveLocaleData(fakerCore, 'food', 'fruit'); // ['apple', 'apricot', ...]
arrayElement(fakerCore, resolveLocaleData(fakerCore, 'food', 'fruit')); // 'cherry'
````
