### PR TITLE
docs(string): document numeric errors

### DIFF
--- a/src/modules/string/module.ts
+++ b/src/modules/string/module.ts
@@ -492,8 +492,7 @@ export class StringModule extends SimpleModuleBase {
    * @param options.allowLeadingZeros Whether leading zeros are allowed or not. Defaults to `true`.
    * @param options.exclude An array of digits which should be excluded in the generated string. Defaults to `[]`.
    *
-   * @throws {FakerError} If no digits are available after applying `exclude`.
-   * @throws {FakerError} If `allowLeadingZeros` is `false` and `0` is the only available digit.
+   * @throws {FakerError} If no digits are available after applying `exclude` and `allowLeadingZeros`.
    *
    * @see faker.number.int(): For generating a number (within a range).
    *

--- a/src/modules/string/module.ts
+++ b/src/modules/string/module.ts
@@ -492,6 +492,9 @@ export class StringModule extends SimpleModuleBase {
    * @param options.allowLeadingZeros Whether leading zeros are allowed or not. Defaults to `true`.
    * @param options.exclude An array of digits which should be excluded in the generated string. Defaults to `[]`.
    *
+   * @throws {FakerError} If no digits are available after applying `exclude`.
+   * @throws {FakerError} If `allowLeadingZeros` is `false` and `0` is the only available digit.
+   *
    * @see faker.number.int(): For generating a number (within a range).
    *
    * @example


### PR DESCRIPTION
Closes #4018

Adds the two missing `@throws {FakerError}` entries to `faker.string.numeric()` documentation.

Checks:
- pnpm run format
- pnpm run lint
- pnpm run build
- pnpm run ts-check
- pnpm run preflight