### PR TITLE
docs: handle experimental flag

### DIFF
--- a/docs/.vitepress/components/api-docs/method.ts
+++ b/docs/.vitepress/components/api-docs/method.ts
@@ -1,6 +1,7 @@
 export interface ApiDocsMethod {
   readonly name: string;
   readonly deprecated: string | undefined; // HTML
+  readonly experimental: true | undefined;
   readonly description: string; // HTML
   readonly remark: string | undefined; // HTML
   readonly since: string;

--- a/docs/.vitepress/components/api-docs/method.vue
+++ b/docs/.vitepress/components/api-docs/method.vue
@@ -8,6 +8,7 @@ import RefreshableCode from './refreshable-code.vue';
 const { method } = defineProps<{ method: ApiDocsMethod }>();
 const {
   deprecated,
+  experimental,
   description,
   remark,
   since,
@@ -38,6 +39,11 @@ function seeAlsoToUrl(see: string): string {
       <p class="custom-block-title">Deprecated</p>
       <p>This method is deprecated and will be removed in a future version.</p>
       <span v-html="deprecated" />
+    </div>
+
+    <div v-if="experimental" class="warning custom-block">
+      <p class="custom-block-title">Experimental</p>
+      <p>This method is experimental and may change in future versions.</p>
     </div>
 
     <div v-html="description"></div>

--- a/docs/.vitepress/components/api-docs/method.vue
+++ b/docs/.vitepress/components/api-docs/method.vue
@@ -43,7 +43,7 @@ function seeAlsoToUrl(see: string): string {
 
     <div v-if="experimental" class="warning custom-block">
       <p class="custom-block-title">Experimental</p>
-      <p>This method is experimental and may change in future versions.</p>
+      <p>This method is experimental and changes may not follow semantic versioning.</p>
     </div>
 
     <div v-html="description"></div>

--- a/docs/.vitepress/components/api-docs/method.vue
+++ b/docs/.vitepress/components/api-docs/method.vue
@@ -43,7 +43,10 @@ function seeAlsoToUrl(see: string): string {
 
     <div v-if="experimental" class="warning custom-block">
       <p class="custom-block-title">Experimental</p>
-      <p>This method is experimental and changes may not follow semantic versioning.</p>
+      <p>
+        This method is experimental and changes may not follow semantic
+        versioning.
+      </p>
     </div>
 
     <div v-html="description"></div>

--- a/docs/.vitepress/components/api-docs/method.vue
+++ b/docs/.vitepress/components/api-docs/method.vue
@@ -44,7 +44,7 @@ function seeAlsoToUrl(see: string): string {
     <div v-if="experimental" class="warning custom-block">
       <p class="custom-block-title">Experimental</p>
       <p>
-        This method is experimental and changes may not follow semantic
+        This method is experimental and future changes may not follow semantic
         versioning.
       </p>
     </div>

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -194,6 +194,7 @@ export default defineConfig(
             { tags: ['since'] },
             { tags: ['default'] },
             { tags: ['deprecated'] },
+            { tags: ['experimental'] },
           ],
         },
       ],

--- a/scripts/apidocs/output/page.ts
+++ b/scripts/apidocs/output/page.ts
@@ -166,6 +166,7 @@ async function toMethodData(method: RawApiDocsMethod): Promise<ApiDocsMethod> {
   const signatureData = required(signatures.at(-1), 'method signature');
   const {
     deprecated,
+    experimental,
     description,
     since,
     parameters,
@@ -232,6 +233,7 @@ async function toMethodData(method: RawApiDocsMethod): Promise<ApiDocsMethod> {
     signature: await codeToHtml(formattedSignature),
     examples: await codeGroupToHtml(examples),
     refresh,
+    experimental,
     deprecated: await mdToHtml(deprecated),
     seeAlsos: await Promise.all(
       seeAlsos.map((seeAlso) => mdToHtml(seeAlso, true))

--- a/scripts/apidocs/processing/jsdocs.ts
+++ b/scripts/apidocs/processing/jsdocs.ts
@@ -21,6 +21,10 @@ export function getDeprecated(jsdocs: JSDoc): string | undefined {
   return getOptionalTagFromJSDoc(jsdocs, 'deprecated');
 }
 
+export function getExperimental(jsdocs: JSDoc): true | undefined {
+  return hasTagFromJSDoc(jsdocs, 'experimental') ? true : undefined;
+}
+
 export function getDescription(jsdocs: JSDoc | JSDocTag): string {
   return required(jsdocs.getCommentText(), 'jsdocs description');
 }
@@ -97,5 +101,14 @@ function getTagsFromJSDoc(
         full ? tag.getStructure().text?.toString() : tag.getCommentText()
       ),
     `@${type}`
+  );
+}
+
+function hasTagFromJSDoc(jsdocs: JSDoc, type: string): boolean {
+  return (
+    optionalOne(
+      jsdocs.getTags().filter((tag) => tag.getTagName() === type),
+      `@${type}`
+    ) != null
   );
 }

--- a/scripts/apidocs/processing/signature.ts
+++ b/scripts/apidocs/processing/signature.ts
@@ -7,6 +7,7 @@ import {
   getDeprecated,
   getDescription,
   getExamples,
+  getExperimental,
   getJsDocs,
   getRemarks,
   getSeeAlsos,
@@ -27,6 +28,10 @@ export interface RawApiDocsSignature {
    * The deprecation notice of the signature, if it has one.
    */
   deprecated: string | undefined;
+  /**
+   * Whether the signature is experimental and may change in future versions.
+   */
+  experimental: true | undefined;
   /**
    * The description of the signature.
    */
@@ -109,6 +114,7 @@ function processSignature(
   try {
     return {
       deprecated: getDeprecated(jsdocs),
+      experimental: getExperimental(jsdocs),
       description: getDescription(jsdocs),
       since: getSince(jsdocs),
       parameters,

--- a/src/utils/get-default-ref-date.ts
+++ b/src/utils/get-default-ref-date.ts
@@ -33,6 +33,8 @@ const DEFAULT_REF_DATE_SOURCE: () => Date = () => new Date();
  * getDefaultRefDate(fakerCore) // 2020-01-01T00:00:02Z
  *
  * @since 10.5.0
+ *
+ * @experimental
  */
 export function getDefaultRefDate(fakerCore: FakerCore): Date {
   return (fakerCore.config.defaultRefDate ?? DEFAULT_REF_DATE_SOURCE)();

--- a/src/utils/set-default-ref-date.ts
+++ b/src/utils/set-default-ref-date.ts
@@ -33,6 +33,8 @@ import type { FakerCore } from '../core';
  * getDefaultRefDate(fakerCore) // 2020-01-01T00:00:02Z
  *
  * @since 10.5.0
+ *
+ * @experimental
  */
 export function setDefaultRefDate(
   fakerCore: FakerCore,

--- a/test/scripts/apidocs/__snapshots__/method.spec.ts.snap
+++ b/test/scripts/apidocs/__snapshots__/method.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`method > expected and actual methods are equal 1`] = `
   "methodWithDeprecated",
   "methodWithDeprecatedOption",
   "methodWithExample",
+  "methodWithExperimental",
   "methodWithMultipleExamples",
   "methodWithMultipleRemarks",
   "methodWithMultipleSeeMarkers",
@@ -38,6 +39,7 @@ exports[`method > processMethodLike(complexArrayParameter) 1`] = `
       "deprecated": undefined,
       "description": "Complex array parameter.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -122,6 +124,7 @@ exports[`method > processMethodLike(defaultBooleanParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with a default parameter.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": "true",
@@ -160,6 +163,7 @@ exports[`method > processMethodLike(functionParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with a function parameters.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -198,6 +202,7 @@ exports[`method > processMethodLike(literalUnionParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with LiteralUnion.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -480,6 +485,7 @@ exports[`method > processMethodLike(methodWithDeprecated) 1`] = `
       "deprecated": "do something else",
       "description": "Test with deprecated and see marker.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -510,6 +516,7 @@ exports[`method > processMethodLike(methodWithDeprecatedOption) 1`] = `
       "deprecated": undefined,
       "description": "Test with deprecated option.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -585,6 +592,7 @@ exports[`method > processMethodLike(methodWithExample) 1`] = `
       "examples": [
         "test.apidocs.methodWithExample() // 0",
       ],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -593,6 +601,35 @@ exports[`method > processMethodLike(methodWithExample) 1`] = `
       },
       "seeAlsos": [],
       "signature": "function methodWithExample(): number;",
+      "since": "1.0.0",
+      "throws": [],
+    },
+  ],
+  "source": {
+    "column": -1,
+    "filePath": "test/scripts/apidocs/method.example.ts",
+    "line": -1,
+  },
+}
+`;
+
+exports[`method > processMethodLike(methodWithExperimental) 1`] = `
+{
+  "name": "methodWithExperimental",
+  "signatures": [
+    {
+      "deprecated": undefined,
+      "description": "Test with experimental .",
+      "examples": [],
+      "experimental": true,
+      "parameters": [],
+      "remarks": [],
+      "returns": {
+        "text": "number",
+        "type": "simple",
+      },
+      "seeAlsos": [],
+      "signature": "function methodWithExperimental(): number;",
       "since": "1.0.0",
       "throws": [],
     },
@@ -619,6 +656,7 @@ test.apidocs.methodWithMultipleExamples() // 0",
 const value = test.apidocs.methodWithMultipleExamples();
 console.log(value); // 0",
       ],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -647,6 +685,7 @@ exports[`method > processMethodLike(methodWithMultipleRemarks) 1`] = `
       "deprecated": undefined,
       "description": "Test with multiple remark markers.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [
         "First special text.",
@@ -679,6 +718,7 @@ exports[`method > processMethodLike(methodWithMultipleSeeMarkers) 1`] = `
       "deprecated": undefined,
       "description": "Test with multiple see markers.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -710,6 +750,7 @@ exports[`method > processMethodLike(methodWithMultipleSeeMarkersAndBackticks) 1`
       "deprecated": undefined,
       "description": "Test with multiple see markers and backticks.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -741,6 +782,7 @@ exports[`method > processMethodLike(methodWithMultipleThrows) 1`] = `
       "deprecated": undefined,
       "description": "Test with multiple throws.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -772,6 +814,7 @@ exports[`method > processMethodLike(methodWithRemark) 1`] = `
       "deprecated": undefined,
       "description": "Test with remark marker.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [
         "This text is special.",
@@ -802,6 +845,7 @@ exports[`method > processMethodLike(methodWithSinceMarker) 1`] = `
       "deprecated": undefined,
       "description": "Test with since marker.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -830,6 +874,7 @@ exports[`method > processMethodLike(methodWithThrows) 1`] = `
       "deprecated": undefined,
       "description": "Test with throws.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -860,6 +905,7 @@ exports[`method > processMethodLike(multiParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with multiple parameters.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -916,6 +962,7 @@ exports[`method > processMethodLike(noParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with no parameters.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [],
       "remarks": [],
       "returns": {
@@ -944,6 +991,7 @@ exports[`method > processMethodLike(optionalStringParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with an optional parameter.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -982,6 +1030,7 @@ exports[`method > processMethodLike(optionsInlineParamMethodWithDefaults) 1`] = 
       "deprecated": undefined,
       "description": "Test with a function parameters (inline types) with defaults.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": "{ value: 1 }",
@@ -1080,6 +1129,7 @@ exports[`method > processMethodLike(optionsInterfaceParamMethodWithDefaults) 1`]
       "deprecated": undefined,
       "description": "Test with a function parameters with defaults.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": "{ value: 1 }",
@@ -1140,6 +1190,7 @@ exports[`method > processMethodLike(optionsParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with an options parameter.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -1249,6 +1300,7 @@ exports[`method > processMethodLike(optionsTypeParamMethodWithDefaults) 1`] = `
       "deprecated": undefined,
       "description": "Test with a function parameters with defaults.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": "{ value: 1 }",
@@ -1336,6 +1388,7 @@ exports[`method > processMethodLike(recordParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with a Record parameter.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -1374,6 +1427,7 @@ exports[`method > processMethodLike(requiredNumberParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with a required parameter.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,
@@ -1412,6 +1466,7 @@ exports[`method > processMethodLike(stringUnionParamMethod) 1`] = `
       "deprecated": undefined,
       "description": "Test with string union.",
       "examples": [],
+      "experimental": undefined,
       "parameters": [
         {
           "default": undefined,

--- a/test/scripts/apidocs/method.example.ts
+++ b/test/scripts/apidocs/method.example.ts
@@ -378,6 +378,17 @@ export class SignatureTest {
   }
 
   /**
+   * Test with experimental .
+   *
+   * @since 1.0.0
+   *
+   * @experimental
+   */
+  methodWithExperimental(): number {
+    return 0;
+  }
+
+  /**
    * Test with throws.
    *
    * @throws {FakerError} Everytime.

--- a/test/scripts/apidocs/page.spec.ts
+++ b/test/scripts/apidocs/page.spec.ts
@@ -11,6 +11,7 @@ function newTestMethod(
     signatures: [
       {
         deprecated: 'deprecated',
+        experimental: undefined,
         description: 'description',
         remarks: [],
         since: 'since',


### PR DESCRIPTION
- Add support for `@experimental` jsdoc flag.
  - Currently, the flag does not support additional text, as experimental is self explanatory (IMO)
- Flag get/setDefaultRefDate SMF as `@experimental`
- FakerCore is currently not flagged
- Update the experimental banner copy to explicitly mention semantic versioning and clarify that **future** changes may not follow SemVer.

### Preview

<img src="https://github.com/user-attachments/assets/527949d4-52f6-41ae-96e4-d81208f17413">

- <a href="https://deploy-preview-3885.fakerjs.dev/api/utils.html#getdefaultrefdate">getDefaultRefDate</a>
- <a href="https://deploy-preview-3885.fakerjs.dev/api/utils.html#setdefaultrefdate">setDefaultRefDate</a>