### PR TITLE
feat: faker.location.street useAbbreviated option

### DIFF
--- a/src/modules/location/module.ts
+++ b/src/modules/location/module.ts
@@ -2,6 +2,31 @@ import { FakerError } from '../../errors/faker-error';
 import type { Faker } from '../../faker';
 import { SimpleModuleBase } from '../../internal/module-base';
 
+// Common USPS-style street-suffix abbreviations used when `street({ useAbbreviated: true })`.
+const STREET_SUFFIX_ABBREVIATIONS: Record<string, string> = {
+  Alley: 'Aly',
+  Avenue: 'Ave',
+  Boulevard: 'Blvd',
+  Circle: 'Cir',
+  Court: 'Ct',
+  Drive: 'Dr',
+  Expressway: 'Expy',
+  Freeway: 'Fwy',
+  Highway: 'Hwy',
+  Lane: 'Ln',
+  Parkway: 'Pkwy',
+  Place: 'Pl',
+  Plaza: 'Plz',
+  Road: 'Rd',
+  Route: 'Rte',
+  Square: 'Sq',
+  Street: 'St',
+  Terrace: 'Ter',
+  Trail: 'Trl',
+  Turnpike: 'Tpke',
+  Valley: 'Vly',
+};
+
 /**
  * Represents a language with its full name, 2 character ISO 639-1 code, and 3 character ISO 639-2 code.
  */
@@ -315,14 +340,31 @@ export class LocationModule extends SimpleLocationModule {
   /**
    * Generates a random localized street name.
    *
+   * @param options The optional options object.
+   * @param options.useAbbreviated Whether to abbreviate common street suffixes (e.g. `Street` to `St`).
+   *
    * @example
    * faker.location.street() // 'Schroeder Isle'
+   * faker.location.street({ useAbbreviated: true }) // 'Schroeder St'
    *
    * @since 8.0.0
    */
-  street(): string {
-    return this.faker.helpers.fake(
+  street(options?: {
+    /**
+     * Whether to abbreviate common street suffixes (e.g. `Street` to `St`).
+     */
+    useAbbreviated?: boolean;
+  }): string {
+    const result = this.faker.helpers.fake(
       this.faker.definitions.location.street_pattern
+    );
+    if (!options?.useAbbreviated) {
+      return result;
+    }
+
+    return result.replaceAll(
+      /\b(Alley|Avenue|Boulevard|Circle|Court|Drive|Expressway|Freeway|Highway|Lane|Parkway|Place|Plaza|Road|Route|Square|Street|Terrace|Trail|Turnpike|Valley)\b/g,
+      (word) => STREET_SUFFIX_ABBREVIATIONS[word] ?? word
     );
   }
 

--- a/test/modules/__snapshots__/location.spec.ts.snap
+++ b/test/modules/__snapshots__/location.spec.ts.snap
@@ -137,7 +137,9 @@ exports[`location > 42 > state > noArgs 1`] = `"Maine"`;
 
 exports[`location > 42 > state > with options 1`] = `"ME"`;
 
-exports[`location > 42 > street 1`] = `"Miller Crest"`;
+exports[`location > 42 > street > noArgs 1`] = `"Miller Crest"`;
+
+exports[`location > 42 > street > with useAbbreviated 1`] = `"Miller Crest"`;
 
 exports[`location > 42 > streetAddress > noArgs 1`] = `"9751 Lilliana Rapid"`;
 
@@ -291,7 +293,9 @@ exports[`location > 1211 > state > noArgs 1`] = `"Washington"`;
 
 exports[`location > 1211 > state > with options 1`] = `"WA"`;
 
-exports[`location > 1211 > street 1`] = `"W Chestnut Street"`;
+exports[`location > 1211 > street > noArgs 1`] = `"W Chestnut Street"`;
+
+exports[`location > 1211 > street > with useAbbreviated 1`] = `"W Chestnut St"`;
 
 exports[`location > 1211 > streetAddress > noArgs 1`] = `"929 S Broad Street"`;
 
@@ -444,7 +448,9 @@ exports[`location > 1337 > state > noArgs 1`] = `"Indiana"`;
 
 exports[`location > 1337 > state > with options 1`] = `"IN"`;
 
-exports[`location > 1337 > street 1`] = `"Jennie Gateway"`;
+exports[`location > 1337 > street > noArgs 1`] = `"Jennie Gateway"`;
+
+exports[`location > 1337 > street > with useAbbreviated 1`] = `"Jennie Gateway"`;
 
 exports[`location > 1337 > streetAddress > noArgs 1`] = `"22435 Brian Hills"`;
 

--- a/test/modules/location.spec.ts
+++ b/test/modules/location.spec.ts
@@ -65,7 +65,9 @@ const NON_SEEDED_BASED_RUN = 5;
 
 describe('location', () => {
   seededTests(faker, 'location', (t) => {
-    t.it('street');
+    t.describe('street', (t) => {
+      t.it('noArgs').it('with useAbbreviated', { useAbbreviated: true });
+    });
 
     t.it('buildingNumber');
 


### PR DESCRIPTION
Closes #3703.

Add an optional `{ useAbbreviated?: boolean }` to location.street: when true, common USPS style street suffixes in the generated street are abbreviated (Street to St, Avenue to Ave, Boulevard to Blvd, Road to Rd, Drive to Dr, Lane to Ln, Court to Ct, Place to Pl, Parkway to Pkwy, Highway to Hwy, Terrace to Ter, Circle to Cir, etc.) using a word boundary regex. Default (no option or false) behavior is unchanged.