### PR TITLE
infra: ensure markdown rendered is only ever initialized once

### DIFF
--- a/scripts/shared/markdown.ts
+++ b/scripts/shared/markdown.ts
@@ -4,15 +4,18 @@ import { createMarkdownRenderer } from 'vitepress';
 import vitepressConfig from '../../docs/.vitepress/config';
 import { FILE_PATH_API_DOCS } from './paths';
 
+let markdownPromise: Promise<MarkdownRenderer>;
 let markdown: MarkdownRenderer;
 
 export async function initMarkdownRenderer(): Promise<void> {
   // eslint-disable-next-line unicorn/no-top-level-assignment-in-function
-  markdown ??= await createMarkdownRenderer(
+  markdownPromise ??= createMarkdownRenderer(
     FILE_PATH_API_DOCS,
     vitepressConfig.markdown,
     '/'
   );
+  // eslint-disable-next-line unicorn/no-top-level-assignment-in-function
+  markdown ??= await markdownPromise;
 }
 
 const htmlSanitizeOptions: sanitizeHtml.IOptions = {


### PR DESCRIPTION
Implement suggestion from https://github.com/shikijs/shiki/discussions/1289

- https://github.com/shikijs/shiki/discussions/1289
- https://github.com/faker-js/faker/actions/runs/27549969244/job/81433308467

---

Store the promise to ensure we only ever initialize the markdown rendered backend once.
This is an attempt to fix the flaky markdown rendered test.

While I don't think that it is the cause for the failure, it does fix the unintended side effects of calling `initMarkdownRenderer()` multiple times.