### PR TITLE
fix(helpers): lazy results in fake

### DIFF
--- a/src/modules/helpers/eval.ts
+++ b/src/modules/helpers/eval.ts
@@ -217,7 +217,7 @@ function resolveProperty(entrypoint: unknown, key: string): unknown {
         return undefined;
       }
 
-      return entrypoint?.[key as keyof typeof entrypoint];
+      return resolveProperty(entrypoint, key);
     }
 
     case 'object': {

--- a/test/modules/helpers-eval.spec.ts
+++ b/test/modules/helpers-eval.spec.ts
@@ -99,6 +99,17 @@ describe('fakeEval()', () => {
     expect(faker.definitions.airline.airline).toContain(actual);
   });
 
+  it('supports returning lazy results', () => {
+    faker.rawDefinitions.custom = {
+      lazy: () => ({
+        key: 'lazy result',
+      }),
+    };
+    const actual = fakeEval('custom.lazy.key', faker);
+    expect(actual).toBeTypeOf('string');
+    expect(actual).toBe('lazy result');
+  });
+
   it('supports patterns after a function call', () => {
     const actual = fakeEval('airline.airline().name', faker);
     expect(actual).toBeTypeOf('string');


### PR DESCRIPTION
I noticed with some constelations of lazy locale data, that properties fail to resolve.
This PR fixes this by eagerly evaluating the lazy functions before accessing the property within.