### PR TITLE
fix(date): incorrect date boundary in past and future

### DIFF
--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -6,15 +6,6 @@ import { assertLocaleData } from '../../internal/locale-proxy';
 import { SimpleModuleBase } from '../../internal/module-base';
 
 /**
- * Small helper function to convert a number of years to an amount of milliseconds.
- *
- * @param years The number of years to convert to milliseconds.
- */
-function yearsToMs(years: number): number {
-  return years * 365 * 24 * 3600 * 1000;
-}
-
-/**
  * Module to generate dates (without methods requiring localized data).
  */
 export class SimpleDateModule extends SimpleModuleBase {
@@ -119,11 +110,15 @@ export class SimpleDateModule extends SimpleModuleBase {
       );
     }
 
-    const time = toDate(refDate).getTime();
+    const time = toDate(refDate);
+    const from = new Date(time);
+    from.setUTCFullYear(from.getUTCFullYear() - years.max);
+    const to = new Date(time);
+    to.setUTCFullYear(to.getUTCFullYear() - years.min);
 
     return this.between({
-      from: time - yearsToMs(years.max),
-      to: time - yearsToMs(years.min) - 1000,
+      from,
+      to: to.getTime() - 1000,
     });
   }
 
@@ -194,11 +189,15 @@ export class SimpleDateModule extends SimpleModuleBase {
       );
     }
 
-    const time = toDate(refDate).getTime();
+    const time = toDate(refDate);
+    const from = new Date(time);
+    from.setUTCFullYear(from.getUTCFullYear() + years.min);
+    const to = new Date(time);
+    to.setUTCFullYear(to.getUTCFullYear() + years.max);
 
     return this.between({
-      from: time + yearsToMs(years.min) + 1000,
-      to: time + yearsToMs(years.max),
+      from: from.getTime() + 1000,
+      to,
     });
   }
 

--- a/test/modules/__snapshots__/date.spec.ts.snap
+++ b/test/modules/__snapshots__/date.spec.ts.snap
@@ -81,9 +81,9 @@ exports[`date > 42 > future > with only number refDate 1`] = `2021-07-08T10:07:3
 
 exports[`date > 42 > future > with only string refDate 1`] = `2021-07-08T10:07:33.524Z`;
 
-exports[`date > 42 > future > with value numeric 1`] = `2024-11-19T18:52:08.216Z`;
+exports[`date > 42 > future > with value numeric 1`] = `2024-11-20T12:50:48.749Z`;
 
-exports[`date > 42 > future > with value range 1`] = `2027-07-06T01:53:51.028Z`;
+exports[`date > 42 > future > with value range 1`] = `2027-07-07T04:51:51.827Z`;
 
 exports[`date > 42 > month > noArgs 1`] = `"January"`;
 
@@ -93,15 +93,15 @@ exports[`date > 42 > month > with abbreviated = true and context = true 1`] = `"
 
 exports[`date > 42 > month > with context = true 1`] = `"January"`;
 
-exports[`date > 42 > past > with only Date refDate 1`] = `2020-07-08T10:07:32.524Z`;
+exports[`date > 42 > past > with only Date refDate 1`] = `2020-07-07T19:06:52.791Z`;
 
-exports[`date > 42 > past > with only number refDate 1`] = `2020-07-08T10:07:32.524Z`;
+exports[`date > 42 > past > with only number refDate 1`] = `2020-07-07T19:06:52.791Z`;
 
-exports[`date > 42 > past > with only string refDate 1`] = `2020-07-08T10:07:32.524Z`;
+exports[`date > 42 > past > with only string refDate 1`] = `2020-07-07T19:06:52.791Z`;
 
-exports[`date > 42 > past > with value numeric 1`] = `2014-11-22T18:52:07.216Z`;
+exports[`date > 42 > past > with value numeric 1`] = `2014-11-20T21:50:08.015Z`;
 
-exports[`date > 42 > past > with value range 1`] = `2012-07-09T01:53:50.028Z`;
+exports[`date > 42 > past > with value range 1`] = `2012-07-06T19:52:30.561Z`;
 
 exports[`date > 42 > recent > with only Date refDate 1`] = `2021-02-21T02:08:35.603Z`;
 
@@ -211,9 +211,9 @@ exports[`date > 1211 > future > with only number refDate 1`] = `2022-01-26T14:59
 
 exports[`date > 1211 > future > with only string refDate 1`] = `2022-01-26T14:59:27.356Z`;
 
-exports[`date > 1211 > future > with value numeric 1`] = `2030-06-03T19:31:11.518Z`;
+exports[`date > 1211 > future > with value numeric 1`] = `2030-06-05T16:05:19.800Z`;
 
-exports[`date > 1211 > future > with value range 1`] = `2032-06-28T21:40:59.944Z`;
+exports[`date > 1211 > future > with value range 1`] = `2032-07-01T16:32:12.368Z`;
 
 exports[`date > 1211 > month > noArgs 1`] = `"September"`;
 
@@ -223,15 +223,15 @@ exports[`date > 1211 > month > with abbreviated = true and context = true 1`] = 
 
 exports[`date > 1211 > month > with context = true 1`] = `"September"`;
 
-exports[`date > 1211 > past > with only Date refDate 1`] = `2021-01-26T14:59:26.356Z`;
+exports[`date > 1211 > past > with only Date refDate 1`] = `2021-01-26T13:16:30.498Z`;
 
-exports[`date > 1211 > past > with only number refDate 1`] = `2021-01-26T14:59:26.356Z`;
+exports[`date > 1211 > past > with only number refDate 1`] = `2021-01-26T13:16:30.498Z`;
 
-exports[`date > 1211 > past > with only string refDate 1`] = `2021-01-26T14:59:26.356Z`;
+exports[`date > 1211 > past > with only string refDate 1`] = `2021-01-26T13:16:30.498Z`;
 
-exports[`date > 1211 > past > with value numeric 1`] = `2020-06-05T19:31:10.518Z`;
+exports[`date > 1211 > past > with value numeric 1`] = `2020-06-05T14:22:22.942Z`;
 
-exports[`date > 1211 > past > with value range 1`] = `2017-07-02T21:40:58.944Z`;
+exports[`date > 1211 > past > with value range 1`] = `2017-07-01T18:15:07.227Z`;
 
 exports[`date > 1211 > recent > with only Date refDate 1`] = `2021-02-21T15:26:18.924Z`;
 
@@ -339,9 +339,9 @@ exports[`date > 1337 > future > with only number refDate 1`] = `2021-05-28T08:29
 
 exports[`date > 1337 > future > with only string refDate 1`] = `2021-05-28T08:29:26.600Z`;
 
-exports[`date > 1337 > future > with value numeric 1`] = `2023-10-06T02:30:57.962Z`;
+exports[`date > 1337 > future > with value numeric 1`] = `2023-10-06T15:05:35.825Z`;
 
-exports[`date > 1337 > future > with value range 1`] = `2026-07-01T11:10:47.810Z`;
+exports[`date > 1337 > future > with value range 1`] = `2026-07-02T06:02:44.606Z`;
 
 exports[`date > 1337 > month > noArgs 1`] = `"February"`;
 
@@ -351,15 +351,15 @@ exports[`date > 1337 > month > with abbreviated = true and context = true 1`] = 
 
 exports[`date > 1337 > month > with context = true 1`] = `"February"`;
 
-exports[`date > 1337 > past > with only Date refDate 1`] = `2020-05-28T08:29:25.600Z`;
+exports[`date > 1337 > past > with only Date refDate 1`] = `2020-05-27T14:46:44.532Z`;
 
-exports[`date > 1337 > past > with only number refDate 1`] = `2020-05-28T08:29:25.600Z`;
+exports[`date > 1337 > past > with only number refDate 1`] = `2020-05-27T14:46:44.532Z`;
 
-exports[`date > 1337 > past > with only string refDate 1`] = `2020-05-28T08:29:25.600Z`;
+exports[`date > 1337 > past > with only string refDate 1`] = `2020-05-27T14:46:44.532Z`;
 
-exports[`date > 1337 > past > with value numeric 1`] = `2013-10-08T02:30:56.962Z`;
+exports[`date > 1337 > past > with value numeric 1`] = `2013-10-05T21:22:53.757Z`;
 
-exports[`date > 1337 > past > with value range 1`] = `2011-07-05T11:10:46.810Z`;
+exports[`date > 1337 > past > with value range 1`] = `2011-07-02T23:45:24.674Z`;
 
 exports[`date > 1337 > recent > with only Date refDate 1`] = `2021-02-20T23:26:34.381Z`;
 

--- a/test/modules/date.spec.ts
+++ b/test/modules/date.spec.ts
@@ -222,10 +222,10 @@ describe('date', () => {
 
           const date = customFaker.date.past({
             years: { min: 20, max: 40 },
-            refDate: new Date(2020, 2, 1, 0, 0, 1),
+            refDate: new Date(Date.UTC(2020, 2, 1, 0, 0, 1)),
           });
 
-          expect(date).toEqual(new Date(2000, 2, 1));
+          expect(date).toEqual(new Date(Date.UTC(2000, 2, 1)));
         });
 
         it('should return a date between 20 and 40 years in the past (max)', () => {
@@ -240,10 +240,10 @@ describe('date', () => {
 
           const date = customFaker.date.past({
             years: { min: 20, max: 40 },
-            refDate: new Date(2020, 2, 1),
+            refDate: new Date(Date.UTC(2020, 2, 1)),
           });
 
-          expect(date).toEqual(new Date(1980, 2, 1));
+          expect(date).toEqual(new Date(Date.UTC(1980, 2, 1)));
         });
 
         it('should throw an error when years = 0', () => {
@@ -342,10 +342,10 @@ describe('date', () => {
 
           const date = customFaker.date.future({
             years: { min: 20, max: 40 },
-            refDate: new Date(2020, 2, 1),
+            refDate: new Date(Date.UTC(2020, 2, 1)),
           });
 
-          expect(date).toEqual(new Date(2040, 2, 1, 0, 0, 1));
+          expect(date).toEqual(new Date(Date.UTC(2040, 2, 1, 0, 0, 1)));
         });
 
         it('should return a date between 20 and 40 years in the future (max)', () => {
@@ -360,10 +360,10 @@ describe('date', () => {
 
           const date = customFaker.date.future({
             years: { min: 20, max: 40 },
-            refDate: new Date(2020, 2, 1),
+            refDate: new Date(Date.UTC(2020, 2, 1)),
           });
 
-          expect(date).toEqual(new Date(2060, 2, 1));
+          expect(date).toEqual(new Date(Date.UTC(2060, 2, 1)));
         });
 
         it('should throw an error when years = 0', () => {

--- a/test/modules/date.spec.ts
+++ b/test/modules/date.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { FakerError, allLocales, faker, fakerAZ } from '../../src';
+import { FakerError, SimpleFaker, allLocales, faker, fakerAZ } from '../../src';
 import { seededTests } from '../support/seeded-runs';
 import { times } from './../support/times';
 
@@ -210,6 +210,42 @@ describe('date', () => {
           expect(date).greaterThanOrEqual(yearAgoMax);
         });
 
+        it('should return a date between 20 and 40 years in the past (min)', () => {
+          const customFaker = new SimpleFaker({
+            randomizer: {
+              next() {
+                return 0.999999999999999;
+              },
+              seed() {},
+            },
+          });
+
+          const date = customFaker.date.past({
+            years: { min: 20, max: 40 },
+            refDate: new Date(2020, 2, 1, 0, 0, 1),
+          });
+
+          expect(date).toEqual(new Date(2000, 2, 1));
+        });
+
+        it('should return a date between 20 and 40 years in the past (max)', () => {
+          const customFaker = new SimpleFaker({
+            randomizer: {
+              next() {
+                return 0;
+              },
+              seed() {},
+            },
+          });
+
+          const date = customFaker.date.past({
+            years: { min: 20, max: 40 },
+            refDate: new Date(2020, 2, 1),
+          });
+
+          expect(date).toEqual(new Date(1980, 2, 1));
+        });
+
         it('should throw an error when years = 0', () => {
           const refDate = new Date();
           expect(() =>
@@ -292,6 +328,42 @@ describe('date', () => {
           expect(date).greaterThan(today);
           expect(date).greaterThan(yearUntilMin);
           expect(date).lessThanOrEqual(yearUntilMax);
+        });
+
+        it('should return a date between 20 and 40 years in the future (min)', () => {
+          const customFaker = new SimpleFaker({
+            randomizer: {
+              next() {
+                return 0;
+              },
+              seed() {},
+            },
+          });
+
+          const date = customFaker.date.future({
+            years: { min: 20, max: 40 },
+            refDate: new Date(2020, 2, 1),
+          });
+
+          expect(date).toEqual(new Date(2040, 2, 1, 0, 0, 1));
+        });
+
+        it('should return a date between 20 and 40 years in the future (max)', () => {
+          const customFaker = new SimpleFaker({
+            randomizer: {
+              next() {
+                return 0.999999999999999;
+              },
+              seed() {},
+            },
+          });
+
+          const date = customFaker.date.future({
+            years: { min: 20, max: 40 },
+            refDate: new Date(2020, 2, 1),
+          });
+
+          expect(date).toEqual(new Date(2060, 2, 1));
         });
 
         it('should throw an error when years = 0', () => {


### PR DESCRIPTION
Fix incorrect date boundaries in `past()` and `future()` causing random pipeline failures.

The issue is mainly caused by leap years as those have more days than usual, that didn't get accounted for.