### PR TITLE
fix(string): generate valid ULIDs for negative reference dates

### DIFF
--- a/src/internal/base32.ts
+++ b/src/internal/base32.ts
@@ -9,7 +9,7 @@ export const CROCKFORDS_BASE32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
  * @param date The Date to encode.
  */
 export function dateToBase32(date: Date): string {
-  let value = date.valueOf();
+  let value = Math.max(date.valueOf(), 0);
   let result = '';
   for (let len = 10; len > 0; len--) {
     const mod = value % 32;

--- a/test/modules/string.spec.ts
+++ b/test/modules/string.spec.ts
@@ -834,6 +834,13 @@ describe('string', () => {
           expect(ulid).toMatch(regex);
           expect(ulid).toSatisfy(isULID);
         });
+
+        it('generates nil bytes in the unix part if a negative is given as a ref date', () => {
+          const ulid = faker.string.ulid({ refDate: -3000 });
+
+          expect(ulid).toSatisfy(isULID);
+          expect(ulid).toStartWith('0000000000');
+        });
       });
 
       describe(`nanoid`, () => {


### PR DESCRIPTION
`faker.string.ulid({ refDate: -1 })` currently uses negative Base32 indices while encoding the timestamp, which inserts `undefined` into the result and produces an invalid ULID.

This normalizes pre-epoch timestamps to the Unix epoch before Base32 encoding, matching the existing UUID v7 behavior. A public API regression test verifies that negative reference dates now produce valid ULIDs with a zeroed timestamp prefix.

Validation:

- `pnpm exec vitest run test/internal/base32.spec.ts test/modules/string.spec.ts` (1175 passed, no type errors)
- `pnpm exec prettier --check src/internal/base32.ts test/modules/string.spec.ts`
- `pnpm exec eslint src/internal/base32.ts test/modules/string.spec.ts`
