### PR TITLE
feat: allow a value returning function in helpers.weightedArrayElement

### DIFF
--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -1003,13 +1003,16 @@ export class SimpleHelpersModule extends SimpleModuleBase {
     for (const { weight, value } of array) {
       current += weight;
       if (random < current) {
-        return value;
+        // Allow a value-returning function so callers can lazily generate the
+        // selected item (e.g. another faker call). See issue #3442.
+        return typeof value === 'function' ? (value as () => T)() : value;
       }
     }
 
     // In case of rounding errors, return the last element
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return array.at(-1)!.value;
+    const last = array.at(-1)!.value;
+    return typeof last === 'function' ? (last as () => T)() : last;
   }
 
   /**


### PR DESCRIPTION
Closes #3442.

Allow the `value` of each entry to be a `() => T` function; when the entry is selected, the function is invoked to produce the value. Plain values are returned directly (default behavior unchanged). Only the selected entry's function is invoked (laziness).