### PR TITLE
fix(string): reject refDates that a ULID timestamp cannot encode

### DIFF
--- a/src/internal/base32.ts
+++ b/src/internal/base32.ts
@@ -6,7 +6,7 @@ export const CROCKFORDS_BASE32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 /**
  * Encodes a Date into 10 characters base32 string.
  *
- * @param date The Date to encode.
+ * @param date The Date to encode. Must not be before the Unix epoch, as negative timestamps have no base32 representation here.
  */
 export function dateToBase32(date: Date): string {
   let value = date.valueOf();

--- a/src/modules/string/module.ts
+++ b/src/modules/string/module.ts
@@ -6,6 +6,11 @@ import type { LiteralUnion } from '../../internal/types';
 import type { Casing, NumberOrRange } from '../../utils/types';
 import { uuidV4, uuidV7 } from './uuid';
 
+/**
+ * The largest timestamp a ULID can encode, as the timestamp component is a 48 bit unsigned integer.
+ */
+const MAX_ULID_TIMESTAMP = 2 ** 48 - 1;
+
 const UPPER_CHARS: ReadonlyArray<string> = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
 const LOWER_CHARS: ReadonlyArray<string> = [...'abcdefghijklmnopqrstuvwxyz'];
 const DIGIT_CHARS: ReadonlyArray<string> = [...'0123456789'];
@@ -711,6 +716,8 @@ export class StringModule extends SimpleModuleBase {
    * The encoded timestamp is represented by the first 10 characters of the result.
    * Defaults to `faker.defaultRefDate()`.
    *
+   * @throws {FakerError} If `refDate` is outside the range a ULID timestamp can encode.
+   *
    * @example
    * faker.string.ulid() // '01ARZ3NDEKTSV4RRFFQ69G5FAV'
    * faker.string.ulid({ refDate: '2020-01-01T00:00:00.000Z' }) // '01DXF6DT00CX9QNNW7PNXQ3YR8'
@@ -722,6 +729,7 @@ export class StringModule extends SimpleModuleBase {
       /**
        * The date to use as reference point for the newly generated ULID encoded timestamp.
        * The encoded timestamp is represented by the first 10 characters of the result.
+       * Must be between `1970-01-01T00:00:00.000Z` and `+010889-08-02T05:31:50.655Z`.
        *
        * @default faker.defaultRefDate()
        */
@@ -730,6 +738,16 @@ export class StringModule extends SimpleModuleBase {
   ): string {
     const { refDate = this.faker.defaultRefDate() } = options;
     const date = toDate(refDate);
+
+    if (date.valueOf() < 0 || date.valueOf() > MAX_ULID_TIMESTAMP) {
+      throw new FakerError(
+        `Unable to generate ULID: the refDate must be between ${new Date(
+          0
+        ).toISOString()} and ${new Date(
+          MAX_ULID_TIMESTAMP
+        ).toISOString()}, but was ${date.toISOString()}.`
+      );
+    }
 
     return dateToBase32(date) + this.fromCharacters(CROCKFORDS_BASE32, 16);
   }

--- a/test/modules/string.spec.ts
+++ b/test/modules/string.spec.ts
@@ -828,6 +828,30 @@ describe('string', () => {
           }
         );
 
+        it.each([
+          '1969-12-31T23:59:59.999Z',
+          '1900-01-01T00:00:00.000Z',
+          '+010889-08-02T05:31:50.656Z',
+          '+275760-09-13T00:00:00.000Z',
+        ])('should reject the unencodable refDate %s', (refDate) => {
+          expect(() => faker.string.ulid({ refDate })).toThrow(
+            new FakerError(
+              `Unable to generate ULID: the refDate must be between 1970-01-01T00:00:00.000Z and +010889-08-02T05:31:50.655Z, but was ${refDate}.`
+            )
+          );
+        });
+
+        it.each([
+          '2021-02-21T17:09:15.711Z',
+          '1970-01-01T00:00:00.000Z',
+          '+010889-08-02T05:31:50.655Z',
+        ])('generates a valid ULID for the refDate %s', (refDate) => {
+          const ulid = faker.string.ulid({ refDate });
+          const regex = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/;
+          expect(ulid).toMatch(regex);
+          expect(ulid).toSatisfy(isULID);
+        });
+
         it('generates a valid ULID', () => {
           const ulid = faker.string.ulid();
           const regex = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/;


### PR DESCRIPTION
`faker.string.ulid({ refDate })` accepts any date, but the timestamp encoder behind it only works for the 48-bit unsigned millisecond range that a ULID timestamp is defined over. Outside that range it doesn't fail — it returns a string that isn't a ULID.

For any date before the Unix epoch the result contains the literal text `undefined`:

```js
faker.seed(3);

faker.string.ulid({ refDate: '2020-01-01T00:00:00.000Z' }) // '01DXF6DT00HP9GWW461E0EM8NJ'          (26 chars, valid)
faker.string.ulid({ refDate: '1969-12-31T23:59:59.999Z' }) // '000000000undefinedWVC2MHB7DF89EVJ9'   (34 chars)
faker.string.ulid({ refDate: '1900-01-01T00:00:00.000Z' }) // '0undefined0undefinedundefined…'       (74 chars)
```

`dateToBase32` peels off base32 digits with `value % 32`, and in JS that is negative for a negative timestamp, so `CROCKFORDS_BASE32[mod]` is `undefined` and gets concatenated into the result. One `undefined` appears per digit that lands negative, which is why the length varies with how far back the date is.

The other end of the range fails more quietly. `2**48 - 1` ms is `+010889-08-02T05:31:50.655Z`; past that the timestamp needs an 11th digit, so the 10 characters that are emitted are a truncated timestamp whose first character is above `7`:

```js
faker.string.ulid({ refDate: new Date(8.64e15) }) // 'NJ131DR0004H6YNHP8XTQFTQNX'
```

`refDate` is a documented public option and `faker.setDefaultRefDate()` feeds the same value in globally, so generating a fixture set anchored to a historical date is enough to hit this. Every one of the outputs above is rejected by `isULID`, which the spec file already imports.

## Changes

- `string.ulid()` throws a `FakerError` when `refDate` is before `1970-01-01T00:00:00.000Z` or after `+010889-08-02T05:31:50.655Z`, naming both bounds and the offending date. This follows what `date.between()` and friends already do for out-of-range inputs rather than returning something that looks like an ID but isn't.
- Documented the accepted range on the `refDate` option and added `@throws`, plus a note on `dateToBase32` that it has no representation for pre-epoch timestamps.

## Tests

- Four cases asserting the throw: one millisecond before the epoch, `1900-01-01`, one millisecond past the encodable maximum, and the largest `Date` JS can hold. All four fail on `next` (they return the malformed strings above).
- Three cases asserting a valid ULID is still produced, covering both boundaries exactly: `1970-01-01T00:00:00.000Z` and `+010889-08-02T05:31:50.655Z`, alongside the existing 2021 date. These check the `/^[0-7][0-9A-HJKMNP-TV-Z]{25}$/` shape and `isULID`.

The existing suite couldn't catch this: `generates a valid ULID` only ever uses the default `refDate`, and the three seeded `refDate` cases all pass the same `2021-02-21T17:09:15.711Z`, so no test has ever encoded a timestamp outside the working range.

## Notes

- No behavioural change for in-range dates, and no change to the number or order of RNG calls, so the seeded snapshots are untouched.
- `pnpm run preflight` is green: 52,770 tests passing, no type errors, no lint or format changes.
