### PR TITLE
chore: consistent type import paths

### DIFF
--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -1,6 +1,7 @@
-import type { Faker, SimpleFaker } from '../..';
 import { FakerError } from '../../errors/faker-error';
+import type { Faker } from '../../faker';
 import { SimpleModuleBase } from '../../internal/module-base';
+import type { SimpleFaker } from '../../simple-faker';
 import type { NumberRange } from '../../utils/types';
 import { fakeEval } from './eval';
 import { luhnCheckValue } from './luhn-check';

--- a/src/modules/string/uuid.ts
+++ b/src/modules/string/uuid.ts
@@ -1,4 +1,4 @@
-import type { SimpleFaker } from '../../';
+import type { SimpleFaker } from '../../simple-faker';
 
 /**
  * Returns a UUID v4 ([Universally Unique Identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier)).

--- a/src/utils/merge-locales.ts
+++ b/src/utils/merge-locales.ts
@@ -1,4 +1,4 @@
-import type { LocaleDefinition } from '..';
+import type { LocaleDefinition } from '../definitions';
 
 /**
  * Merges the given locales into one locale.


### PR DESCRIPTION
I noticed that the helpers module imports it's types directly from the root index, while all other modules import the faker instance from the faker file directly. This (minimally) speeds up build performance for partial builds, as a smaller set of files need to be parsed for the build process to complete.

I searched for: `import (type )?\{ .*(\.|/)'`
in: `src`
excluding: `src/locales`

`src/locales` always imports the definitions from the root index.
I plan to address that once this PR is merged, as it requires changes to the `generate:locales` script.