### PR TITLE
feat: weight genders in person.gender()

### DIFF
--- a/src/modules/person/module.ts
+++ b/src/modules/person/module.ts
@@ -235,6 +235,9 @@ export class PersonModule extends ModuleBase {
   /**
    * Returns a random gender.
    *
+   * @param options The optional options object.
+   * @param options.weighting When set, weight the selection toward entries whose name contains this gender as a whole word (`'female'`, `'male'`, or `'mixed'` for no weighting).
+   *
    * @see faker.person.sex(): For generating a binary-gender value.
    *
    * @example
@@ -242,10 +245,26 @@ export class PersonModule extends ModuleBase {
    *
    * @since 8.0.0
    */
-  gender(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.person.gender
-    );
+  gender(options?: {
+    /**
+     * When set, weight the selection toward entries whose name contains this gender as a whole word (`'female'`, `'male'`, or `'mixed'` for no weighting).
+     */
+    weighting?: 'female' | 'male' | 'mixed';
+  }): string {
+    const list = this.faker.definitions.person.gender;
+    if (!options?.weighting || options.weighting === 'mixed') {
+      return this.faker.helpers.arrayElement(list);
+    }
+
+    // Weight every entry whose name contains the requested gender as a whole
+    // word (case-insensitive). A word-boundary regex is used so that 'male' does
+    // not match inside 'female'. See issue #1730.
+    const re = new RegExp(`\\b${options.weighting}\\b`, 'i');
+    const weighted = list.map((g) => ({
+      weight: re.test(g) ? list.length : 1,
+      value: g,
+    }));
+    return this.faker.helpers.weightedArrayElement(weighted);
   }
 
   /**

--- a/test/modules/__snapshots__/person.spec.ts.snap
+++ b/test/modules/__snapshots__/person.spec.ts.snap
@@ -16,7 +16,11 @@ exports[`person > 42 > fullName > with lastName 1`] = `"Nikita Doe"`;
 
 exports[`person > 42 > fullName > with sex 1`] = `"Valentina Miller"`;
 
-exports[`person > 42 > gender 1`] = `"Gender nonconforming"`;
+exports[`person > 42 > gender > noArgs 1`] = `"Gender nonconforming"`;
+
+exports[`person > 42 > gender > with female weighting 1`] = `"Female to male transsexual man"`;
+
+exports[`person > 42 > gender > with male weighting 1`] = `"Female to male transsexual man"`;
 
 exports[`person > 42 > jobArea 1`] = `"Identity"`;
 
@@ -70,7 +74,11 @@ exports[`person > 1211 > fullName > with lastName 1`] = `"Mr. Dallas Doe MD"`;
 
 exports[`person > 1211 > fullName > with sex 1`] = `"Schuyler Zieme"`;
 
-exports[`person > 1211 > gender 1`] = `"Trigender"`;
+exports[`person > 1211 > gender > noArgs 1`] = `"Trigender"`;
+
+exports[`person > 1211 > gender > with female weighting 1`] = `"Transgender female"`;
+
+exports[`person > 1211 > gender > with male weighting 1`] = `"Transsexual male"`;
 
 exports[`person > 1211 > jobArea 1`] = `"Factors"`;
 
@@ -124,7 +132,11 @@ exports[`person > 1337 > fullName > with lastName 1`] = `"Elda Doe"`;
 
 exports[`person > 1337 > fullName > with sex 1`] = `"Candace Koelpin"`;
 
-exports[`person > 1337 > gender 1`] = `"Demigender"`;
+exports[`person > 1337 > gender > noArgs 1`] = `"Demigender"`;
+
+exports[`person > 1337 > gender > with female weighting 1`] = `"Female to male transgender man"`;
+
+exports[`person > 1337 > gender > with male weighting 1`] = `"Female to male transgender man"`;
 
 exports[`person > 1337 > jobArea 1`] = `"Functionality"`;
 

--- a/test/modules/person.spec.ts
+++ b/test/modules/person.spec.ts
@@ -7,14 +7,12 @@ const NON_SEEDED_BASED_RUN = 5;
 
 describe('person', () => {
   seededTests(faker, 'person', (t) => {
-    t.itEach(
-      'gender',
-      'jobTitle',
-      'jobDescriptor',
-      'jobArea',
-      'jobType',
-      'bio'
-    );
+    t.itEach('jobTitle', 'jobDescriptor', 'jobArea', 'jobType', 'bio');
+    t.describe('gender', (t) => {
+      t.it('noArgs')
+        .it('with female weighting', { weighting: 'female' })
+        .it('with male weighting', { weighting: 'male' });
+    });
 
     t.describe('sexType', (t) =>
       t


### PR DESCRIPTION
Closes #1730.

Add an optional `{ weighting?: 'female' | 'male' | 'mixed' }`: when 'mixed' or omitted, behavior is unchanged (uniform arrayElement). When 'female'/'male', every entry whose name contains that gender as a whole word (case insensitive, word boundary regex: so 'male' does not match inside 'female') gets a much higher weight (list.length) via weightedArrayElement, biasing the result toward female/male identifying genders while still allowing other identities.