### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -39,6 +39,10 @@ pnpm add @faker-js/faker --save-dev
 yarn add @faker-js/faker --dev
 ```
 
+```shell [deno]
+deno add --dev @faker-js/faker
+```
+
 :::
 
 ## Faker Modules


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list npm, pnpm, and yarn, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno add -D @faker-js/faker
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install @faker-js/faker`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
