### PR TITLE
infra: ignore tmp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ REVISION
 .tasks-cache
 *DONOTVERSION*
 .history
+/tmp
 
 # Unwanted package managers
 .yarn/


### PR DESCRIPTION
<!-- Please run `pnpm run preflight` before opening a Pull Request to ensure that your code fulfills the minimal requirements for our project. -->

<!-- Please first read https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md -->

<!-- Help us by writing a correct PR title following this guide: https://fakerjs.dev/contributing/submit-a-pull-request#the-pull-request-title -->

Locally I develop more and more with e.g. Claude. Claude sometimes stores temporary files in a system tmp directory (e.g. /tmp on macOS or Linux). Related to some security concerns, I would like to allow Claude only to write into files inside the repo and so not write files into system directory. By ignoring the tmp folder, it can be also cleaned automatically time by time via the `pnpm run clean` command.