### PR TITLE
infra: sort type imports first

### DIFF
--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -16,7 +16,9 @@ export const formatOptions: FormatConfig = {
     groups: [
       ['builtin', 'external', 'internal'],
       { newlinesBetween: false },
-      ['parent', 'sibling', 'index'],
+      ['type-parent', 'value-parent'],
+      ['type-sibling', 'value-sibling'],
+      ['type-index', 'value-index'],
     ],
     newlinesBetween: false,
     order: 'asc',

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -14,7 +14,9 @@ export const formatOptions: FormatConfig = {
   printWidth: 80,
   sortImports: {
     groups: [
-      ['builtin', 'external', 'internal'],
+      ['type-builtin', 'value-builtin'],
+      ['type-external', 'value-external'],
+      ['type-internal', 'value-internal'],
       ['type-parent', 'value-parent'],
       ['type-sibling', 'value-sibling'],
       ['type-index', 'value-index'],

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -15,7 +15,6 @@ export const formatOptions: FormatConfig = {
   sortImports: {
     groups: [
       ['builtin', 'external', 'internal'],
-      { newlinesBetween: false },
       ['type-parent', 'value-parent'],
       ['type-sibling', 'value-sibling'],
       ['type-index', 'value-index'],


### PR DESCRIPTION
Follow up on #4007 

- #4007

---

Ensure, that type imports are ordered before their non-type files.

**Good**

````ts
import type { AlphaNumericChar } from './_types';
import { DIGIT_CHARS, LOWER_CHARS, UPPER_CHARS } from './_types';
````

**Bad**

````ts
import { DIGIT_CHARS, LOWER_CHARS, UPPER_CHARS } from './_types';
import type { AlphaNumericChar } from './_types';
````