### PR TITLE
docs: remove incorrect part from string.sample jsdocs

### DIFF
--- a/src/modules/string/module.ts
+++ b/src/modules/string/module.ts
@@ -572,7 +572,7 @@ export class StringModule extends SimpleModuleBase {
   /**
    * Returns a string containing UTF-16 chars between 33 and 125 (`!` to `}`).
    *
-   * @param length The length of the string (excluding the prefix) to generate either as a fixed length or as a length range. Defaults to `10`.
+   * @param length The length of the string to generate either as a fixed length or as a length range. Defaults to `10`.
    * @param length.min The minimum length of the string to generate.
    * @param length.max The maximum length of the string to generate.
    *


### PR DESCRIPTION
Removes the reference to the prefix from the length parameter, as the method does not support prefixes at all.

Preview:

- https://deploy-preview-3941.fakerjs.dev/api/string.html#sample