### PR TITLE
feat(locale): add Welsh (cy) postal address definitions

### DIFF
--- a/src/locales/cy/location/index.ts
+++ b/src/locales/cy/location/index.ts
@@ -5,10 +5,12 @@
 import type { LocationDefinition } from '../../..';
 import county from './county';
 import direction from './direction';
+import postal_address from './postal_address';
 
 const location: LocationDefinition = {
   county,
   direction,
+  postal_address,
 };
 
 export default location;

--- a/src/locales/cy/location/postal_address.ts
+++ b/src/locales/cy/location/postal_address.ts
@@ -1,0 +1,4 @@
+export default [
+  '{{location.streetAddress}}\n{{location.city}}\n{{location.county}}\n{{location.zipCode}}',
+  '{{location.secondaryAddress}}, {{location.streetAddress}}\n{{location.city}}\n{{location.county}}\n{{location.zipCode}}',
+];

--- a/test/__snapshots__/locale-data.spec.ts.snap
+++ b/test/__snapshots__/locale-data.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`locale-data > should only have known characters 1`] = `
   "base": " ()+,-./:;ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz",
   "bn_BD": " (),-ঁংঅআইঈউএওকখগঘঙচছজঝঞটঠডঢণতথদধনপফবভমযরলশষসহ়ািীুূৃেৈোৌ্ড়য়",
   "cs_CZ": " #()+-.ABCDEFGHIJKLMNOPRSTUVWXZabcdefghijklmnopqrstuvwxyzÁÍÚáéíóöúüýČčĎďěňŘřŠšťůűŽž",
-  "cy": " -ABCDEFGHILMNOPRSTWYabcdefghijklmnoprstuwyôŵ",
+  "cy": " ,-ABCDEFGHILMNOPRSTWYabcdefghijklmnoprstuwyôŵ",
   "da": " !"#()+,-./ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwxyzÅÆØãåæçéíø",
   "de": " #&'()+,-.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzÄÖÜßàãäéíöúü",
   "de_AT": " #&()+,-.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzÄÖÜßãäéíöúü",


### PR DESCRIPTION
Follows https://github.com/faker-js/faker/pull/3849.

Postal address definitions as ask by @matthewmayer in https://github.com/faker-js/faker/pull/3849#issuecomment-4457250292. Uses the new county, based on the `EN_GB` address.