### PR TITLE
feat: introduce NumberRange type

### DIFF
--- a/scripts/apidocs/processing/type.ts
+++ b/scripts/apidocs/processing/type.ts
@@ -91,6 +91,8 @@ export function getTypeText(
           : newSimpleType('string');
 
         return newUnionType([displayType, baseType]);
+      } else if (name === 'NumberRange') {
+        return newSimpleType('{ min: number; max: number }');
       }
 
       const typeParameters = typeArguments.map((t) => getTypeText(t, options));

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,4 +92,4 @@ export {
   generateMersenne32Randomizer,
   generateMersenne53Randomizer,
 } from './utils/mersenne';
-export type { Casing } from './utils/types';
+export type { Casing, NumberRange } from './utils/types';

--- a/src/modules/airline/module.ts
+++ b/src/modules/airline/module.ts
@@ -1,4 +1,5 @@
 import { ModuleBase } from '../../internal/module-base';
+import type { NumberRange } from '../../utils/types';
 
 export enum Aircraft {
   Narrowbody = 'narrowbody',
@@ -240,18 +241,7 @@ export class AirlineModule extends ModuleBase {
        *
        * @default { min: 1, max: 4 }
        */
-      length?:
-        | number
-        | {
-            /**
-             * The minimum number of digits to generate.
-             */
-            min: number;
-            /**
-             * The maximum number of digits to generate.
-             */
-            max: number;
-          };
+      length?: number | NumberRange;
       /**
        * Whether to pad the flight number up to 4 digits with leading zeros.
        *

--- a/src/modules/date/module.ts
+++ b/src/modules/date/module.ts
@@ -4,6 +4,7 @@ import type { Faker } from '../../faker';
 import { toDate } from '../../internal/date';
 import { assertLocaleData } from '../../internal/locale-proxy';
 import { SimpleModuleBase } from '../../internal/module-base';
+import type { NumberRange } from '../../utils/types';
 
 /**
  * Module to generate dates (without methods requiring localized data).
@@ -70,22 +71,7 @@ export class SimpleDateModule extends SimpleModuleBase {
        *
        * @default 1
        */
-      years?:
-        | number
-        | {
-            /**
-             * The minimum amount of years the date should be in the past.
-             *
-             * @default 0
-             */
-            min: number;
-            /**
-             * The maximum amount of years the date should be in the past.
-             *
-             * @default 1
-             */
-            max: number;
-          };
+      years?: number | NumberRange;
       /**
        * The date to use as reference point for the newly generated date.
        *
@@ -149,22 +135,7 @@ export class SimpleDateModule extends SimpleModuleBase {
        *
        * @default 1
        */
-      years?:
-        | number
-        | {
-            /**
-             * The minimum amount of years the date should be in the future.
-             *
-             * @default 0
-             */
-            min: number;
-            /**
-             * The maximum amount of years the date should be in the future.
-             *
-             * @default 1
-             */
-            max: number;
-          };
+      years?: number | NumberRange;
       /**
        * The date to use as reference point for the newly generated date.
        *
@@ -280,18 +251,7 @@ export class SimpleDateModule extends SimpleModuleBase {
      *
      * @default 3
      */
-    count?:
-      | number
-      | {
-          /**
-           * The minimum number of dates to generate.
-           */
-          min: number;
-          /**
-           * The maximum number of dates to generate.
-           */
-          max: number;
-        };
+    count?: number | NumberRange;
   }): Date[] {
     const { from, to, count = 3 } = options;
     return this.faker.helpers

--- a/src/modules/finance/bitcoin.ts
+++ b/src/modules/finance/bitcoin.ts
@@ -1,4 +1,4 @@
-import type { Casing } from '../../utils/types';
+import type { Casing, NumberRange } from '../../utils/types';
 
 /**
  * The bitcoin address families.
@@ -30,7 +30,7 @@ export type BitcoinNetworkType = `${BitcoinNetwork}`;
 
 type BitcoinAddressOptions = {
   prefix: Record<BitcoinNetworkType, string>;
-  length: { min: number; max: number };
+  length: NumberRange;
   casing: Casing;
   exclude: string;
 };

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -1,6 +1,7 @@
 import type { Faker, SimpleFaker } from '../..';
 import { FakerError } from '../../errors/faker-error';
 import { SimpleModuleBase } from '../../internal/module-base';
+import type { NumberRange } from '../../utils/types';
 import { fakeEval } from './eval';
 import { luhnCheckValue } from './luhn-check';
 
@@ -1029,18 +1030,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    */
   arrayElements<const T>(
     array: ReadonlyArray<T>,
-    count?:
-      | number
-      | {
-          /**
-           * The minimum number of elements to pick.
-           */
-          min: number;
-          /**
-           * The maximum number of elements to pick.
-           */
-          max: number;
-        }
+    count?: number | NumberRange
   ): T[] {
     if (array.length === 0) {
       return [];
@@ -1117,20 +1107,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @since 8.0.0
    */
-  rangeToNumber(
-    numberOrRange:
-      | number
-      | {
-          /**
-           * The minimum value for the range.
-           */
-          min: number;
-          /**
-           * The maximum value for the range.
-           */
-          max: number;
-        }
-  ): number {
+  rangeToNumber(numberOrRange: number | NumberRange): number {
     if (typeof numberOrRange === 'number') {
       return numberOrRange;
     }
@@ -1163,18 +1140,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
        *
        * @default 3
        */
-      count?:
-        | number
-        | {
-            /**
-             * The minimum value for the range.
-             */
-            min: number;
-            /**
-             * The maximum value for the range.
-             */
-            max: number;
-          };
+      count?: number | NumberRange;
     } = {}
   ): TResult[] {
     const count = this.rangeToNumber(options.count ?? 3);

--- a/src/modules/lorem/module.ts
+++ b/src/modules/lorem/module.ts
@@ -1,4 +1,5 @@
 import { ModuleBase } from '../../internal/module-base';
+import type { NumberRange } from '../../utils/types';
 import { filterWordListByLength } from '../word/filter-word-list-by-length';
 
 /**
@@ -47,18 +48,7 @@ export class LoremModule extends ModuleBase {
            *
            * @default 1
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -101,20 +91,7 @@ export class LoremModule extends ModuleBase {
    *
    * @since 2.0.1
    */
-  words(
-    wordCount:
-      | number
-      | {
-          /**
-           * The minimum number of words to generate.
-           */
-          min: number;
-          /**
-           * The maximum number of words to generate.
-           */
-          max: number;
-        } = 3
-  ): string {
+  words(wordCount: number | NumberRange = 3): string {
     return this.faker.helpers
       .multiple(() => this.word(), { count: wordCount })
       .join(' ');
@@ -134,20 +111,7 @@ export class LoremModule extends ModuleBase {
    *
    * @since 2.0.1
    */
-  sentence(
-    wordCount:
-      | number
-      | {
-          /**
-           * The minimum number of words to generate.
-           */
-          min: number;
-          /**
-           * The maximum number of words to generate.
-           */
-          max: number;
-        } = { min: 3, max: 10 }
-  ): string {
+  sentence(wordCount: number | NumberRange = { min: 3, max: 10 }): string {
     const sentence = this.words(wordCount);
     return `${sentence.charAt(0).toUpperCase() + sentence.substring(1)}.`;
   }
@@ -166,20 +130,7 @@ export class LoremModule extends ModuleBase {
    *
    * @since 4.0.0
    */
-  slug(
-    wordCount:
-      | number
-      | {
-          /**
-           * The minimum number of words to generate.
-           */
-          min: number;
-          /**
-           * The maximum number of words to generate.
-           */
-          max: number;
-        } = 3
-  ): string {
+  slug(wordCount: number | NumberRange = 3): string {
     const words = this.words(wordCount);
     return this.faker.helpers.slugify(words);
   }
@@ -203,18 +154,7 @@ export class LoremModule extends ModuleBase {
    * @since 2.0.1
    */
   sentences(
-    sentenceCount:
-      | number
-      | {
-          /**
-           * The minimum number of sentences to generate.
-           */
-          min: number;
-          /**
-           * The maximum number of sentences to generate.
-           */
-          max: number;
-        } = { min: 2, max: 6 },
+    sentenceCount: number | NumberRange = { min: 2, max: 6 },
     separator: string = ' '
   ): string {
     return this.faker.helpers
@@ -236,20 +176,7 @@ export class LoremModule extends ModuleBase {
    *
    * @since 2.0.1
    */
-  paragraph(
-    sentenceCount:
-      | number
-      | {
-          /**
-           * The minimum number of sentences to generate.
-           */
-          min: number;
-          /**
-           * The maximum number of sentences to generate.
-           */
-          max: number;
-        } = 3
-  ): string {
+  paragraph(sentenceCount: number | NumberRange = 3): string {
     return this.sentences(sentenceCount);
   }
 
@@ -286,18 +213,7 @@ export class LoremModule extends ModuleBase {
    * @since 2.0.1
    */
   paragraphs(
-    paragraphCount:
-      | number
-      | {
-          /**
-           * The minimum number of paragraphs to generate.
-           */
-          min: number;
-          /**
-           * The maximum number of paragraphs to generate.
-           */
-          max: number;
-        } = 3,
+    paragraphCount: number | NumberRange = 3,
     separator: string = '\n'
   ): string {
     return this.faker.helpers
@@ -360,20 +276,7 @@ export class LoremModule extends ModuleBase {
    *
    * @since 3.1.0
    */
-  lines(
-    lineCount:
-      | number
-      | {
-          /**
-           * The minimum number of lines to generate.
-           */
-          min: number;
-          /**
-           * The maximum number of lines to generate.
-           */
-          max: number;
-        } = { min: 1, max: 5 }
-  ): string {
+  lines(lineCount: number | NumberRange = { min: 1, max: 5 }): string {
     return this.sentences(lineCount, '\n');
   }
 }

--- a/src/modules/string/module.ts
+++ b/src/modules/string/module.ts
@@ -3,7 +3,7 @@ import { CROCKFORDS_BASE32, dateToBase32 } from '../../internal/base32';
 import { toDate } from '../../internal/date';
 import { SimpleModuleBase } from '../../internal/module-base';
 import type { LiteralUnion } from '../../internal/types';
-import type { Casing } from '../../utils/types';
+import type { Casing, NumberRange } from '../../utils/types';
 import { uuidV4, uuidV7 } from './uuid';
 
 const UPPER_CHARS: ReadonlyArray<string> = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
@@ -117,18 +117,7 @@ export class StringModule extends SimpleModuleBase {
    */
   fromCharacters(
     characters: string | ReadonlyArray<string>,
-    length:
-      | number
-      | {
-          /**
-           * The minimum length of the string to generate.
-           */
-          min: number;
-          /**
-           * The maximum length of the string to generate.
-           */
-          max: number;
-        } = 1
+    length: number | NumberRange = 1
   ): string {
     length = this.faker.helpers.rangeToNumber(length);
     if (length <= 0) {
@@ -179,18 +168,7 @@ export class StringModule extends SimpleModuleBase {
            *
            * @default 1
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the string to generate.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the string to generate.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The casing of the characters.
            *
@@ -273,18 +251,7 @@ export class StringModule extends SimpleModuleBase {
            *
            * @default 1
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the string to generate.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the string to generate.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The casing of the characters.
            *
@@ -366,18 +333,7 @@ export class StringModule extends SimpleModuleBase {
        *
        * @default 1
        */
-      length?:
-        | number
-        | {
-            /**
-             * The minimum length of the string (excluding the prefix) to generate.
-             */
-            min: number;
-            /**
-             * The maximum length of the string (excluding the prefix) to generate.
-             */
-            max: number;
-          };
+      length?: number | NumberRange;
       /**
        * Prefix for the generated number.
        *
@@ -418,18 +374,7 @@ export class StringModule extends SimpleModuleBase {
        *
        * @default 1
        */
-      length?:
-        | number
-        | {
-            /**
-             * The minimum length of the string (excluding the prefix) to generate.
-             */
-            min: number;
-            /**
-             * The maximum length of the string (excluding the prefix) to generate.
-             */
-            max: number;
-          };
+      length?: number | NumberRange;
       /**
        * Prefix for the generated number.
        *
@@ -476,18 +421,7 @@ export class StringModule extends SimpleModuleBase {
        *
        * @default 1
        */
-      length?:
-        | number
-        | {
-            /**
-             * The minimum length of the string (excluding the prefix) to generate.
-             */
-            min: number;
-            /**
-             * The maximum length of the string (excluding the prefix) to generate.
-             */
-            max: number;
-          };
+      length?: number | NumberRange;
       /**
        * Casing of the generated number.
        *
@@ -574,18 +508,7 @@ export class StringModule extends SimpleModuleBase {
            *
            * @default 1
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the string to generate.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the string to generate.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * Whether leading zeros are allowed or not.
            *
@@ -660,20 +583,7 @@ export class StringModule extends SimpleModuleBase {
    *
    * @since 8.0.0
    */
-  sample(
-    length:
-      | number
-      | {
-          /**
-           * The minimum length of the string to generate.
-           */
-          min: number;
-          /**
-           * The maximum length of the string to generate.
-           */
-          max: number;
-        } = 10
-  ): string {
+  sample(length: number | NumberRange = 10): string {
     length = this.faker.helpers.rangeToNumber(length);
 
     const charCodeOption = {
@@ -838,20 +748,7 @@ export class StringModule extends SimpleModuleBase {
    *
    * @since 8.0.0
    */
-  nanoid(
-    length:
-      | number
-      | {
-          /**
-           * The minimum length of the Nano ID to generate.
-           */
-          min: number;
-          /**
-           * The maximum length of the Nano ID to generate.
-           */
-          max: number;
-        } = 21
-  ): string {
+  nanoid(length: number | NumberRange = 21): string {
     length = this.faker.helpers.rangeToNumber(length);
     if (length <= 0) {
       return '';
@@ -897,20 +794,7 @@ export class StringModule extends SimpleModuleBase {
    *
    * @since 8.0.0
    */
-  symbol(
-    length:
-      | number
-      | {
-          /**
-           * The minimum length of the string to generate.
-           */
-          min: number;
-          /**
-           * The maximum length of the string to generate.
-           */
-          max: number;
-        } = 1
-  ): string {
+  symbol(length: number | NumberRange = 1): string {
     return this.fromCharacters(
       [
         '!',

--- a/src/modules/system/module.ts
+++ b/src/modules/system/module.ts
@@ -1,5 +1,6 @@
 import { FakerError } from '../../errors/faker-error';
 import { ModuleBase } from '../../internal/module-base';
+import type { NumberRange } from '../../utils/types';
 
 const commonFileTypes = ['video', 'audio', 'image', 'text', 'application'];
 
@@ -57,18 +58,7 @@ export class SystemModule extends ModuleBase {
        *
        * @default 1
        */
-      extensionCount?:
-        | number
-        | {
-            /**
-             * Minimum number of extensions.
-             */
-            min: number;
-            /**
-             * Maximum number of extensions.
-             */
-            max: number;
-          };
+      extensionCount?: number | NumberRange;
     } = {}
   ): string {
     const { extensionCount = 1 } = options;

--- a/src/modules/word/filter-word-list-by-length.ts
+++ b/src/modules/word/filter-word-list-by-length.ts
@@ -1,5 +1,6 @@
 import { FakerError } from '../../errors/faker-error';
 import { groupBy } from '../../internal/group-by';
+import type { NumberRange } from '../../utils/types';
 
 /**
  * The error handling strategies for the `filterWordListByLength` function.
@@ -10,10 +11,7 @@ const STRATEGIES = {
   fail: () => {
     throw new FakerError('No words found that match the given length.');
   },
-  closest: (
-    wordList: ReadonlyArray<string>,
-    length: { min: number; max: number }
-  ): string[] => {
+  closest: (wordList: ReadonlyArray<string>, length: NumberRange): string[] => {
     const wordsByLength = groupBy(wordList, (word) => word.length);
     const lengths = Object.keys(wordsByLength).map(Number);
     const min = Math.min(...lengths);
@@ -40,7 +38,7 @@ const STRATEGIES = {
   },
 } satisfies Record<
   NonNullable<Parameters<typeof filterWordListByLength>[0]['strategy']>,
-  (wordList: string[], length: { min: number; max: number }) => string[]
+  (wordList: string[], length: NumberRange) => string[]
 >;
 
 /**
@@ -63,7 +61,7 @@ const STRATEGIES = {
  */
 export function filterWordListByLength(options: {
   wordList: ReadonlyArray<string>;
-  length?: number | { min: number; max: number };
+  length?: number | NumberRange;
   strategy?: 'fail' | 'closest' | 'shortest' | 'longest' | 'any-length';
 }): string[] {
   const { wordList, length, strategy = 'fail' } = options;

--- a/src/modules/word/module.ts
+++ b/src/modules/word/module.ts
@@ -1,5 +1,6 @@
 import { FakerError } from '../../errors/faker-error';
 import { ModuleBase } from '../../internal/module-base';
+import type { NumberRange } from '../../utils/types';
 import { filterWordListByLength } from './filter-word-list-by-length';
 
 /**
@@ -38,18 +39,7 @@ export class WordModule extends ModuleBase {
           /**
            * The expected length of the word.
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -110,18 +100,7 @@ export class WordModule extends ModuleBase {
           /**
            * The expected length of the word.
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -182,18 +161,7 @@ export class WordModule extends ModuleBase {
           /**
            * The expected length of the word.
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -254,18 +222,7 @@ export class WordModule extends ModuleBase {
           /**
            * The expected length of the word.
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -326,18 +283,7 @@ export class WordModule extends ModuleBase {
           /**
            * The expected length of the word.
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -398,18 +344,7 @@ export class WordModule extends ModuleBase {
           /**
            * The expected length of the word.
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -470,18 +405,7 @@ export class WordModule extends ModuleBase {
           /**
            * The expected length of the word.
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -540,18 +464,7 @@ export class WordModule extends ModuleBase {
           /**
            * The expected length of the word.
            */
-          length?:
-            | number
-            | {
-                /**
-                 * The minimum length of the word.
-                 */
-                min: number;
-                /**
-                 * The maximum length of the word.
-                 */
-                max: number;
-              };
+          length?: number | NumberRange;
           /**
            * The strategy to apply when no words with a matching length are found.
            *
@@ -615,18 +528,7 @@ export class WordModule extends ModuleBase {
            *
            * @default { min: 1, max: 3 }
            */
-          count?:
-            | number
-            | {
-                /**
-                 * The minimum number of words to return.
-                 */
-                min: number;
-                /**
-                 * The maximum number of words to return.
-                 */
-                max: number;
-              };
+          count?: number | NumberRange;
         } = {}
   ): string {
     if (typeof options === 'number') {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,3 +6,17 @@
  * - `'mixed'`: Generated characters keep their original casing.
  */
 export type Casing = 'upper' | 'lower' | 'mixed';
+
+/**
+ * A range of numbers with an inclusive minimum and maximum.
+ */
+export interface NumberRange {
+  /**
+   * The minimum value (inclusive).
+   */
+  min: number;
+  /**
+   * The maximum value (inclusive).
+   */
+  max: number;
+}

--- a/test/scripts/apidocs/__snapshots__/method.spec.ts.snap
+++ b/test/scripts/apidocs/__snapshots__/method.spec.ts.snap
@@ -20,6 +20,7 @@ exports[`method > expected and actual methods are equal 1`] = `
   "methodWithThrows",
   "multiParamMethod",
   "noParamMethod",
+  "numberRangeParamMethod",
   "optionalStringParamMethod",
   "optionsInlineParamMethodWithDefaults",
   "optionsInterfaceParamMethodWithDefaults",
@@ -342,7 +343,7 @@ exports[`method > processMethodLike(literalUnionParamMethod) 1`] = `
         },
         {
           "default": undefined,
-          "description": "Value \`'a'\` or \`'b'\` or an array thereof.",
+          "description": "\`'a'\` or \`'b'\` or an array thereof.",
           "name": "mixed",
           "type": {
             "text": "'a' | 'b' | string | Array<'a' | 'b' | string>",
@@ -395,7 +396,7 @@ exports[`method > processMethodLike(literalUnionParamMethod) 1`] = `
         },
         {
           "default": undefined,
-          "description": "Value \`'a'\` or \`'b'\` or an array thereof.",
+          "description": "\`'a'\` or \`'b'\` or an array thereof.",
           "name": "namedMixed",
           "type": {
             "text": "'a' | 'b' | string | Array<AB | string>",
@@ -971,6 +972,111 @@ exports[`method > processMethodLike(noParamMethod) 1`] = `
       },
       "seeAlsos": [],
       "signature": "function noParamMethod(): number;",
+      "since": "1.0.0",
+      "throws": [],
+    },
+  ],
+  "source": {
+    "column": -1,
+    "filePath": "test/scripts/apidocs/method.example.ts",
+    "line": -1,
+  },
+}
+`;
+
+exports[`method > processMethodLike(numberRangeParamMethod) 1`] = `
+{
+  "name": "numberRangeParamMethod",
+  "signatures": [
+    {
+      "deprecated": undefined,
+      "description": "Test with NumberRange.",
+      "examples": [],
+      "experimental": undefined,
+      "parameters": [
+        {
+          "default": undefined,
+          "description": "\`{min: 1, max: 10}\`.",
+          "name": "value",
+          "type": {
+            "text": "{ min: number; max: number }",
+            "type": "simple",
+          },
+        },
+        {
+          "default": undefined,
+          "description": "Array of \`{min: 1, max: 10}\`.",
+          "name": "array",
+          "type": {
+            "text": "Array<{ min: number; max: number }>",
+            "type": "generic",
+            "typeParameters": [
+              {
+                "text": "{ min: number; max: number }",
+                "type": "simple",
+              },
+            ],
+          },
+        },
+        {
+          "default": undefined,
+          "description": "The options parameter.",
+          "name": "options",
+          "type": {
+            "text": "{ ... }",
+            "type": "simple",
+          },
+        },
+        {
+          "default": undefined,
+          "description": "The count parameter.",
+          "name": "options.count",
+          "type": {
+            "text": "{ min: number; max: number }",
+            "type": "simple",
+          },
+        },
+        {
+          "default": undefined,
+          "description": "\`{min: 1, max: 10}\` or an array thereof.",
+          "name": "mixed",
+          "type": {
+            "text": "{ min: number; max: number } | Array<{ min: number; max: number }>",
+            "type": "union",
+            "types": [
+              {
+                "text": "{ min: number; max: number }",
+                "type": "simple",
+              },
+              {
+                "text": "Array<{ min: number; max: number }>",
+                "type": "generic",
+                "typeParameters": [
+                  {
+                    "text": "{ min: number; max: number }",
+                    "type": "simple",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+      "remarks": [],
+      "returns": {
+        "text": "string",
+        "type": "simple",
+      },
+      "seeAlsos": [],
+      "signature": "function numberRangeParamMethod(
+    value: NumberRange,
+    array: ReadonlyArray<NumberRange>,
+    options: {
+      /** The count parameter. */
+      count: NumberRange;
+    },
+    mixed: NumberRange | ReadonlyArray<NumberRange>
+  ): string;",
       "since": "1.0.0",
       "throws": [],
     },

--- a/test/scripts/apidocs/method.example.ts
+++ b/test/scripts/apidocs/method.example.ts
@@ -1,4 +1,4 @@
-import type { Casing, ColorFormat } from '../../../src';
+import type { Casing, ColorFormat, NumberRange } from '../../../src';
 import { FakerError } from '../../../src/errors/faker-error';
 import type { LiteralUnion } from '../../../src/internal/types';
 import type { AlphaNumericChar } from '../../../src/modules/string';
@@ -182,8 +182,8 @@ export class SignatureTest {
    * @param namedValue `'a'` or `'b'`.
    * @param array Array of `'a'` or `'b'`.
    * @param namedArray Array of `'a'` or `'b'`.
-   * @param mixed Value `'a'` or `'b'` or an array thereof.
-   * @param namedMixed Value `'a'` or `'b'` or an array thereof.
+   * @param mixed `'a'` or `'b'` or an array thereof.
+   * @param namedMixed `'a'` or `'b'` or an array thereof.
    *
    * @since 1.0.0
    */
@@ -203,6 +203,34 @@ export class SignatureTest {
       String(mixed) +
       String(namedMixed)
     );
+  }
+
+  /**
+   * Test with NumberRange.
+   *
+   * @param value `{min: 1, max: 10}`.
+   * @param array Array of `{min: 1, max: 10}`.
+   * @param options The options parameter.
+   * @param options.count `{min: 1, max: 10}`.
+   * @param mixed `{min: 1, max: 10}` or an array thereof.
+   *
+   * @since 1.0.0
+   */
+  numberRangeParamMethod(
+    value: NumberRange,
+    array: ReadonlyArray<NumberRange>,
+    options: {
+      /** The count parameter. */
+      count: NumberRange;
+    },
+    mixed: NumberRange | ReadonlyArray<NumberRange>
+  ): string {
+    return JSON.stringify({
+      value,
+      array,
+      options,
+      mixed,
+    });
   }
 
   /**


### PR DESCRIPTION
_the following PR description is claude generated_

## Summary

Introduces a shared, publicly exported `NumberRange` interface and uses it to replace the ~40 inline `{ min: number; max: number }` shapes scattered across the module method signatures.

```ts
export interface NumberRange {
  /** The minimum value (inclusive). */
  min: number;
  /** The maximum value (inclusive). */
  max: number;
}
```

```ts
import { faker, type NumberRange } from '@faker-js/faker';

const count: NumberRange = { min: 1, max: 10 };

faker.lorem.words(count);
faker.helpers.arrayElements(['a', 'b', 'c'], count);
faker.string.alpha({ length: count });
```

Refs #1443.

## Motivation

- **Shorter, more readable signatures.** Method signatures that previously inlined a multi-line `number | { min; max }` object now read as `number | NumberRange`.
- **A reusable, importable type for consumers.** Users can declare a single `NumberRange` value and pass it to any range-accepting method, instead of re-declaring the shape inline or reverse-engineering it via `Parameters<...>`.
- **Deduplication.** One canonical definition replaces ~40 copies of the same shape.

## Design decision (Option 3)

The discussion weighed several approaches (a single shared type vs. per-concept named types such as `WordCountRange`, hybrid inline/shared shapes, and intersection types). We are going with **Option 3: a single shared `NumberRange`**.

Rationale:

- For the consumer, `NumberRange` and a hypothetical `WordCountRange` are structurally identical - extra per-concept types mostly add mental overhead and import churn.
- Starting with one type is the forward-compatible choice: a more specific type can be **added later non-breakingly** if users ask for it, whereas removing redundant types after the fact would be a breaking change.

## Tradeoffs

- The per-field JSDoc that previously lived on each inline `min`/`max` (e.g. *"The minimum number of words to generate."*) is replaced by the generic `NumberRange` field docs (*"The minimum value (inclusive)."*). The method-level `@param x.min` / `@param x.max` lines are unaffected.
- **Known follow-up:** the API-docs generator no longer renders the `min`/`max` sub-parameters (and their per-field defaults) for parameters typed as `NumberRange`. This needs to be addressed separately in the apidoc generation - see the discussion thread.
