### PR TITLE
fix(locale): only generate valid French postal codes

### DIFF
--- a/src/locales/fr/location/postcode.ts
+++ b/src/locales/fr/location/postcode.ts
@@ -1,1 +1,18 @@
-export default ['#####'];
+// French postal codes are five digits whose leading digits identify the
+// department: metropolitan departments use the prefixes 01-95 (followed by
+// three digits), while the overseas departments and collectivities use 971-978,
+// 984 and 986-989 (followed by two digits). The 00xxx, 96xxx, 980-983xx, 985xx
+// and 99xxx ranges are not assigned, so they are excluded here. See #3550 and
+// https://en.wikipedia.org/wiki/Postal_codes_in_France
+const range = (start: number, end: number): number[] =>
+  Array.from({ length: end - start + 1 }, (_, index) => start + index);
+
+const metropolitan = range(1, 95).map(
+  (department) => `${department.toString().padStart(2, '0')}###`
+);
+
+const overseas = [...range(971, 978), 984, ...range(986, 989)].map(
+  (territory) => `${territory}##`
+);
+
+export default [...metropolitan, ...overseas];

--- a/test/modules/location.spec.ts
+++ b/test/modules/location.spec.ts
@@ -8,6 +8,7 @@ import {
   faker,
   fakerEN_CA,
   fakerEN_US,
+  fakerFR,
   fakerNL,
   simpleFaker,
 } from '../../src';
@@ -219,6 +220,25 @@ describe('location', () => {
 
             expect(zipCode).toMatch(/^[1-9]\d{3} [A-Z]{2}$/);
             expect(zipCode.slice(-2)).not.toBeOneOf(['SS', 'SD', 'SA']);
+          }
+        });
+
+        it('should only return valid department prefixes for fr locale', () => {
+          // French postal codes use department prefixes 01-95 (metropolitan)
+          // and 971-978/984/986-989 (overseas); 00xxx, 96xxx and 99xxx are not
+          // assigned. See https://github.com/faker-js/faker/issues/3550
+          const overseas = new Set([
+            971, 972, 973, 974, 975, 976, 977, 978, 984, 986, 987, 988, 989,
+          ]);
+
+          for (let i = 0; i < 1000; i++) {
+            const zipCode = fakerFR.location.zipCode();
+
+            expect(zipCode).toMatch(/^\d{5}$/);
+            const department = Number(zipCode.slice(0, 2));
+            const isMetropolitan = department >= 1 && department <= 95;
+            const isOverseas = overseas.has(Number(zipCode.slice(0, 3)));
+            expect(isMetropolitan || isOverseas).toBe(true);
           }
         });
 


### PR DESCRIPTION
Closes #3550.

## Problem

The French (`fr`) postcode definition is:

```ts
export default ['#####'];
```

`#` is replaced by any digit, so `fakerFR.location.zipCode()` generates **any** 5-digit string — including ranges that are not valid French postal codes and fail validation (e.g. `validator.isPostalCode(code, 'FR')`):

- `00000`–`00999`
- `96000`–`96999`
- `99000`–`99999`

French postal codes start with a department prefix: metropolitan departments use `01`–`95`, and the overseas departments/collectivities use `971`–`978`, `984` and `986`–`989`.

## Fix

Build the pattern array from the real department prefixes (metropolitan `01###`–`95###`, overseas `971##`–`978##`, `984##`, `986##`–`989##`), so the unassigned `00xxx` / `96xxx` / `99xxx` ranges are never produced. This mirrors the approach of the recently merged `nl` postcode fix (#3888) — patterns are generated programmatically rather than hard-coded.

## Tests

Adds a regression test (`should only return valid department prefixes for fr locale`) modeled on the existing `nl` test: over 1000 samples it asserts each `fakerFR.location.zipCode()` is 5 digits and starts with a valid metropolitan (`01`–`95`) or overseas (`971`–`978`/`984`/`986`–`989`) prefix. It fails on the current definition (which produces `00`/`96`/`99` prefixes) and passes with this change. The full `location` suite (2417 tests) passes, `pnpm run generate:locales` reports no further changes, and ESLint/Prettier are clean.
