### PR TITLE
docs(helpers): document weighted array errors

### DIFF
--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -964,6 +964,9 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @param array[].weight The weight of the value.
    * @param array[].value The value to pick.
    *
+   * @throws {FakerError} If the given array is empty.
+   * @throws {FakerError} If any weight is zero or negative.
+   *
    * @example
    * faker.helpers.weightedArrayElement([{ weight: 5, value: 'sunny' }, { weight: 4, value: 'rainy' }, { weight: 1, value: 'snowy' }]) // 'sunny', 50% of the time, 'rainy' 40% of the time, 'snowy' 10% of the time
    *


### PR DESCRIPTION
Documents both `FakerError` conditions in `weightedArrayElement`: an empty input array and a zero or negative weight.

Verification:

- `corepack pnpm run preflight`
- 54 test files passed, 52,874 tests passed, no type errors
- build and publint passed

Oxlint completed with the existing `test/modules/finance.spec.ts` `.todo` warning.

Closes #4015
