### PR TITLE
fix(color): output valid CSS HSL alpha values

### DIFF
--- a/src/modules/color/module.ts
+++ b/src/modules/color/module.ts
@@ -146,7 +146,7 @@ function toCSS(
     case 'hsla': {
       return `hsl(${values[0]}deg ${toPercentage(values[1])}% ${toPercentage(
         values[2]
-      )}% / ${toPercentage(values[3])})`;
+      )}% / ${values[3]})`;
     }
 
     case 'hwb': {

--- a/test/modules/color.spec.ts
+++ b/test/modules/color.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { CssFunction, CssSpace, faker } from '../../src';
 import { seededTests } from '../support/seeded-runs';
 import { times } from '../support/times';
@@ -20,6 +20,19 @@ describe('color', () => {
       'lch',
       'colorByCSSColorSpace'
     );
+  });
+
+  describe(`hsl({ format: 'css', includeAlpha: true })`, () => {
+    it('should use a CSS number between 0 and 1 for the alpha value', () => {
+      const mock = vi.spyOn(faker.number, 'float').mockReturnValue(0.5);
+
+      try {
+        const color = faker.color.hsl({ format: 'css', includeAlpha: true });
+        expect(color).match(/^hsl\(\d{1,3}deg 50% 50% \/ 0\.5\)$/);
+      } finally {
+        mock.mockRestore();
+      }
+    });
   });
 
   describe.each(times(NON_SEEDED_BASED_RUN).map(() => faker.seed()))(


### PR DESCRIPTION
`faker.color.hsl({ format: 'css', includeAlpha: true })` currently converts the generated alpha value from the valid numeric range `0`–`1` to `0`–`100`, but emits it without a percent sign. For example, an alpha of `0.6` becomes `/ 60`, which is outside the valid CSS number range.

Keep the generated alpha value unchanged when formatting CSS HSL colors, matching both the documented example and the CSS numeric alpha syntax. A focused regression test fixes the random values so the conversion error is deterministic.

Validation:

- `CI=true pnpm run preflight` (generate, format, lint, build, 53,131 tests passed, type-check)
- `pnpm exec vitest run test/modules/color.spec.ts` (237 passed)
- `pnpm exec prettier --check src/modules/color/module.ts test/modules/color.spec.ts`
- `pnpm exec eslint src/modules/color/module.ts test/modules/color.spec.ts`
- `pnpm run ts-check`
