### PR TITLE
docs(location): remove stray parenthesis from overview

### DIFF
--- a/src/modules/location/module.ts
+++ b/src/modules/location/module.ts
@@ -199,7 +199,7 @@ export class SimpleLocationModule extends SimpleModuleBase {
  *
  * ### Overview
  *
- * For a typical street address for a locale, use [`streetAddress()`](https://fakerjs.dev/api/location.html#streetaddress), [`city()`](https://fakerjs.dev/api/location.html#city), [`state()`](https://fakerjs.dev/api/location.html#state)), and [`zipCode()`](https://fakerjs.dev/api/location.html#zipcode). Most locales provide localized versions for a specific country.
+ * For a typical street address for a locale, use [`streetAddress()`](https://fakerjs.dev/api/location.html#streetaddress), [`city()`](https://fakerjs.dev/api/location.html#city), [`state()`](https://fakerjs.dev/api/location.html#state), and [`zipCode()`](https://fakerjs.dev/api/location.html#zipcode). Most locales provide localized versions for a specific country.
  *
  * If you need latitude and longitude coordinates, use [`latitude()`](https://fakerjs.dev/api/location.html#latitude) and [`longitude()`](https://fakerjs.dev/api/location.html#longitude), or [`nearbyGPSCoordinate()`](https://fakerjs.dev/api/location.html#nearbygpscoordinate) for a latitude/longitude near a given location.
  *


### PR DESCRIPTION
## Summary

Remove the extra closing parenthesis after the state() API link in the Location module overview. The typo originates in the source JSDoc and is copied into the generated Location API page.

## Validation

- git diff --check
- Confirmed the source JSDoc and locally updated generated API page no longer contain the malformed #state)) link ending

The full API docs generator was not run end-to-end because the existing local node_modules predates the newly added oxfmt dependency; the generated Markdown file is gitignored and the tracked source is the single intended change.