### PR TITLE
fix(internet): exclude reserved port 0 from internet.port()

### DIFF
--- a/src/modules/internet/module.ts
+++ b/src/modules/internet/module.ts
@@ -750,7 +750,7 @@ export class InternetModule extends ModuleBase {
    * @since 5.4.0
    */
   port(): number {
-    return this.faker.number.int(65535);
+    return this.faker.number.int({ min: 1, max: 65535 });
   }
 
   /**

--- a/test/modules/__snapshots__/internet.spec.ts.snap
+++ b/test/modules/__snapshots__/internet.spec.ts.snap
@@ -90,7 +90,7 @@ exports[`internet > 42 > password > with pattern option 1`] = `"522319233860266"
 
 exports[`internet > 42 > password > with prefix option 1`] = `"testDfYsZdp522R"`;
 
-exports[`internet > 42 > port 1`] = `24545`;
+exports[`internet > 42 > port 1`] = `24546`;
 
 exports[`internet > 42 > protocol 1`] = `"http"`;
 

--- a/test/modules/internet.spec.ts
+++ b/test/modules/internet.spec.ts
@@ -766,7 +766,7 @@ describe('internet', () => {
           const port = faker.internet.port();
 
           expect(port).toBeTypeOf('number');
-          expect(port).toBeGreaterThanOrEqual(0);
+          expect(port).toBeGreaterThanOrEqual(1);
           expect(port).toBeLessThanOrEqual(65535);
           expect(String(port)).toSatisfy(isPort);
         });


### PR DESCRIPTION
Closes #3937

`faker.internet.port()` calls `this.faker.number.int(65535)`, whose range is inclusive of `0`. Port `0` is listed as `Reserved` by IANA (RFC 6335 §6) and is never a usable service port, so seeded values fed into a real socket (`net.connect({ port: 0 })`) trigger OS-assigned ephemeral behavior instead of the seeded value.

This restricts the range to `1..65535`:

```diff
-    return this.faker.number.int(65535);
+    return this.faker.number.int({ min: 1, max: 65535 });
```

- Tightened the existing test assertion (`toBeGreaterThanOrEqual(0)` → `1`).
- Regenerated the single affected seeded snapshot (`internet > 42 > port`); no other snapshots changed.
- `pnpm exec vitest run test/modules/internet.spec.ts` → 1125 passed, no type errors.
