### PR TITLE
docs(helpers): document weightedArrayElement throws

### DIFF
--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -964,6 +964,9 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param array[].weight The weight of the value.
    * @param array[].value The value to pick.
    *
+   * @throws {FakerError} If the array is empty.
+   * @throws {FakerError} If any element's weight is not a positive number.
+   *
    * @example
    * faker.helpers.weightedArrayElement([{ weight: 5, value: 'sunny' }, { weight: 4, value: 'rainy' }, { weight: 1, value: 'snowy' }]) // 'sunny', 50% of the time, 'rainy' 40% of the time, 'snowy' 10% of the time
    *


### PR DESCRIPTION
## Description

`faker.helpers.weightedArrayElement` can throw `FakerError` in two cases but had no `@throws` JSDoc, per the contributing guidelines requirement that throwing functions document it:

https://github.com/faker-js/faker/blob/next/CONTRIBUTING.md?plain=1#L362

## Change

Added `@throws` tags for both real throw conditions in the implementation:
- empty array
- any element with a non-positive `weight`

Fixes #4015