### PR TITLE
fix(word): pick nearest length for closest strategy

### DIFF
--- a/src/modules/word/filter-word-list-by-length.ts
+++ b/src/modules/word/filter-word-list-by-length.ts
@@ -14,10 +14,17 @@ const STRATEGIES = {
   closest: (wordList: ReadonlyArray<string>, length: NumberRange): string[] => {
     const wordsByLength = groupBy(wordList, (word) => word.length);
     const lengths = Object.keys(wordsByLength).map(Number);
-    const min = Math.min(...lengths);
-    const max = Math.max(...lengths);
+    const closestBelow = Math.max(
+      ...lengths.filter((wordLength) => wordLength < length.min)
+    );
+    const closestAbove = Math.min(
+      ...lengths.filter((wordLength) => wordLength > length.max)
+    );
 
-    const closestOffset = Math.min(length.min - min, max - length.max);
+    const closestOffset = Math.min(
+      length.min - closestBelow,
+      closestAbove - length.max
+    );
 
     return wordList.filter(
       (word) =>

--- a/test/modules/word.spec.ts
+++ b/test/modules/word.spec.ts
@@ -106,6 +106,17 @@ describe('word', () => {
       expect(result).toEqual(['very-long', 'almostRight']);
     });
 
+    it('returns the nearest words when the closest length is not the shortest or longest word', () => {
+      // Lengths present: 1, 4, 5. The closest length to 3 is 4 (distance 1),
+      // not the shortest (1) or longest (5) word (distance 2).
+      const result = filterWordListByLength({
+        wordList: ['a', 'wxyz', 'abcde'],
+        length: 3,
+        strategy: 'closest',
+      });
+      expect(result).toEqual(['wxyz']);
+    });
+
     it('throws an error when strategy is "fail" and no words match the given length', () => {
       expect(() => {
         filterWordListByLength({


### PR DESCRIPTION
The `closest` resolution strategy picked its offset from the shortest and longest words in the list rather than the lengths nearest to the requested range. When the nearest available length sat between those extremes, the method returned words farther from the target than needed. On the default `en` locale, `faker.word.noun({ length: 17, strategy: 'closest' })` returned words of length 15 or 19 even though length-16 nouns exist.

This derives the offset from the closest length below the range and the closest length above it, so the returned words are the actual nearest ones. Behavior for ranges fully outside the available lengths is unchanged. Adds a unit test covering an interior gap.
