### PR TITLE
feat(date): add ability to provide date range for `recent` and `soon`

### DIFF
--- a/src/modules/date/index.ts
+++ b/src/modules/date/index.ts
@@ -303,14 +303,18 @@ export class SimpleDateModule extends SimpleModuleBase {
    * Generates a random date in the recent past.
    *
    * @param options The optional options object.
-   * @param options.days The range of days the date may be in the past. Defaults to `1`.
+   * @param options.days The range of days the date may be in the past. Either as a fixed amount of days or as a day range. Defaults to `1`.
    * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `faker.defaultRefDate()`.
+   *
+   * @throws {FakerError} If `days.max` is less than 0.
+   * @throws {FakerError} If `days.min` is greater than or equal to `days.max`.
    *
    * @see faker.date.past(): For generating dates further back in time (years instead of days).
    *
    * @example
    * faker.date.recent() // '2022-02-04T02:09:35.077Z'
    * faker.date.recent({ days: 10 }) // '2022-01-29T06:12:12.829Z'
+   * faker.date.recent({ days: { min: 4, max: 7 } }) // '2022-02-02T17:54:01.818Z'
    * faker.date.recent({ days: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2019-12-27T18:11:19.117Z'
    *
    * @since 8.0.0
@@ -322,7 +326,22 @@ export class SimpleDateModule extends SimpleModuleBase {
        *
        * @default 1
        */
-      days?: number;
+      days?:
+        | number
+        | {
+            /**
+             * The minimum amount of days the date should be in the past.
+             *
+             * @default 0
+             */
+            min: number;
+            /**
+             * The maximum amount of days the date should be in the past.
+             *
+             * @default 1
+             */
+            max: number;
+          };
       /**
        * The date to use as reference point for the newly generated date.
        *
@@ -331,17 +350,31 @@ export class SimpleDateModule extends SimpleModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    const { days = 1, refDate = this.faker.defaultRefDate() } = options;
+    const { refDate = this.faker.defaultRefDate() } = options;
+    let { days = 1 } = options;
+    if (typeof days === 'number') {
+      days = { min: 0, max: days };
+    }
 
-    if (days <= 0) {
+    if (days.max <= 0) {
       throw new FakerError('Days must be greater than 0.');
     }
 
-    const time = toDate(refDate).getTime();
+    if (days.min >= days.max) {
+      throw new FakerError(
+        'The maximum amount of days must be greater than the minimum amount of days.'
+      );
+    }
+
+    const time = toDate(refDate);
+    const from = new Date(time);
+    from.setUTCDate(from.getUTCDate() - days.max);
+    const to = new Date(time);
+    to.setUTCDate(to.getUTCDate() - days.min);
 
     return this.between({
-      from: time - days * 24 * 3600 * 1000,
-      to: time - 1000,
+      from,
+      to: to.getTime() - 1000,
     });
   }
 
@@ -349,14 +382,18 @@ export class SimpleDateModule extends SimpleModuleBase {
    * Generates a random date in the near future.
    *
    * @param options The optional options object.
-   * @param options.days The range of days the date may be in the future. Defaults to `1`.
+   * @param options.days The range of days the date may be in the future. Either as a fixed amount of days or as a day range. Defaults to `1`.
    * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `faker.defaultRefDate()`.
+   *
+   * @throws {FakerError} If `days.max` is less than 0.
+   * @throws {FakerError} If `days.min` is greater than or equal to `days.max`.
    *
    * @see faker.date.future(): For generating dates further in the future (years instead of days).
    *
    * @example
    * faker.date.soon() // '2022-02-05T09:55:39.216Z'
    * faker.date.soon({ days: 10 }) // '2022-02-11T05:14:39.138Z'
+   * faker.date.soon({ days: { min: 4, max: 7 } }) // '2022-02-09T17:54:01.818Z'
    * faker.date.soon({ days: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2020-01-01T02:40:44.990Z'
    *
    * @since 8.0.0
@@ -368,7 +405,22 @@ export class SimpleDateModule extends SimpleModuleBase {
        *
        * @default 1
        */
-      days?: number;
+      days?:
+        | number
+        | {
+            /**
+             * The minimum amount of days the date should be in the future.
+             *
+             * @default 0
+             */
+            min: number;
+            /**
+             * The maximum amount of days the date should be in the future.
+             *
+             * @default 1
+             */
+            max: number;
+          };
       /**
        * The date to use as reference point for the newly generated date.
        *
@@ -377,17 +429,31 @@ export class SimpleDateModule extends SimpleModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    const { days = 1, refDate = this.faker.defaultRefDate() } = options;
+    const { refDate = this.faker.defaultRefDate() } = options;
+    let { days = 1 } = options;
+    if (typeof days === 'number') {
+      days = { min: 0, max: days };
+    }
 
-    if (days <= 0) {
+    if (days.max <= 0) {
       throw new FakerError('Days must be greater than 0.');
     }
 
-    const time = toDate(refDate).getTime();
+    if (days.min >= days.max) {
+      throw new FakerError(
+        'The maximum amount of days must be greater than the minimum amount of days.'
+      );
+    }
+
+    const time = toDate(refDate);
+    const from = new Date(time);
+    from.setUTCDate(from.getUTCDate() + days.min);
+    const to = new Date(time);
+    to.setUTCDate(to.getUTCDate() + days.max);
 
     return this.between({
-      from: time + 1000,
-      to: time + days * 24 * 3600 * 1000,
+      from: from.getTime() + 1000,
+      to,
     });
   }
 

--- a/test/modules/__snapshots__/date.spec.ts.snap
+++ b/test/modules/__snapshots__/date.spec.ts.snap
@@ -109,7 +109,9 @@ exports[`date > 42 > recent > with only number refDate 1`] = `2021-02-21T02:08:3
 
 exports[`date > 42 > recent > with only string refDate 1`] = `2021-02-21T02:08:35.603Z`;
 
-exports[`date > 42 > recent > with value 1`] = `2021-02-15T11:02:37.999Z`;
+exports[`date > 42 > recent > with value numeric 1`] = `2021-02-15T11:02:37.999Z`;
+
+exports[`date > 42 > recent > with value range 1`] = `2021-02-13T02:03:17.733Z`;
 
 exports[`date > 42 > soon > with only Date refDate 1`] = `2021-02-22T02:08:36.603Z`;
 
@@ -117,7 +119,9 @@ exports[`date > 42 > soon > with only number refDate 1`] = `2021-02-22T02:08:36.
 
 exports[`date > 42 > soon > with only string refDate 1`] = `2021-02-22T02:08:36.603Z`;
 
-exports[`date > 42 > soon > with value 1`] = `2021-02-25T11:02:38.999Z`;
+exports[`date > 42 > soon > with value numeric 1`] = `2021-02-25T11:02:38.999Z`;
+
+exports[`date > 42 > soon > with value range 1`] = `2021-02-28T02:03:18.733Z`;
 
 exports[`date > 42 > timeZone 1`] = `"America/North_Dakota/Center"`;
 
@@ -239,7 +243,9 @@ exports[`date > 1211 > recent > with only number refDate 1`] = `2021-02-21T15:26
 
 exports[`date > 1211 > recent > with only string refDate 1`] = `2021-02-21T15:26:18.924Z`;
 
-exports[`date > 1211 > recent > with value 1`] = `2021-02-20T23:59:56.196Z`;
+exports[`date > 1211 > recent > with value numeric 1`] = `2021-02-20T23:59:56.196Z`;
+
+exports[`date > 1211 > recent > with value range 1`] = `2021-02-18T01:42:52.055Z`;
 
 exports[`date > 1211 > soon > with only Date refDate 1`] = `2021-02-22T15:26:19.924Z`;
 
@@ -247,7 +253,9 @@ exports[`date > 1211 > soon > with only number refDate 1`] = `2021-02-22T15:26:1
 
 exports[`date > 1211 > soon > with only string refDate 1`] = `2021-02-22T15:26:19.924Z`;
 
-exports[`date > 1211 > soon > with value 1`] = `2021-03-02T23:59:57.196Z`;
+exports[`date > 1211 > soon > with value numeric 1`] = `2021-03-02T23:59:57.196Z`;
+
+exports[`date > 1211 > soon > with value range 1`] = `2021-03-05T01:42:53.055Z`;
 
 exports[`date > 1211 > timeZone 1`] = `"Pacific/Fiji"`;
 
@@ -367,7 +375,9 @@ exports[`date > 1337 > recent > with only number refDate 1`] = `2021-02-20T23:26
 
 exports[`date > 1337 > recent > with only string refDate 1`] = `2021-02-20T23:26:34.381Z`;
 
-exports[`date > 1337 > recent > with value 1`] = `2021-02-14T08:02:24.768Z`;
+exports[`date > 1337 > recent > with value numeric 1`] = `2021-02-14T08:02:24.768Z`;
+
+exports[`date > 1337 > recent > with value range 1`] = `2021-02-12T01:45:05.836Z`;
 
 exports[`date > 1337 > soon > with only Date refDate 1`] = `2021-02-21T23:26:35.381Z`;
 
@@ -375,7 +385,9 @@ exports[`date > 1337 > soon > with only number refDate 1`] = `2021-02-21T23:26:3
 
 exports[`date > 1337 > soon > with only string refDate 1`] = `2021-02-21T23:26:35.381Z`;
 
-exports[`date > 1337 > soon > with value 1`] = `2021-02-24T08:02:25.768Z`;
+exports[`date > 1337 > soon > with value numeric 1`] = `2021-02-24T08:02:25.768Z`;
+
+exports[`date > 1337 > soon > with value range 1`] = `2021-02-27T01:45:06.836Z`;
 
 exports[`date > 1337 > timeZone 1`] = `"America/Guadeloupe"`;
 

--- a/test/modules/date.spec.ts
+++ b/test/modules/date.spec.ts
@@ -57,7 +57,8 @@ describe('date', () => {
         .it('with only number refDate', {
           refDate: new Date(refDate).getTime(),
         })
-        .it('with value', { days: 10, refDate });
+        .it('with value numeric', { days: 10, refDate })
+        .it('with value range', { days: { min: 3, max: 12 }, refDate });
     });
 
     t.describeEach(
@@ -558,11 +559,94 @@ describe('date', () => {
           expect(date).lessThanOrEqual(new Date());
         });
 
+        it('should return a date between 20 and 40 days in the past', () => {
+          const today = new Date();
+          const daysAgoMax = 40;
+          const dayAgoMax = new Date(today);
+          dayAgoMax.setDate(dayAgoMax.getDate() - daysAgoMax);
+
+          const daysAgoMin = 20;
+          const dayAgoMin = new Date(today);
+          dayAgoMin.setDate(dayAgoMin.getDate() - daysAgoMin);
+
+          const date = faker.date.recent({
+            days: { min: daysAgoMin, max: daysAgoMax },
+          });
+
+          expect(date).lessThan(today);
+          expect(date).lessThan(dayAgoMin);
+          expect(date).greaterThanOrEqual(dayAgoMax);
+        });
+
+        it('should return a date between 20 and 40 days in the past (min)', () => {
+          const customFaker = new SimpleFaker({
+            randomizer: {
+              next() {
+                return 0.9999999999999;
+              },
+              seed() {},
+            },
+          });
+
+          const date = customFaker.date.recent({
+            days: { min: 20, max: 40 },
+            refDate: new Date(Date.UTC(2020, 2, 1, 0, 0, 1)),
+          });
+
+          expect(date).toEqual(new Date(Date.UTC(2020, 1, 10)));
+        });
+
+        it('should return a date between 20 and 40 days in the past (max)', () => {
+          const customFaker = new SimpleFaker({
+            randomizer: {
+              next() {
+                return 0;
+              },
+              seed() {},
+            },
+          });
+
+          const date = customFaker.date.recent({
+            days: { min: 20, max: 40 },
+            refDate: new Date(Date.UTC(2020, 2, 1)),
+          });
+
+          expect(date).toEqual(new Date(Date.UTC(2020, 0, 21)));
+        });
+
         it('should throw an error when days = 0', () => {
           const refDate = new Date();
           expect(() =>
             faker.date.recent({ days: 0, refDate: refDate.toISOString() })
           ).toThrow(new FakerError('Days must be greater than 0.'));
+        });
+
+        it('should throw an error when days.min > days.max', () => {
+          const refDate = new Date();
+          expect(() =>
+            faker.date.recent({
+              days: { min: 3, max: 2 },
+              refDate: refDate.toISOString(),
+            })
+          ).toThrow(
+            new FakerError(
+              'The maximum amount of days must be greater than the minimum amount of days.'
+            )
+          );
+        });
+
+        it('should throw an error when days.min = days.max', () => {
+          const refDate = new Date();
+          expect(() =>
+            faker.date.recent({
+              days: { min: 6, max: 6 },
+              refDate: refDate.toISOString(),
+            })
+          ).toThrow(
+            new FakerError(
+              'The maximum amount of days must be greater than the minimum amount of days.'
+            )
+          );
         });
 
         it.each(converterMap)(
@@ -599,11 +683,94 @@ describe('date', () => {
           expect(date).greaterThanOrEqual(new Date());
         });
 
+        it('should return a date between 20 and 40 days in the future', () => {
+          const today = new Date();
+          const daysUntilMin = 20;
+          const dayUntilMin = new Date(today);
+          dayUntilMin.setDate(dayUntilMin.getDate() + daysUntilMin);
+
+          const daysUntilMax = 40;
+          const dayUntilMax = new Date(today);
+          dayUntilMax.setDate(dayUntilMax.getDate() + daysUntilMax);
+
+          const date = faker.date.soon({
+            days: { min: daysUntilMin, max: daysUntilMax },
+          });
+
+          expect(date).greaterThan(today);
+          expect(date).greaterThan(dayUntilMin);
+          expect(date).lessThanOrEqual(dayUntilMax);
+        });
+
+        it('should return a date between 20 and 40 days in the future (min)', () => {
+          const customFaker = new SimpleFaker({
+            randomizer: {
+              next() {
+                return 0;
+              },
+              seed() {},
+            },
+          });
+
+          const date = customFaker.date.soon({
+            days: { min: 20, max: 40 },
+            refDate: new Date(Date.UTC(2020, 2, 1)),
+          });
+
+          expect(date).toEqual(new Date(Date.UTC(2020, 2, 21, 0, 0, 1)));
+        });
+
+        it('should return a date between 20 and 40 days in the future (max)', () => {
+          const customFaker = new SimpleFaker({
+            randomizer: {
+              next() {
+                return 0.9999999999999;
+              },
+              seed() {},
+            },
+          });
+
+          const date = customFaker.date.soon({
+            days: { min: 20, max: 40 },
+            refDate: new Date(Date.UTC(2020, 2, 1)),
+          });
+
+          expect(date).toEqual(new Date(Date.UTC(2020, 3, 10)));
+        });
+
         it('should throw an error when days = 0', () => {
           const refDate = new Date();
           expect(() =>
             faker.date.soon({ days: 0, refDate: refDate.toISOString() })
           ).toThrow(new FakerError('Days must be greater than 0.'));
+        });
+
+        it('should throw an error when days.min > days.max', () => {
+          const refDate = new Date();
+          expect(() =>
+            faker.date.soon({
+              days: { min: 3, max: 2 },
+              refDate: refDate.toISOString(),
+            })
+          ).toThrow(
+            new FakerError(
+              'The maximum amount of days must be greater than the minimum amount of days.'
+            )
+          );
+        });
+
+        it('should throw an error when days.min = days.max', () => {
+          const refDate = new Date();
+          expect(() =>
+            faker.date.soon({
+              days: { min: 6, max: 6 },
+              refDate: refDate.toISOString(),
+            })
+          ).toThrow(
+            new FakerError(
+              'The maximum amount of days must be greater than the minimum amount of days.'
+            )
+          );
         });
 
         it.each(converterMap)(


### PR DESCRIPTION
Continuation of #3653 and #3783

- #3653
- #3783

---

Extend `date.recent` and `date.soon`s' `days` option to support ranges.

````ts
faker.date.recent({ days: { min: 4, max: 7 } }) // '2026-04-30T13:17:16.910Z'
faker.date.soon({ days: { min: 4, max: 7 } }) // '2026-05-11T01:14:05.068Z'
````

````txt
$ pnpm run docs:diff
Documentation changes detected:
- Date
  - recent
  - soon
````

### Preview

- [recent](https://deploy-preview-3844.fakerjs.dev/api/date.html#recent)
- [soon](https://deploy-preview-3844.fakerjs.dev/api/date.html#soon)