### PR TITLE
feat: option to exclude emoji from person.bio()

### DIFF
--- a/src/modules/person/module.ts
+++ b/src/modules/person/module.ts
@@ -3,6 +3,24 @@ import type { Faker } from '../../faker';
 import { ModuleBase } from '../../internal/module-base';
 
 /**
+ * Strips emoji + related zero-width / variation / flag code points from a
+ * string, collapsing any resulting whitespace. Returns the original string if
+ * the result would be empty.
+ *
+ * @param text The text to strip emoji from.
+ */
+function stripEmoji(text: string): string {
+  const stripped = text
+    .replaceAll(/\p{Extended_Pictographic}/gu, '')
+    .replaceAll('\u200D', '')
+    .replaceAll(/[\uFE0E\uFE0F]/g, '')
+    .replaceAll(/[\u{1F1E6}-\u{1F1FF}]/gu, '')
+    .replaceAll(/\s+/g, ' ')
+    .trim();
+  return stripped.length > 0 ? stripped : text;
+}
+
+/**
  * The enum for values corresponding to a person's sex.
  */
 export enum Sex {
@@ -304,15 +322,32 @@ export class PersonModule extends ModuleBase {
   }
 
   /**
-   * Returns a random short biography
+   * Returns a random short biography.
+   *
+   * @param options The optional options object.
+   * @param options.excludesEmoji When `true`, strip emoji and related code points from the result.
+   * @param options.excludeEmoji Alias of `excludesEmoji`. When `true`, strip emoji and related code points from the result.
    *
    * @example
    * faker.person.bio() // 'oatmeal advocate, veteran 🐠'
    *
    * @since 8.0.0
    */
-  bio(): string {
-    return this.faker.helpers.fake(this.faker.definitions.person.bio_pattern);
+  bio(options?: {
+    /**
+     * When `true`, strip emoji and related code points from the result.
+     */
+    excludesEmoji?: boolean;
+    /**
+     * Alias of `excludesEmoji`. When `true`, strip emoji and related code points from the result.
+     */
+    excludeEmoji?: boolean;
+  }): string {
+    const bio = this.faker.helpers.fake(
+      this.faker.definitions.person.bio_pattern
+    );
+    const exclude = options?.excludesEmoji ?? options?.excludeEmoji ?? false;
+    return exclude ? stripEmoji(bio) : bio;
   }
 
   /**

--- a/test/modules/__snapshots__/person.spec.ts.snap
+++ b/test/modules/__snapshots__/person.spec.ts.snap
@@ -1,6 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`person > 42 > bio 1`] = `"traveler, philosopher, model"`;
+exports[`person > 42 > bio > noArgs 1`] = `"traveler, philosopher, model"`;
+
+exports[`person > 42 > bio > with excludesEmoji 1`] = `"traveler, philosopher, model"`;
 
 exports[`person > 42 > firstName > noArgs 1`] = `"Nikita"`;
 
@@ -54,7 +56,9 @@ exports[`person > 42 > suffix > with sex 1`] = `"III"`;
 
 exports[`person > 42 > zodiacSign 1`] = `"Gemini"`;
 
-exports[`person > 1211 > bio 1`] = `"decongestant supporter, parent 🥊"`;
+exports[`person > 1211 > bio > noArgs 1`] = `"decongestant supporter, parent 🥊"`;
+
+exports[`person > 1211 > bio > with excludesEmoji 1`] = `"decongestant supporter, parent"`;
 
 exports[`person > 1211 > firstName > noArgs 1`] = `"Dallas"`;
 
@@ -108,7 +112,9 @@ exports[`person > 1211 > suffix > with sex 1`] = `"DVM"`;
 
 exports[`person > 1211 > zodiacSign 1`] = `"Capricorn"`;
 
-exports[`person > 1337 > bio 1`] = `"creator, engineer, friend"`;
+exports[`person > 1337 > bio > noArgs 1`] = `"creator, engineer, friend"`;
+
+exports[`person > 1337 > bio > with excludesEmoji 1`] = `"creator, engineer, friend"`;
 
 exports[`person > 1337 > firstName > noArgs 1`] = `"Elda"`;
 

--- a/test/modules/person.spec.ts
+++ b/test/modules/person.spec.ts
@@ -7,14 +7,10 @@ const NON_SEEDED_BASED_RUN = 5;
 
 describe('person', () => {
   seededTests(faker, 'person', (t) => {
-    t.itEach(
-      'gender',
-      'jobTitle',
-      'jobDescriptor',
-      'jobArea',
-      'jobType',
-      'bio'
-    );
+    t.itEach('gender', 'jobTitle', 'jobDescriptor', 'jobArea', 'jobType');
+    t.describe('bio', (t) => {
+      t.it('noArgs').it('with excludesEmoji', { excludesEmoji: true });
+    });
 
     t.describe('sexType', (t) =>
       t


### PR DESCRIPTION
Closes #2623.

Add an optional `{ excludeEmoji?: boolean }` to person.bio: when true, the generated bio is stripped of emoji (Extended_Pictographic), zero width joiners, variation selectors, and regional indicator flag pairs, with resulting whitespace collapsed. If stripping would leave an empty string, the original bio is returned. Default (no option or excludeEmoji:false) behavior is unchanged.