### PR TITLE
docs: remove cjs hint

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -18,7 +18,7 @@ This documentation only covers the JavaScript implementation of Faker.
 You can run Faker in the browser, or in Node.js. Faker v11.0 requires Node.js version 22 or above.
 
 ::: tip Note
-When using CJS, you need to use at least Node.js v20.19. See https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require
+For CJS, refer to https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require
 :::
 
 ## Installation

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -18,7 +18,7 @@ This documentation only covers the JavaScript implementation of Faker.
 You can run Faker in the browser, or in Node.js. Faker v11.0 requires Node.js version 22 or above.
 
 ::: tip Note
-For CJS, refer to https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require
+For CJS, see https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require
 :::
 
 ## Installation

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -17,10 +17,6 @@ This documentation only covers the JavaScript implementation of Faker.
 
 You can run Faker in the browser, or in Node.js. Faker v11.0 requires Node.js version 22 or above.
 
-::: tip Note
-For CJS, see https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require
-:::
-
 ## Installation
 
 Install it as a Dev Dependency using your favorite package manager.


### PR DESCRIPTION
Cleanup after #3916

- #3916
- Found in https://github.com/faker-js/faker/issues/3997#issuecomment-5306252211

---

Remove remaining hint regarding Node 20.