### PR TITLE
feat: faker.system.directoryPath depth option

### DIFF
--- a/src/modules/system/module.ts
+++ b/src/modules/system/module.ts
@@ -4,6 +4,31 @@ import type { NumberRange } from '../../utils/types';
 
 const commonFileTypes = ['video', 'audio', 'image', 'text', 'application'];
 
+// Common directory-name segments used when generating a path of a given depth.
+const directoryNamePool = [
+  'bin',
+  'boot',
+  'dev',
+  'etc',
+  'home',
+  'lib',
+  'lib64',
+  'log',
+  'mail',
+  'mnt',
+  'opt',
+  'proc',
+  'root',
+  'run',
+  'sbin',
+  'srv',
+  'src',
+  'sys',
+  'tmp',
+  'usr',
+  'var',
+];
+
 const commonMimeTypes = [
   'application/pdf',
   'audio/mpeg',
@@ -181,16 +206,54 @@ export class SystemModule extends ModuleBase {
   }
 
   /**
-   * Returns a directory path.
+   * Returns a directory path for the given depth or a random one.
+   *
+   * When no `depth` is provided, returns a random path from the built-in
+   * directory-path definitions (e.g. `/etc/mail`). See issue #3785.
+   *
+   * @param options The optional options object.
+   * @param options.depth The number of path segments to generate. Uses a built-in pool of directory names for each segment. If omitted, a random defined path is used (default behavior).
+   * @param options.root Whether to prefix the path with a leading `/` (absolute). Only applies when `depth` is set. Defaults to `true`.
    *
    * @example
    * faker.system.directoryPath() // '/etc/mail'
+   * faker.system.directoryPath({ depth: 0 }) // '/'
+   * faker.system.directoryPath({ depth: 1 }) // '/etc'
+   * faker.system.directoryPath({ depth: 2 }) // '/etc/mail'
+   * faker.system.directoryPath({ depth: 3 }) // '/usr/lib/log'
+   * faker.system.directoryPath({ depth: 4, root: false }) // 'bin/lib/log/src'
    *
    * @since 3.1.0
    */
-  directoryPath(): string {
-    const paths = this.faker.definitions.system.directory_path;
-    return this.faker.helpers.arrayElement(paths);
+  directoryPath(options?: {
+    /**
+     * The number of path segments to generate. Uses a built-in pool of directory names for each segment. If omitted, a random defined path is used (default behavior).
+     */
+    depth?: number;
+    /**
+     * Whether to prefix the path with a leading `/` (absolute). Only applies when `depth` is set.
+     *
+     * @default true
+     */
+    root?: boolean;
+  }): string {
+    if (options?.depth === undefined) {
+      return this.faker.helpers.arrayElement(
+        this.faker.definitions.system.directory_path
+      );
+    }
+
+    const { depth, root = true } = options;
+    if (depth < 0) {
+      throw new FakerError(`Invalid depth: ${depth}. Must be >= 0.`);
+    }
+
+    const segments = this.faker.helpers.multiple(
+      () => this.faker.helpers.arrayElement(directoryNamePool),
+      { count: depth }
+    );
+    const body = segments.join('/');
+    return root ? `/${body}` : body;
   }
 
   /**

--- a/test/modules/__snapshots__/system.spec.ts.snap
+++ b/test/modules/__snapshots__/system.spec.ts.snap
@@ -18,7 +18,13 @@ exports[`system > 42 > cron > with includeYear false 1`] = `"* * ? 8 ?"`;
 
 exports[`system > 42 > cron > with includeYear true 1`] = `"* * ? 8 ? *"`;
 
-exports[`system > 42 > directoryPath 1`] = `"/net"`;
+exports[`system > 42 > directoryPath > noArgs 1`] = `"/net"`;
+
+exports[`system > 42 > directoryPath > with depth 0 1`] = `"/"`;
+
+exports[`system > 42 > directoryPath > with depth 1`] = `"/log/usr"`;
+
+exports[`system > 42 > directoryPath > with root false 1`] = `"log/usr"`;
 
 exports[`system > 42 > fileExt > noArgs 1`] = `"docx"`;
 
@@ -98,7 +104,13 @@ exports[`system > 1211 > cron > with includeYear false 1`] = `"55 * ? * *"`;
 
 exports[`system > 1211 > cron > with includeYear true 1`] = `"55 * ? * * *"`;
 
-exports[`system > 1211 > directoryPath 1`] = `"/var/log"`;
+exports[`system > 1211 > directoryPath > noArgs 1`] = `"/var/log"`;
+
+exports[`system > 1211 > directoryPath > with depth 0 1`] = `"/"`;
+
+exports[`system > 1211 > directoryPath > with depth 1`] = `"/usr/tmp"`;
+
+exports[`system > 1211 > directoryPath > with root false 1`] = `"usr/tmp"`;
 
 exports[`system > 1211 > fileExt > noArgs 1`] = `"mp4"`;
 
@@ -178,7 +190,13 @@ exports[`system > 1337 > cron > with includeYear false 1`] = `"* * 9 6 *"`;
 
 exports[`system > 1337 > cron > with includeYear true 1`] = `"* * 9 6 * 2004"`;
 
-exports[`system > 1337 > directoryPath 1`] = `"/home"`;
+exports[`system > 1337 > directoryPath > noArgs 1`] = `"/home"`;
+
+exports[`system > 1337 > directoryPath > with depth 0 1`] = `"/"`;
+
+exports[`system > 1337 > directoryPath > with depth 1`] = `"/lib/etc"`;
+
+exports[`system > 1337 > directoryPath > with root false 1`] = `"lib/etc"`;
 
 exports[`system > 1337 > fileExt > noArgs 1`] = `"xul"`;
 

--- a/test/modules/system.spec.ts
+++ b/test/modules/system.spec.ts
@@ -11,12 +11,17 @@ describe('system', () => {
     t.itEach(
       'commonFileExt',
       'commonFileType',
-      'directoryPath',
       'filePath',
       'fileType',
       'mimeType',
       'semver'
     );
+    t.describe('directoryPath', (t) => {
+      t.it('noArgs')
+        .it('with depth', { depth: 2 })
+        .it('with depth 0', { depth: 0 })
+        .it('with root false', { depth: 2, root: false });
+    });
 
     t.describe('fileName', (t) => {
       t.it('noArgs')


### PR DESCRIPTION
Closes #3785.

Add an optional `{ depth, root }` to directoryPath: when `depth` is omitted, behavior is unchanged (a random path from the built in directory_path definitions). When `depth` is provided, a path with exactly that many segments is generated from a built in pool of common directory names (bin, etc, lib, usr, ...). depth 0 to "/"; root:false produces a relative path.