### PR TITLE
infra: rename _local to .local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,5 +112,5 @@ cypress/screenshots
 cypress/videos
 .playwright-mcp/
 
-_local/
+.local/
 .claude/

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "10.6.0",
   "description": "Generate massive amounts of fake contextual data",
   "scripts": {
-    "clean": "git clean -fdx --exclude _local --exclude .claude",
+    "clean": "git clean -fdx --exclude .local --exclude .claude",
     "build:clean": "git clean -fX dist",
     "build:code": "tsdown",
     "build": "run-s build:clean build:code",


### PR DESCRIPTION
Rename the `_local` folder to `.local` for consistency with the other folders in the project root.

According to the original PR: The folder may be used to store more long lived local scripts or files that may help during development.

- https://github.com/faker-js/faker/pull/3541