### PR TITLE
feat(helpers): resolve primitive fake property chains

### DIFF
--- a/src/modules/helpers/eval.ts
+++ b/src/modules/helpers/eval.ts
@@ -217,15 +217,41 @@ function resolveProperty(entrypoint: unknown, key: string): unknown {
         return undefined;
       }
 
-      return entrypoint?.[key as keyof typeof entrypoint];
+      return getProperty(entrypoint, key);
     }
 
     case 'object': {
-      return entrypoint?.[key as keyof typeof entrypoint];
+      return getProperty(entrypoint, key);
+    }
+
+    case 'bigint':
+    case 'boolean':
+    case 'number':
+    case 'string': {
+      return getProperty(entrypoint, key);
     }
 
     default: {
       return undefined;
     }
   }
+}
+
+type Callable = (this: unknown, ...args: unknown[]) => unknown;
+
+/**
+ * Resolves the given property and binds methods to their source value.
+ *
+ * @param entrypoint The entrypoint to resolve the property on.
+ * @param key The property name to resolve.
+ */
+function getProperty(entrypoint: unknown, key: string): unknown {
+  if (entrypoint == null) {
+    return undefined;
+  }
+
+  const value = (new Object(entrypoint) as Record<string, unknown>)[key];
+  return typeof value === 'function'
+    ? (value as Callable).bind(entrypoint)
+    : value;
 }

--- a/test/modules/helpers-eval.spec.ts
+++ b/test/modules/helpers-eval.spec.ts
@@ -115,6 +115,17 @@ describe('fakeEval()', () => {
     ).toContain(actual);
   });
 
+  it('supports prototype methods after generated primitive values', () => {
+    const entrypoint = { value: () => 1234 };
+
+    expect(fakeEval('value.toPrecision(3)', faker, [entrypoint])).toBe(
+      '1.23e+3'
+    );
+    expect(fakeEval('value().toPrecision(3)', faker, [entrypoint])).toBe(
+      '1.23e+3'
+    );
+  });
+
   it('requires a dot after a function call', () => {
     expect(() => fakeEval('airline.airline()iataCode', faker)).toThrow(
       new FakerError(

--- a/test/modules/helpers.spec.ts
+++ b/test/modules/helpers.spec.ts
@@ -1057,6 +1057,10 @@ describe('helpers', () => {
           expect(faker.helpers.fake('{{string.alphanumeric(0)}}')).toBe('');
         });
 
+        it('should resolve properties after generated primitive values', () => {
+          expect(faker.helpers.fake('{{string.alpha(10).length}}')).toBe('10');
+        });
+
         it('should be able to return locale definition strings', () => {
           expect(faker.definitions.cell_phone?.formats).toContain(
             faker.helpers.fake('{{cell_phone.formats}}')


### PR DESCRIPTION
## Summary
- resolve properties on primitive values returned while evaluating helpers.fake/fakeEval chains
- bind resolved prototype methods to their source value so chained calls keep the correct receiver
- add regressions for implicit and explicit generated primitive property chains

Closes #3465

## Verification
- `corepack pnpm exec vitest run test/modules/helpers-eval.spec.ts test/modules/helpers.spec.ts`
- `corepack pnpm exec prettier --check src/modules/helpers/eval.ts test/modules/helpers-eval.spec.ts test/modules/helpers.spec.ts`
- `corepack pnpm exec eslint src/modules/helpers/eval.ts test/modules/helpers-eval.spec.ts test/modules/helpers.spec.ts`
- `git diff --check`
- `corepack pnpm exec vitest run test/scripts/shared/markdown.spec.ts`
- `corepack pnpm run ts-check`
- `corepack pnpm run test`