### PR TITLE
docs: fix typos in jsdocs

### DIFF
--- a/src/internal/locale-proxy.ts
+++ b/src/internal/locale-proxy.ts
@@ -39,7 +39,7 @@ const throwReadOnlyError: () => never = () => {
  *
  * @param value The value to check.
  *
- * @returns  True if the value is a LocaleProxy, false otherwise.
+ * @returns True if the value is a LocaleProxy, false otherwise.
  */
 function isLocaleProxy(value: unknown): value is LocaleProxy {
   return (

--- a/src/modules/color/index.ts
+++ b/src/modules/color/index.ts
@@ -234,7 +234,7 @@ export class ColorModule extends ModuleBase {
   }
 
   /**
-   * Returns a random css supported color function name.
+   * Returns a random CSS-supported color function name.
    *
    * @example
    * faker.color.cssSupportedFunction() // 'rgb'
@@ -246,7 +246,7 @@ export class ColorModule extends ModuleBase {
   }
 
   /**
-   * Returns a random css supported color space name.
+   * Returns a random CSS-supported color space name.
    *
    * @example
    * faker.color.cssSupportedSpace() // 'display-p3'

--- a/src/modules/company/index.ts
+++ b/src/modules/company/index.ts
@@ -56,7 +56,7 @@ export class CompanyModule extends ModuleBase {
   }
 
   /**
-   * Returns a random catch phrase adjective that can be displayed to an end user..
+   * Returns a random catch phrase adjective that can be displayed to an end user.
    *
    * @example
    * faker.company.catchPhraseAdjective() // 'Multi-tiered'
@@ -70,7 +70,7 @@ export class CompanyModule extends ModuleBase {
   }
 
   /**
-   * Returns a random catch phrase descriptor that can be displayed to an end user..
+   * Returns a random catch phrase descriptor that can be displayed to an end user.
    *
    * @example
    * faker.company.catchPhraseDescriptor() // 'composite'
@@ -84,7 +84,7 @@ export class CompanyModule extends ModuleBase {
   }
 
   /**
-   * Returns a random catch phrase noun that can be displayed to an end user..
+   * Returns a random catch phrase noun that can be displayed to an end user.
    *
    * @example
    * faker.company.catchPhraseNoun() // 'leverage'

--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -60,7 +60,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `faker.defaultRefDate()`.
    *
    * @throws {FakerError} If `years.max` is less than 0.
-   * @throws {FakerError} If `years.min` is greater or equal than `years.max`.
+   * @throws {FakerError} If `years.min` is greater than or equal to `years.max`.
    *
    * @see faker.date.recent(): For generating dates in the recent past (days instead of years).
    *
@@ -135,7 +135,7 @@ export class SimpleDateModule extends SimpleModuleBase {
    * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `faker.defaultRefDate()`.
    *
    * @throws {FakerError} If `years.max` is less than 0.
-   * @throws {FakerError} If `years.min` is greater or equal than `years.max`.
+   * @throws {FakerError} If `years.min` is greater than or equal to `years.max`.
    *
    * @see faker.date.soon(): For generating dates in the near future (days instead of years).
    *

--- a/src/modules/finance/index.ts
+++ b/src/modules/finance/index.ts
@@ -379,7 +379,7 @@ export class FinanceModule extends ModuleBase {
    * Generates a random Bitcoin address.
    *
    * @param options An optional options object.
-   * @param options.type The bitcoin address type (`'legacy'`, `'sewgit'`, `'bech32'` or `'taproot'`). Defaults to a random address type.
+   * @param options.type The bitcoin address type (`'legacy'`, `'segwit'`, `'bech32'` or `'taproot'`). Defaults to a random address type.
    * @param options.network The bitcoin network (`'mainnet'` or `'testnet'`). Defaults to `'mainnet'`.
    *
    * @example
@@ -392,9 +392,9 @@ export class FinanceModule extends ModuleBase {
   bitcoinAddress(
     options: {
       /**
-       * The bitcoin address type (`'legacy'`, `'sewgit'`, `'bech32'` or `'taproot'`).
+       * The bitcoin address type (`'legacy'`, `'segwit'`, `'bech32'` or `'taproot'`).
        *
-       * @default faker.helpers.arrayElement(['legacy','sewgit','bech32','taproot'])
+       * @default faker.helpers.enumValue(BitcoinAddressFamily)
        */
       type?: BitcoinAddressFamilyType;
       /**

--- a/src/modules/food/index.ts
+++ b/src/modules/food/index.ts
@@ -112,7 +112,7 @@ export class FoodModule extends ModuleBase {
   }
 
   /**
-   * Generates a random meat
+   * Generates a random meat.
    *
    * @example
    * faker.food.meat() // 'venison'

--- a/src/modules/helpers/index.ts
+++ b/src/modules/helpers/index.ts
@@ -224,7 +224,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
   }
 
   /**
-   * Parses the given string symbol by symbols and replaces the placeholder appropriately.
+   * Parses the given string symbol by symbol and replaces the placeholder appropriately.
    *
    * - `#` will be replaced with a digit (`0` - `9`).
    * - `?` will be replaced with an upper letter ('A' - 'Z')
@@ -752,7 +752,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @template TResult The type of result of the given callback.
    *
-   * @param callback The callback to that will be invoked if the probability check was successful.
+   * @param callback The callback that will be invoked if the probability check was successful.
    * @param options The options to use.
    * @param options.probability The probability (`[0.00, 1.00]`) of the callback being invoked. Defaults to `0.5`.
    *

--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -138,7 +138,7 @@ function makeValidDomainWordSlug(faker: Faker, word: string): string {
  *
  * ### Overview
  *
- * For user accounts, you may need an [`email()`](https://fakerjs.dev/api/internet.html#email) and a [`password()`](https://fakerjs.dev/api/internet.html#password), as well as a ASCII [`username()`](https://fakerjs.dev/api/internet.html#username) or Unicode [`displayName()`](https://fakerjs.dev/api/internet.html#displayname). Since the emails generated could coincidentally be real email addresses, you should not use these for sending real email addresses. If this is a concern, use [`exampleEmail()`](https://fakerjs.dev/api/internet.html#exampleemail) instead.
+ * For user accounts, you may need an [`email()`](https://fakerjs.dev/api/internet.html#email) and a [`password()`](https://fakerjs.dev/api/internet.html#password), as well as an ASCII [`username()`](https://fakerjs.dev/api/internet.html#username) or Unicode [`displayName()`](https://fakerjs.dev/api/internet.html#displayname). Since the emails generated could coincidentally be real email addresses, you should not use these for sending real email addresses. If this is a concern, use [`exampleEmail()`](https://fakerjs.dev/api/internet.html#exampleemail) instead.
  *
  * For websites, you can generate a [`domainName()`](https://fakerjs.dev/api/internet.html#domainname) or a full [`url()`](https://fakerjs.dev/api/internet.html#url).
  *

--- a/src/modules/number/index.ts
+++ b/src/modules/number/index.ts
@@ -122,7 +122,7 @@ export class NumberModule extends SimpleModuleBase {
    * @param options.min Lower bound for generated number, inclusive. Defaults to `0.0`.
    * @param options.max Upper bound for generated number, exclusive, unless `multipleOf` or `fractionDigits` are passed. Defaults to `1.0`.
    * @param options.multipleOf The generated number will be a multiple of this parameter. Only one of `multipleOf` or `fractionDigits` should be passed.
-   * @param options.fractionDigits The maximum number of digits to appear after the decimal point, for example `2` will round to 2 decimal points.  Only one of `multipleOf` or `fractionDigits` should be passed.
+   * @param options.fractionDigits The maximum number of digits to appear after the decimal point, for example `2` will round to 2 decimal points. Only one of `multipleOf` or `fractionDigits` should be passed.
    * @param options.distributor A function to determine the distribution of generated values. Defaults to `uniformDistributor()`.
    *
    * @throws {FakerError} When `min` is greater than `max`.
@@ -160,7 +160,7 @@ export class NumberModule extends SimpleModuleBase {
            */
           max?: number;
           /**
-           * The maximum number of digits to appear after the decimal point, for example `2` will round to 2 decimal points.  Only one of `multipleOf` or `fractionDigits` should be passed.
+           * The maximum number of digits to appear after the decimal point, for example `2` will round to 2 decimal points. Only one of `multipleOf` or `fractionDigits` should be passed.
            */
           fractionDigits?: number;
           /**

--- a/src/simple-faker.ts
+++ b/src/simple-faker.ts
@@ -170,7 +170,7 @@ export class SimpleFaker {
    * Please note that generated values are dependent on both the seed and the
    * number of calls that have been made since it was set.
    *
-   * This method is intended to allow for consistent values in a tests, so you
+   * This method is intended to allow for consistent values in tests, so you
    * might want to use hardcoded values as the seed.
    *
    * In addition to that it can be used for creating truly random tests
@@ -207,7 +207,7 @@ export class SimpleFaker {
    * Please note that generated values are dependent on both the seed and the
    * number of calls that have been made since it was set.
    *
-   * This method is intended to allow for consistent values in a tests, so you
+   * This method is intended to allow for consistent values in tests, so you
    * might want to use hardcoded values as the seed.
    *
    * In addition to that it can be used for creating truly random tests


### PR DESCRIPTION
Fixes typos, grammar and similar issues in our docs.