### PR TITLE
fix(color): stop scaling the HSLA alpha into a percentage

### DIFF
--- a/src/modules/color/module.ts
+++ b/src/modules/color/module.ts
@@ -144,9 +144,11 @@ function toCSS(
     }
 
     case 'hsla': {
+      // The alpha is a number between 0 and 1, like in `rgba` above,
+      // not a percentage.
       return `hsl(${values[0]}deg ${toPercentage(values[1])}% ${toPercentage(
         values[2]
-      )}% / ${toPercentage(values[3])})`;
+      )}% / ${values[3]})`;
     }
 
     case 'hwb': {

--- a/src/modules/color/module.ts
+++ b/src/modules/color/module.ts
@@ -144,8 +144,6 @@ function toCSS(
     }
 
     case 'hsla': {
-      // The alpha is a number between 0 and 1, like in `rgba` above,
-      // not a percentage.
       return `hsl(${values[0]}deg ${toPercentage(values[1])}% ${toPercentage(
         values[2]
       )}% / ${values[3]})`;

--- a/test/modules/color.spec.ts
+++ b/test/modules/color.spec.ts
@@ -216,6 +216,13 @@ describe('color', () => {
             /^(hsl\([0-9]{1,3}deg [0-9]{1,3}% [0-9]{1,3}% \/ \d*\.?\d*\))$/
           );
         });
+
+        it('should return the alpha as a value between 0 and 1, like rgba', () => {
+          const color = faker.color.hsl({ format: 'css', includeAlpha: true });
+          const alpha = Number(color.split('/', 2)[1].replace(')', '').trim());
+          expect(alpha).toBeGreaterThanOrEqual(0);
+          expect(alpha).toBeLessThanOrEqual(1);
+        });
       });
 
       describe(`hsl({ format: 'binary' })`, () => {

--- a/test/modules/color.spec.ts
+++ b/test/modules/color.spec.ts
@@ -219,7 +219,9 @@ describe('color', () => {
 
         it('should return the alpha as a value between 0 and 1, like rgba', () => {
           const color = faker.color.hsl({ format: 'css', includeAlpha: true });
-          const alpha = Number(color.split('/', 2)[1].replace(')', '').trim());
+          const alpha = Number.parseFloat(
+            color.split('/', 2)[1].replace(')', '').trim()
+          );
           expect(alpha).toBeGreaterThanOrEqual(0);
           expect(alpha).toBeLessThanOrEqual(1);
         });


### PR DESCRIPTION
Part of issue #3956 - this change resolves the second of the two bugs mentioned there, while the LCH hue fix remains in its own pull request, as requested.

Previously, in the `toCSS` function for `hsla`, the alpha value was mistakenly converted to a percentage. For instance, `0.6` became `60`, but `hsl()` actually expects the decimal form directly (like `/ 0.6`). This caused inconsistency with how `rgba` handled alpha. Now, the alpha value stays as a decimal, aligning both formats properly.

The `hsla` test still uses its original regex pattern but now includes an extra check to ensure alpha values stay within the valid 0 to 1 range. That’s because the old pattern `\d*\.?\d*` could match both invalid forms like `60` and correct ones like `0.6`. No snapshot updates were needed, since `hsla` CSS output wasn’t previously captured in snapshots.

All preflight checks passed smoothly: locale sync, documentation, formatting, linting, build, full test suite, and type checking. One test, `test/docs/versions.spec.ts`, still fails - but it’s unrelated. It fails the same way in the base branch due to missing git tags when cloning with `--depth 1`. With that aside, all tests pass - totaling 52,733 successful runs.