### PR TITLE
test(seed): make random seed test deterministic

### DIFF
--- a/test/internal/seed.spec.ts
+++ b/test/internal/seed.spec.ts
@@ -1,11 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { randomSeed } from '../../src/internal/seed';
 
 describe('seed', () => {
-  it('should generate a random seed', () => {
-    const actual = randomSeed();
+  it('should generate a seed from Math.random', () => {
+    const random = 0.5;
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(random);
 
-    expect(actual).toBeTypeOf('number');
-    expect(actual).not.toBe(randomSeed());
+    expect(randomSeed()).toBe(Math.ceil(random * Number.MAX_SAFE_INTEGER));
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION
The seed unit test compared two real Math.random results and assumed they would differ. A collision is valid, so the assertion introduced an unnecessary nondeterministic failure path without checking how randomSeed transforms its input.

This mocks Math.random with a fixed value, asserts the exact seed calculation, and restores the spy after the assertion.

## Validation

- ./node_modules/.bin/vitest run test/internal/seed.spec.ts — 1 test passed, no type errors
- git diff --check — passed

Full local preflight was not run because the existing dependency tree predates the upstream Oxfmt/Oxlint migration; remote CI will run with the current lockfile.