### PR TITLE
docs(helpers): clarify fake() does not execute javascript

### DIFF
--- a/src/modules/helpers/eval.ts
+++ b/src/modules/helpers/eval.ts
@@ -46,7 +46,8 @@ const REGEX_DOT_OR_BRACKET = /\.|\(/;
  * const airlineMethodName = fakeEval('airline.airline.name', faker); // 'bound airline'
  * ```
  *
- * It is NOT possible to access any values not passed as entrypoints.
+ * It is not possible to execute arbitrary JavaScript through this method;
+ * expressions can only resolve properties and methods reachable from the given entrypoints.
  *
  * This method will never return arrays, as it will pick a random element from them instead.
  *

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -1201,8 +1201,10 @@ export class HelpersModule extends SimpleHelpersModule {
    * ```
    *
    * The pattern is not evaluated as JavaScript: only faker methods can be called, and any
-   * parameters are parsed as JSON or plain strings. Nevertheless, you should treat the pattern
-   * as trusted input and not pass unsanitized values from untrusted or external sources.
+   * parameters are parsed as JSON or plain strings. Nevertheless, it is possible for certain
+   * maliciously crafted patterns to use large amounts of memory or CPU time, so the pattern
+   * itself must always be from trusted input. Do not evaluate patterns provided by untrusted
+   * user input or external sources.
    *
    * @param pattern The pattern string that will get interpolated.
    *
@@ -1255,8 +1257,10 @@ export class HelpersModule extends SimpleHelpersModule {
    * ```
    *
    * The pattern is not evaluated as JavaScript: only faker methods can be called, and any
-   * parameters are parsed as JSON or plain strings. Nevertheless, you should treat the pattern
-   * as trusted input and not pass unsanitized values from untrusted or external sources.
+   * parameters are parsed as JSON or plain strings. Nevertheless, it is possible for certain
+   * maliciously crafted patterns to use large amounts of memory or CPU time, so the pattern
+   * itself must always be from trusted input. Do not evaluate patterns provided by untrusted
+   * user input or external sources.
    *
    * @param patterns The array to select a pattern from, that will then get interpolated. Must not be empty.
    *
@@ -1300,8 +1304,10 @@ export class HelpersModule extends SimpleHelpersModule {
    * ```
    *
    * The pattern is not evaluated as JavaScript: only faker methods can be called, and any
-   * parameters are parsed as JSON or plain strings. Nevertheless, you should treat the pattern
-   * as trusted input and not pass unsanitized values from untrusted or external sources.
+   * parameters are parsed as JSON or plain strings. Nevertheless, it is possible for certain
+   * maliciously crafted patterns to use large amounts of memory or CPU time, so the pattern
+   * itself must always be from trusted input. Do not evaluate patterns provided by untrusted
+   * user input or external sources.
    *
    * @param pattern The pattern string that will get interpolated. If an array is passed, a random element will be picked and interpolated.
    *

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -1177,7 +1177,7 @@ export class HelpersModule extends SimpleHelpersModule {
    * e.g. ``const address = `${faker.location.zipCode()} ${faker.location.city()}`;``
    *
    * This method is useful if you have to build a random string from a static, non-executable source
-   * (e.g. string coming from a user, stored in a database or a file).
+   * that you control (e.g. a template authored by a developer or stored in a database or file).
    *
    * It checks the given string for placeholders and replaces them by calling faker methods:
    *
@@ -1200,7 +1200,9 @@ export class HelpersModule extends SimpleHelpersModule {
    * const message = faker.helpers.fake('Your pin is {{string.numeric(4, {"allowLeadingZeros": true})}}.');
    * ```
    *
-   * It is also NOT possible to use any non-faker methods or plain javascript in such patterns.
+   * The pattern is not evaluated as JavaScript: only faker methods can be called, and any
+   * parameters are parsed as JSON or plain strings. Nevertheless, you should treat the pattern
+   * as trusted input and not pass unsanitized values from untrusted or external sources.
    *
    * @param pattern The pattern string that will get interpolated.
    *
@@ -1226,7 +1228,7 @@ export class HelpersModule extends SimpleHelpersModule {
    * e.g. ``const address = `${faker.location.zipCode()} ${faker.location.city()}`;``
    *
    * This method is useful if you have to build a random string from a static, non-executable source
-   * (e.g. string coming from a user, stored in a database or a file).
+   * that you control (e.g. a template authored by a developer or stored in a database or file).
    *
    * It checks the given string for placeholders and replaces them by calling faker methods:
    *
@@ -1252,7 +1254,9 @@ export class HelpersModule extends SimpleHelpersModule {
    * const message = faker.helpers.fake(['Your pin is {{string.numeric(4, {"allowLeadingZeros": true})}}.']);
    * ```
    *
-   * It is also NOT possible to use any non-faker methods or plain javascript in such patterns.
+   * The pattern is not evaluated as JavaScript: only faker methods can be called, and any
+   * parameters are parsed as JSON or plain strings. Nevertheless, you should treat the pattern
+   * as trusted input and not pass unsanitized values from untrusted or external sources.
    *
    * @param patterns The array to select a pattern from, that will then get interpolated. Must not be empty.
    *
@@ -1272,7 +1276,7 @@ export class HelpersModule extends SimpleHelpersModule {
    * e.g. ``const address = `${faker.location.zipCode()} ${faker.location.city()}`;``
    *
    * This method is useful if you have to build a random string from a static, non-executable source
-   * (e.g. string coming from a user, stored in a database or a file).
+   * that you control (e.g. a template authored by a developer or stored in a database or file).
    *
    * It checks the given string for placeholders and replaces them by calling faker methods:
    *
@@ -1295,7 +1299,9 @@ export class HelpersModule extends SimpleHelpersModule {
    * const message = faker.helpers.fake('Your pin is {{string.numeric(4, {"allowLeadingZeros": true})}}.');
    * ```
    *
-   * It is also NOT possible to use any non-faker methods or plain javascript in such patterns.
+   * The pattern is not evaluated as JavaScript: only faker methods can be called, and any
+   * parameters are parsed as JSON or plain strings. Nevertheless, you should treat the pattern
+   * as trusted input and not pass unsanitized values from untrusted or external sources.
    *
    * @param pattern The pattern string that will get interpolated. If an array is passed, a random element will be picked and interpolated.
    *

--- a/test/modules/helpers-eval.spec.ts
+++ b/test/modules/helpers-eval.spec.ts
@@ -205,13 +205,9 @@ describe('fakeEval()', () => {
       expect(globalWithFlag.__fakerPwned, attack).toBe(false);
     });
 
-    it('rejects the proof-of-concept via helpers.fake()', () => {
-      expect(() =>
-        faker.helpers.fake(
-          '{{do.evil.constructor.constructor(globalThis.__fakerPwned = true)()}}'
-        )
-      ).toThrow(FakerError);
-      expect(globalWithFlag.__fakerPwned).toBe(false);
+    it.each(attacks)('rejects %s via helpers.fake()', (attack) => {
+      expect(() => faker.helpers.fake(`{{${attack}}}`)).toThrow(FakerError);
+      expect(globalWithFlag.__fakerPwned, attack).toBe(false);
     });
   });
 });

--- a/test/modules/helpers-eval.spec.ts
+++ b/test/modules/helpers-eval.spec.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FakerError, faker } from '../../src';
 import { fakeEval } from '../../src/modules/helpers/eval';
 
-// A hostile definition that resolves to a function returning a function,
-// mirroring the original GHSA-qxc2-j82w-r537 proof-of-concept.
-const noop = (): void => undefined;
-const functionReturningFunction = (): (() => void) => noop;
+// A hostile definition resolving to a function returning a function, mirroring the original GHSA-qxc2-j82w-r537 proof-of-concept.
+const noop = () => {};
+
+const hostileDefinition = { evil: () => noop };
 
 describe('fakeEval()', () => {
   it('does not allow empty string input', () => {
@@ -179,55 +179,39 @@ describe('fakeEval()', () => {
   describe('does not allow arbitrary code execution (GHSA-qxc2-j82w-r537)', () => {
     const globalWithFlag = globalThis as Record<string, unknown>;
 
+    // Every payload is an observable side effect (setting the global flag), so we
+    // notice if it ever executes instead of a silent expression like `return 1`.
     const attacks = [
-      'evil.constructor(return 1)',
-      'evil().constructor(return 1)',
-      'evil.constructor.constructor(globalThis.__fakerPwned = true)',
-      'evil.constructor.constructor(globalThis.__fakerPwned = true)()',
+      'do.evil.constructor(globalThis.__fakerPwned = true)()',
+      'do.evil().constructor(globalThis.__fakerPwned = true)()',
+      'do.evil.constructor.constructor(globalThis.__fakerPwned = true)',
+      'do.evil.constructor.constructor(globalThis.__fakerPwned = true)()',
       'string.constructor.constructor(globalThis.__fakerPwned = true)()',
     ];
 
-    it('via fakeEval()', () => {
+    beforeEach(() => {
       globalWithFlag.__fakerPwned = false;
-      // A hostile definition resolving to a function returning a function, mirroring the original proof-of-concept.
-      (faker.rawDefinitions as Record<string, unknown>).evil =
-        functionReturningFunction;
-
-      try {
-        for (const attack of attacks) {
-          let result: unknown;
-          try {
-            result = fakeEval(attack, faker);
-          } catch (error) {
-            // Rejecting the expression is a safe outcome, but it must fail with the library's own error type, never a raw JS engine error.
-            expect(error, attack).toBeInstanceOf(FakerError);
-          }
-
-          expect(globalWithFlag.__fakerPwned, attack).toBe(false);
-          expect(result, attack).not.toBe(Function);
-        }
-      } finally {
-        delete (faker.rawDefinitions as Record<string, unknown>).evil;
-        delete globalWithFlag.__fakerPwned;
-      }
+      faker.definitions.raw.do = hostileDefinition;
     });
 
-    it('via helpers.fake()', () => {
-      globalWithFlag.__fakerPwned = false;
-      (faker.rawDefinitions as Record<string, unknown>).evil =
-        functionReturningFunction;
+    afterEach(() => {
+      delete faker.definitions.raw.do;
+      delete globalWithFlag.__fakerPwned;
+    });
 
-      try {
-        expect(() =>
-          faker.helpers.fake(
-            '{{evil.constructor.constructor(globalThis.__fakerPwned = true)()}}'
-          )
-        ).toThrow(FakerError);
-        expect(globalWithFlag.__fakerPwned).toBe(false);
-      } finally {
-        delete (faker.rawDefinitions as Record<string, unknown>).evil;
-        delete globalWithFlag.__fakerPwned;
-      }
+    it.each(attacks)('rejects %s via fakeEval()', (attack) => {
+      // The expression must always be rejected with the library's own error type, never evaluated as JavaScript.
+      expect(() => fakeEval(attack, faker)).toThrow(FakerError);
+      expect(globalWithFlag.__fakerPwned, attack).toBe(false);
+    });
+
+    it('rejects the proof-of-concept via helpers.fake()', () => {
+      expect(() =>
+        faker.helpers.fake(
+          '{{do.evil.constructor.constructor(globalThis.__fakerPwned = true)()}}'
+        )
+      ).toThrow(FakerError);
+      expect(globalWithFlag.__fakerPwned).toBe(false);
     });
   });
 });

--- a/test/modules/helpers-eval.spec.ts
+++ b/test/modules/helpers-eval.spec.ts
@@ -180,11 +180,11 @@ describe('fakeEval()', () => {
     const globalWithFlag = globalThis as Record<string, unknown>;
 
     const attacks = [
-      "evil.constructor('return 1')",
-      "evil().constructor('return 1')",
-      "evil.constructor.constructor('globalThis.__fakerPwned = true')",
-      "evil.constructor.constructor('globalThis.__fakerPwned = true')()",
-      "string.constructor.constructor('globalThis.__fakerPwned = true')()",
+      'evil.constructor(return 1)',
+      'evil().constructor(return 1)',
+      'evil.constructor.constructor(globalThis.__fakerPwned = true)',
+      'evil.constructor.constructor(globalThis.__fakerPwned = true)()',
+      'string.constructor.constructor(globalThis.__fakerPwned = true)()',
     ];
 
     it('via fakeEval()', () => {
@@ -219,7 +219,9 @@ describe('fakeEval()', () => {
 
       try {
         expect(() =>
-          faker.helpers.fake("{{evil.constructor('return 1')}}")
+          faker.helpers.fake(
+            '{{evil.constructor.constructor(globalThis.__fakerPwned = true)()}}'
+          )
         ).toThrow(FakerError);
         expect(globalWithFlag.__fakerPwned).toBe(false);
       } finally {

--- a/test/modules/helpers-eval.spec.ts
+++ b/test/modules/helpers-eval.spec.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { FakerError, faker } from '../../src';
 import { fakeEval } from '../../src/modules/helpers/eval';
 
+// A hostile definition that resolves to a function returning a function,
+// mirroring the original GHSA-qxc2-j82w-r537 proof-of-concept.
+const noop = (): void => undefined;
+const functionReturningFunction = (): (() => void) => noop;
+
 describe('fakeEval()', () => {
   it('does not allow empty string input', () => {
     expect(() => fakeEval('', faker)).toThrow(
@@ -166,5 +171,61 @@ describe('fakeEval()', () => {
     expect(() => fakeEval('airline.airline(.iataCode', faker)).toThrow(
       new FakerError("Missing closing parenthesis in '(.iataCode'")
     );
+  });
+
+  // Regression test for GHSA-qxc2-j82w-r537: fake()/fakeEval() must never evaluate the expression as JavaScript.
+  // In particular, a (hostile) definition that resolves to a function must not expose the `Function` constructor via a `.constructor` chain, which would allow arbitrary code execution.
+  // Functions are always invoked (never property-accessed), so the constructor chain can never reach `Function`.
+  describe('does not allow arbitrary code execution (GHSA-qxc2-j82w-r537)', () => {
+    const globalWithFlag = globalThis as Record<string, unknown>;
+
+    const attacks = [
+      "evil.constructor('return 1')",
+      "evil().constructor('return 1')",
+      "evil.constructor.constructor('globalThis.__fakerPwned = true')",
+      "evil.constructor.constructor('globalThis.__fakerPwned = true')()",
+      "string.constructor.constructor('globalThis.__fakerPwned = true')()",
+    ];
+
+    it('via fakeEval()', () => {
+      globalWithFlag.__fakerPwned = false;
+      // A hostile definition resolving to a function returning a function, mirroring the original proof-of-concept.
+      (faker.rawDefinitions as Record<string, unknown>).evil =
+        functionReturningFunction;
+
+      try {
+        for (const attack of attacks) {
+          let result: unknown;
+          try {
+            result = fakeEval(attack, faker);
+          } catch (error) {
+            // Rejecting the expression is a safe outcome, but it must fail with the library's own error type, never a raw JS engine error.
+            expect(error, attack).toBeInstanceOf(FakerError);
+          }
+
+          expect(globalWithFlag.__fakerPwned, attack).toBe(false);
+          expect(result, attack).not.toBe(Function);
+        }
+      } finally {
+        delete (faker.rawDefinitions as Record<string, unknown>).evil;
+        delete globalWithFlag.__fakerPwned;
+      }
+    });
+
+    it('via helpers.fake()', () => {
+      globalWithFlag.__fakerPwned = false;
+      (faker.rawDefinitions as Record<string, unknown>).evil =
+        functionReturningFunction;
+
+      try {
+        expect(() =>
+          faker.helpers.fake("{{evil.constructor('return 1')}}")
+        ).toThrow(FakerError);
+        expect(globalWithFlag.__fakerPwned).toBe(false);
+      } finally {
+        delete (faker.rawDefinitions as Record<string, unknown>).evil;
+        delete globalWithFlag.__fakerPwned;
+      }
+    });
   });
 });


### PR DESCRIPTION
Follow-up to the published security advisory [GHSA-qxc2-j82w-r537](https://github.com/faker-js/faker/security/advisories/GHSA-qxc2-j82w-r537) (arbitrary code execution via `helpers.fake()`).

The underlying vulnerability was already fixed in `10.5.0` by #3852, which made `resolveProperty()` invoke functions and recurse instead of reading a property off the function object — so a `.constructor` chain can never reach the `Function` constructor. That fix was shipped as an incidental change, was never framed as security, and had **no regression test** guarding it. It also left behind JSDoc that overstated the guarantee.

This PR:

- **Corrects the JSDoc claims** that the advisory highlighted:
  - `helpers.fake()` (all three overloads) previously stated *"It is also NOT possible to use any non-faker methods or plain javascript in such patterns."* — reworded to describe the actual behaviour (the pattern is not evaluated as JavaScript; params are parsed as JSON or plain strings) **and** to add a caveat that the pattern should still be treated as trusted input.
  - The *"string coming from a user"* wording is replaced with *"a template authored by a developer or stored in a database or file"*, so the docs no longer imply `fake()` is safe to feed unsanitized external input.
  - `fakeEval()` JSDoc *"It is NOT possible to access any values not passed as entrypoints."* → reworded to the guarantee we actually enforce: no arbitrary JavaScript execution.
- **Adds a regression test** (`test/modules/helpers-eval.spec.ts`) that reproduces the original PoC and several `.constructor`-chain escalations through both `fakeEval()` and `helpers.fake()`, asserting that no injected global side effect ever runs and that the `Function` constructor is never returned. The test was verified to **fail** against the pre-#3852 (vulnerable) implementation and **pass** against current code.

No runtime behaviour changes — documentation and test only.

## Notes

- The "treat as trusted input" caveat is deliberately conservative: faker makes no guarantees about the cost of arbitrary, user-controlled parameters, so callers should sanitize external input regardless.
