### PR TITLE
docs: escape refreshable code results

### DIFF
--- a/docs/.vitepress/components/api-docs/refreshable-code.vue
+++ b/docs/.vitepress/components/api-docs/refreshable-code.vue
@@ -114,7 +114,13 @@ function newCommentLine(content: string): string {
 }
 
 function newCommentSpan(content: string): string {
-  return `<span class="comment-delete-marker" style="--shiki-light:#6A737D;--shiki-dark:#6A737D">// ${content}</span>`;
+  return `<span class="comment-delete-marker" style="--shiki-light:#6A737D;--shiki-dark:#6A737D">// ${escapeHtml(content)}</span>`;
+}
+
+function escapeHtml(text: string): string {
+  const el = document.createElement('span');
+  el.textContent = text;
+  return el.innerHTML;
 }
 
 if (refresh != null && refreshOnLoad) {


### PR DESCRIPTION
Based on https://github.com/faker-js/faker/pull/3879#issuecomment-4620819009

- https://github.com/faker-js/faker/pull/3879#issuecomment-4620819009

---

To eliminate any risk from refreshable code examples, escape the result of refreshable code before inserting it.
This adds to the existing defense layers:

- code review of examples
- log only error type 
- no html like output