### PR TITLE
feat: weight genders in person.gender()

### DIFF
--- a/src/modules/person/module.ts
+++ b/src/modules/person/module.ts
@@ -242,10 +242,20 @@ export class PersonModule extends ModuleBase {
    *
    * @since 8.0.0
    */
-  gender(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.person.gender
-    );
+  gender(options?: { weighting?: 'female' | 'male' | 'mixed' }): string {
+    const list = this.faker.definitions.person.gender;
+    if (!options?.weighting || options.weighting === 'mixed') {
+      return this.faker.helpers.arrayElement(list);
+    }
+    // Weight every entry whose name contains the requested gender as a whole
+    // word (case-insensitive). A word-boundary regex is used so that 'male' does
+    // not match inside 'female'. See issue #1730.
+    const re = new RegExp(`\\b${options.weighting}\\b`, 'i');
+    const weighted = list.map((g) => ({
+      weight: re.test(String(g)) ? list.length : 1,
+      value: g,
+    }));
+    return this.faker.helpers.weightedArrayElement(weighted);
   }
 
   /**


### PR DESCRIPTION
Closes #1730.

Add an optional `{ weighting?: 'female' | 'male' | 'mixed' }`: when 'mixed' or omitted, behavior is unchanged (uniform arrayElement). When 'female'/'male', every entry whose name contains that gender as a whole word (case insensitive, word boundary regex: so 'male' does not match inside 'female') gets a much higher weight (list.length) via weightedArrayElement, biasing the result toward female/male identifying genders while still allowing other identities.