### PR TITLE
feat(locale): add Welsh (cy) postcode definitions

### DIFF
--- a/src/locales/cy/location/index.ts
+++ b/src/locales/cy/location/index.ts
@@ -6,11 +6,13 @@ import type { LocationDefinition } from '../../..';
 import county from './county';
 import direction from './direction';
 import postal_address from './postal_address';
+import postcode from './postcode';
 
 const location: LocationDefinition = {
   county,
   direction,
   postal_address,
+  postcode,
 };
 
 export default location;

--- a/src/locales/cy/location/postcode.ts
+++ b/src/locales/cy/location/postcode.ts
@@ -1,0 +1,6 @@
+const suffixes = ['## ##?', '# #??'];
+const prefixes = ['CF', 'CH', 'HR', 'LD', 'LL', 'NP', 'SA', 'SY'];
+
+export default prefixes.flatMap((prefix) =>
+  suffixes.map((suffix) => prefix + suffix)
+);

--- a/test/__snapshots__/locale-data.spec.ts.snap
+++ b/test/__snapshots__/locale-data.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`locale-data > should only have known characters 1`] = `
   "base": " ()+,-./:;ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz",
   "bn_BD": " (),-ঁংঅআইঈউএওকখগঘঙচছজঝঞটঠডঢণতথদধনপফবভমযরলশষসহ়ািীুূৃেৈোৌ্ড়য়",
   "cs_CZ": " #()+-.ABCDEFGHIJKLMNOPRSTUVWXZabcdefghijklmnopqrstuvwxyzÁÍÚáéíóöúüýČčĎďěňŘřŠšťůűŽž",
-  "cy": " ,-ABCDEFGHILMNOPRSTWYabcdefghijklmnoprstuwyôŵ",
+  "cy": " #,-?ABCDEFGHILMNOPRSTWYabcdefghijklmnoprstuwyôŵ",
   "da": " !"#()+,-./ABCDEFGHIJKLMNOPQRSTUVWYZabcdefghijklmnopqrstuvwxyzÅÆØãåæçéíø",
   "de": " #&'()+,-.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzÄÖÜßàãäéíöúü",
   "de_AT": " #&()+,-.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzÄÖÜßãäéíöúü",


### PR DESCRIPTION
Based on the `en_GB` postcode definitions with a prefix as recommened by @matthewmayer in https://github.com/faker-js/faker/pull/3850#issuecomment-4484704496

<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://fakerjs.dev/contributing/submit-a-pull-request#the-pull-request-title -->
