### PR TITLE
feat(person): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -1,6 +1,7 @@
 export const ALLOWED_MODULES = new Set([
-  'HelpersModule',
-  'StringModule',
-  'NumberModule',
   'DatatypeModule',
+  'DateModule',
+  'HelpersModule',
+  'NumberModule',
+  'StringModule',
 ]);

--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -3,5 +3,6 @@ export const ALLOWED_MODULES = new Set([
   'DateModule',
   'HelpersModule',
   'NumberModule',
+  'PersonModule',
   'StringModule',
 ]);

--- a/scripts/temp-transform-once.ts
+++ b/scripts/temp-transform-once.ts
@@ -7,12 +7,22 @@ import type { SignatureLikeDeclaration } from './apidocs/processing/signature';
 import { getProject } from './apidocs/project';
 import { required } from './apidocs/utils/value-checks';
 import { ImportHelper } from './module-tree/import-helper';
-import { toCamelCase, toKebabCase } from './shared/character-case';
+import {
+  toCamelCase,
+  toKebabCase,
+  toPascalCase,
+} from './shared/character-case';
 import { formatTypescript } from './shared/format';
 import { FILE_PATH_SRC } from './shared/paths';
 import { ALLOWED_MODULES } from './temp-module-filter';
 
 const coreName = 'fakerCore';
+
+const moduleArg = process.argv[2];
+const moduleCondition =
+  moduleArg == null
+    ? () => true
+    : (module: string) => module === toPascalCase(`${moduleArg}Module`);
 
 // Run the script
 
@@ -35,7 +45,8 @@ export async function processModuleClasses(project: Project): Promise<void> {
         (module: string): boolean =>
           module.endsWith('Module') &&
           !module.startsWith('Simple') &&
-          ALLOWED_MODULES.has(module)
+          !ALLOWED_MODULES.has(module) &&
+          moduleCondition(module)
       )
     ).toSorted((a, b) => a.getNameOrThrow().localeCompare(b.getNameOrThrow()))
   );

--- a/src/modules/date/anytime.ts
+++ b/src/modules/date/anytime.ts
@@ -1,0 +1,42 @@
+import type { FakerCore } from '../../core';
+import { toDate } from '../../internal/date';
+import { getDefaultRefDate } from '../../utils/get-default-ref-date';
+import { between } from './between';
+
+/**
+ * Generates a random date that can be either in the past or in the future.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `getDefaultRefDate(fakerCore)`.
+ *
+ * @see between(fakerCore): For generating dates in a specific range.
+ * @see past(fakerCore): For generating dates explicitly in the past.
+ * @see future(fakerCore): For generating dates explicitly in the future.
+ *
+ * @example
+ * anytime(fakerCore) // '2022-07-31T01:33:29.567Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function anytime(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The date to use as reference point for the newly generated date.
+     *
+     * @default getDefaultRefDate(fakerCore)
+     */
+    refDate?: string | Date | number;
+  } = {}
+): Date {
+  const { refDate = getDefaultRefDate(fakerCore) } = options;
+  const time = toDate(refDate).getTime();
+
+  return between(fakerCore, {
+    from: time - 1000 * 60 * 60 * 24 * 365,
+    to: time + 1000 * 60 * 60 * 24 * 365,
+  });
+}

--- a/src/modules/date/between.ts
+++ b/src/modules/date/between.ts
@@ -1,0 +1,46 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import { toDate } from '../../internal/date';
+import { int } from '../number/int';
+
+/**
+ * Generates a random date between the given boundaries.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options object.
+ * @param options.from The early date boundary.
+ * @param options.to The late date boundary.
+ *
+ * @throws {FakerError} If `from` or `to` are not provided.
+ * @throws {FakerError} If `from` is after `to`.
+ *
+ * @example
+ * between(fakerCore, { from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z' }) // '2026-05-16T02:22:53.002Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function between(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The early date boundary.
+     */
+    from: string | Date | number;
+    /**
+     * The late date boundary.
+     */
+    to: string | Date | number;
+  }
+): Date {
+  const { from, to } = options;
+
+  const fromMs = toDate(from, 'from').getTime();
+  const toMs = toDate(to, 'to').getTime();
+  if (fromMs > toMs) {
+    throw new FakerError('`from` date must be before `to` date.');
+  }
+
+  return new Date(int(fakerCore, { min: fromMs, max: toMs }));
+}

--- a/src/modules/date/betweens.ts
+++ b/src/modules/date/betweens.ts
@@ -1,0 +1,62 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import type { NumberOrRange } from '../../utils/types';
+import { multiple } from '../helpers/multiple';
+import { between } from './between';
+
+/**
+ * Generates random dates between the given boundaries. The dates will be returned in an array sorted in chronological order.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options object.
+ * @param options.from The early date boundary.
+ * @param options.to The late date boundary.
+ * @param options.count The number of dates to generate. Defaults to `3`.
+ *
+ * @throws {FakerError} If `from` or `to` are not provided.
+ * @throws {FakerError} If `from` is after `to`.
+ *
+ * @example
+ * betweens(fakerCore, { from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z' })
+ * // [
+ * //   '2022-07-02T06:00:00.000Z',
+ * //   '2024-12-31T12:00:00.000Z',
+ * //   '2027-07-02T18:00:00.000Z'
+ * // ]
+ * betweens(fakerCore, { from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z', count: 2 })
+ * // [ '2023-05-02T16:00:00.000Z', '2026-09-01T08:00:00.000Z' ]
+ * betweens(fakerCore, { from: '2020-01-01T00:00:00.000Z', to: '2030-01-01T00:00:00.000Z', count: { min: 2, max: 5 }})
+ * // [
+ * //   2021-12-19T06:35:40.191Z,
+ * //   2022-09-10T08:03:51.351Z,
+ * //   2023-04-19T11:41:17.501Z
+ * // ]
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function betweens(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The early date boundary.
+     */
+    from: string | Date | number;
+    /**
+     * The late date boundary.
+     */
+    to: string | Date | number;
+    /**
+     * The number of dates to generate.
+     *
+     * @default 3
+     */
+    count?: NumberOrRange;
+  }
+): Date[] {
+  const { from, to, count = 3 } = options;
+  return multiple(fakerCore, () => between(fakerCore, { from, to }), {
+    count,
+  }).toSorted((a, b) => a.getTime() - b.getTime());
+}

--- a/src/modules/date/betweens.ts
+++ b/src/modules/date/betweens.ts
@@ -1,5 +1,4 @@
 import type { FakerCore } from '../../core';
-import { FakerError } from '../../errors/faker-error';
 import type { NumberOrRange } from '../../utils/types';
 import { multiple } from '../helpers/multiple';
 import { between } from './between';

--- a/src/modules/date/birthdate.ts
+++ b/src/modules/date/birthdate.ts
@@ -1,0 +1,214 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import { toDate } from '../../internal/date';
+import { getDefaultRefDate } from '../../utils/get-default-ref-date';
+import { between } from './between';
+
+/**
+ * Returns a random birthdate. By default, the birthdate is generated for an adult between 18 and 80 years old.
+ * But you can customize the `'age'` range or the `'year'` range to generate a more specific birthdate.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use to generate the birthdate.
+ * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `getDefaultRefDate(fakerCore)`.
+ *
+ * @example
+ * birthdate(fakerCore) // '1977-07-10T01:37:30.719Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function birthdate(
+  fakerCore: FakerCore,
+  options?: {
+    /**
+     * The date to use as reference point for the newly generated date.
+     *
+     * @default getDefaultRefDate(fakerCore)
+     */
+    refDate?: string | Date | number;
+  }
+): Date;
+/**
+ * Returns a random birthdate for a given age range.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use to generate the birthdate.
+ * @param options.mode `'age'` to generate a birthdate based on the age range. It is also possible to generate a birthdate based on a `'year'` range.
+ * @param options.min The minimum age to generate a birthdate for.
+ * @param options.max The maximum age to generate a birthdate for.
+ * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `getDefaultRefDate(fakerCore)`.
+ *
+ * @example
+ * birthdate(fakerCore, { mode: 'age', min: 18, max: 65 }) // '2003-11-02T20:03:20.116Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function birthdate(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * `'age'` to generate a birthdate based on the age range.
+     * It is also possible to generate a birthdate based on a `'year'` range.
+     */
+    mode: 'age';
+    /**
+     * The minimum age to generate a birthdate for.
+     */
+    min: number;
+    /**
+     * The maximum age to generate a birthdate for.
+     */
+    max: number;
+    /**
+     * The date to use as reference point for the newly generated date.
+     *
+     * @default getDefaultRefDate(fakerCore)
+     */
+    refDate?: string | Date | number;
+  }
+): Date;
+/**
+ * Returns a random birthdate in the given range of years.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use to generate the birthdate.
+ * @param options.mode `'year'` to generate a birthdate based on the year range. It is also possible to generate a birthdate based on a `'age'` range.
+ * @param options.min The minimum year to generate a birthdate in.
+ * @param options.max The maximum year to generate a birthdate in.
+ *
+ * @example
+ * birthdate(fakerCore, { mode: 'year', min: 1900, max: 2000 }) // '1940-08-20T08:53:07.538Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function birthdate(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * `'year'` to generate a birthdate based on the year range.
+     * It is also possible to generate a birthdate based on an `'age'` range.
+     */
+    mode: 'year';
+    /**
+     * The minimum year to generate a birthdate in.
+     */
+    min: number;
+    /**
+     * The maximum year to generate a birthdate in.
+     */
+    max: number;
+  }
+): Date;
+/**
+ * Returns a random birthdate. By default, the birthdate is generated for an adult between 18 and 80 years old.
+ * But you can customize the `'age'` range or the `'year'` range to generate a more specific birthdate.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use to generate the birthdate.
+ * @param options.mode Either `'age'` or `'year'` to generate a birthdate based on the age or year range.
+ * @param options.min The minimum age or year to generate a birthdate in.
+ * @param options.max The maximum age or year to generate a birthdate in.
+ * @param options.refDate The date to use as reference point for the newly generated date.
+ * Only used when `mode` is `'age'`.
+ * Defaults to `getDefaultRefDate(fakerCore)`.
+ *
+ * @example
+ * birthdate(fakerCore) // '1977-07-10T01:37:30.719Z'
+ * birthdate(fakerCore, { mode: 'age', min: 18, max: 65 }) // '2003-11-02T20:03:20.116Z'
+ * birthdate(fakerCore, { mode: 'year', min: 1900, max: 2000 }) // '1940-08-20T08:53:07.538Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function birthdate(
+  fakerCore: FakerCore,
+  options?:
+    | {
+        /**
+         * The date to use as reference point for the newly generated date.
+         *
+         * @default getDefaultRefDate(fakerCore)
+         */
+        refDate?: string | Date | number;
+      }
+    | {
+        /**
+         * Either `'age'` or `'year'` to generate a birthdate based on the age or year range.
+         */
+        mode: 'age' | 'year';
+        /**
+         * The minimum age/year to generate a birthdate for/in.
+         */
+        min: number;
+        /**
+         * The maximum age/year to generate a birthdate for/in.
+         */
+        max: number;
+        /**
+         * The date to use as reference point for the newly generated date.
+         * Only used when `mode` is `'age'`.
+         *
+         * @default getDefaultRefDate(fakerCore)
+         */
+        refDate?: string | Date | number;
+      }
+): Date;
+
+export function birthdate(
+  fakerCore: FakerCore,
+  options: {
+    mode?: 'age' | 'year';
+    min?: number;
+    max?: number;
+    refDate?: string | Date | number;
+  } = {}
+): Date {
+  const {
+    mode = 'age',
+    min = 18,
+    max = 80,
+    refDate: rawRefDate = getDefaultRefDate(fakerCore),
+  } = options;
+
+  const refDate = toDate(rawRefDate);
+  const refYear = refDate.getUTCFullYear();
+
+  switch (mode) {
+    case 'age': {
+      // Add one day to the `from` date to avoid generating the same date as the reference date.
+      const oneDay = 24 * 60 * 60 * 1000;
+      const from = new Date(refDate).setUTCFullYear(refYear - max - 1) + oneDay;
+      const to = new Date(refDate).setUTCFullYear(refYear - min);
+
+      if (from > to) {
+        throw new FakerError(
+          `Max age ${max} should be greater than or equal to min age ${min}.`
+        );
+      }
+
+      return between(fakerCore, { from, to });
+    }
+
+    case 'year': {
+      // Avoid generating dates on the first and last date of the year
+      // to avoid running into other years depending on the timezone.
+      const from = new Date(Date.UTC(0, 0, 2)).setUTCFullYear(min);
+      const to = new Date(Date.UTC(0, 11, 30)).setUTCFullYear(max);
+
+      if (from > to) {
+        throw new FakerError(
+          `Max year ${max} should be greater than or equal to min year ${min}.`
+        );
+      }
+
+      return between(fakerCore, { from, to });
+    }
+  }
+}

--- a/src/modules/date/future.ts
+++ b/src/modules/date/future.ts
@@ -1,0 +1,74 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import { toDate } from '../../internal/date';
+import { getDefaultRefDate } from '../../utils/get-default-ref-date';
+import type { NumberOrRange } from '../../utils/types';
+import { between } from './between';
+
+/**
+ * Generates a random date in the future.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.years The range of years the date may be in the future. Either as a fixed amount of years or as a year range. Defaults to `1`.
+ * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `getDefaultRefDate(fakerCore)`.
+ *
+ * @throws {FakerError} If `years.max` is less than 0.
+ * @throws {FakerError} If `years.min` is greater than or equal to `years.max`.
+ *
+ * @see soon(fakerCore): For generating dates in the near future (days instead of years).
+ *
+ * @example
+ * future(fakerCore) // '2022-11-19T05:52:49.100Z'
+ * future(fakerCore, { years: 10 }) // '2030-11-23T09:38:28.710Z'
+ * future(fakerCore, { years: { min: 4, max: 7 } }) // '2031-05-21T05:49:21.116Z'
+ * future(fakerCore, { years: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2020-12-13T22:45:10.252Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function future(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The range of years the date may be in the future.
+     *
+     * @default 1
+     */
+    years?: NumberOrRange;
+    /**
+     * The date to use as reference point for the newly generated date.
+     *
+     * @default getDefaultRefDate(fakerCore)
+     */
+    refDate?: string | Date | number;
+  } = {}
+): Date {
+  const { refDate = getDefaultRefDate(fakerCore) } = options;
+  let { years = 1 } = options;
+  if (typeof years === 'number') {
+    years = { min: 0, max: years };
+  }
+
+  if (years.max <= 0) {
+    throw new FakerError('Years must be greater than 0.');
+  }
+
+  if (years.min >= years.max) {
+    throw new FakerError(
+      'The maximum amount of years must be greater than the minimum amount of years.'
+    );
+  }
+
+  const time = toDate(refDate);
+  const from = new Date(time);
+  from.setUTCFullYear(from.getUTCFullYear() + years.min);
+  const to = new Date(time);
+  to.setUTCFullYear(to.getUTCFullYear() + years.max);
+
+  return between(fakerCore, {
+    from: from.getTime() + 1000,
+    to,
+  });
+}

--- a/src/modules/date/module.ts
+++ b/src/modules/date/module.ts
@@ -1,15 +1,27 @@
-import type { DateEntryDefinition } from '../../definitions';
-import { FakerError } from '../../errors/faker-error';
 import type { Faker } from '../../faker';
-import { toDate } from '../../internal/date';
-import { assertLocaleData } from '../../internal/locale-proxy';
 import { SimpleModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
+import { anytime as dateAnytime } from './anytime';
+import { between as dateBetween } from './between';
+import { betweens as dateBetweens } from './betweens';
+import { birthdate as dateBirthdate } from './birthdate';
+import { future as dateFuture } from './future';
+import { month as dateMonth } from './month';
+import { past as datePast } from './past';
+import { recent as dateRecent } from './recent';
+import { soon as dateSoon } from './soon';
+import { timeZone as dateTimeZone } from './time-zone';
+import { weekday as dateWeekday } from './weekday';
 
 /**
  * Module to generate dates (without methods requiring localized data).
  */
 export class SimpleDateModule extends SimpleModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree date' to update the methods from their respective files.
+   */
+
   /**
    * Generates a random date that can be either in the past or in the future.
    *
@@ -35,13 +47,7 @@ export class SimpleDateModule extends SimpleModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    const { refDate = this.faker.defaultRefDate() } = options;
-    const time = toDate(refDate).getTime();
-
-    return this.between({
-      from: time - 1000 * 60 * 60 * 24 * 365,
-      to: time + 1000 * 60 * 60 * 24 * 365,
-    });
+    return dateAnytime(this.faker.fakerCore, options);
   }
 
   /**
@@ -80,32 +86,7 @@ export class SimpleDateModule extends SimpleModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    const { refDate = this.faker.defaultRefDate() } = options;
-    let { years = 1 } = options;
-    if (typeof years === 'number') {
-      years = { min: 0, max: years };
-    }
-
-    if (years.max <= 0) {
-      throw new FakerError('Years must be greater than 0.');
-    }
-
-    if (years.min >= years.max) {
-      throw new FakerError(
-        'The maximum amount of years must be greater than the minimum amount of years.'
-      );
-    }
-
-    const time = toDate(refDate);
-    const from = new Date(time);
-    from.setUTCFullYear(from.getUTCFullYear() - years.max);
-    const to = new Date(time);
-    to.setUTCFullYear(to.getUTCFullYear() - years.min);
-
-    return this.between({
-      from,
-      to: to.getTime() - 1000,
-    });
+    return datePast(this.faker.fakerCore, options);
   }
 
   /**
@@ -144,32 +125,7 @@ export class SimpleDateModule extends SimpleModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    const { refDate = this.faker.defaultRefDate() } = options;
-    let { years = 1 } = options;
-    if (typeof years === 'number') {
-      years = { min: 0, max: years };
-    }
-
-    if (years.max <= 0) {
-      throw new FakerError('Years must be greater than 0.');
-    }
-
-    if (years.min >= years.max) {
-      throw new FakerError(
-        'The maximum amount of years must be greater than the minimum amount of years.'
-      );
-    }
-
-    const time = toDate(refDate);
-    const from = new Date(time);
-    from.setUTCFullYear(from.getUTCFullYear() + years.min);
-    const to = new Date(time);
-    to.setUTCFullYear(to.getUTCFullYear() + years.max);
-
-    return this.between({
-      from: from.getTime() + 1000,
-      to,
-    });
+    return dateFuture(this.faker.fakerCore, options);
   }
 
   /**
@@ -197,15 +153,7 @@ export class SimpleDateModule extends SimpleModuleBase {
      */
     to: string | Date | number;
   }): Date {
-    const { from, to } = options;
-
-    const fromMs = toDate(from, 'from').getTime();
-    const toMs = toDate(to, 'to').getTime();
-    if (fromMs > toMs) {
-      throw new FakerError('`from` date must be before `to` date.');
-    }
-
-    return new Date(this.faker.number.int({ min: fromMs, max: toMs }));
+    return dateBetween(this.faker.fakerCore, options);
   }
 
   /**
@@ -253,10 +201,7 @@ export class SimpleDateModule extends SimpleModuleBase {
      */
     count?: NumberOrRange;
   }): Date[] {
-    const { from, to, count = 3 } = options;
-    return this.faker.helpers
-      .multiple(() => this.between({ from, to }), { count })
-      .toSorted((a, b) => a.getTime() - b.getTime());
+    return dateBetweens(this.faker.fakerCore, options);
   }
 
   /**
@@ -310,32 +255,7 @@ export class SimpleDateModule extends SimpleModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    const { refDate = this.faker.defaultRefDate() } = options;
-    let { days = 1 } = options;
-    if (typeof days === 'number') {
-      days = { min: 0, max: days };
-    }
-
-    if (days.max <= 0) {
-      throw new FakerError('Days must be greater than 0.');
-    }
-
-    if (days.min >= days.max) {
-      throw new FakerError(
-        'The maximum amount of days must be greater than the minimum amount of days.'
-      );
-    }
-
-    const time = toDate(refDate);
-    const from = new Date(time);
-    from.setUTCDate(from.getUTCDate() - days.max);
-    const to = new Date(time);
-    to.setUTCDate(to.getUTCDate() - days.min);
-
-    return this.between({
-      from,
-      to: to.getTime() - 1000,
-    });
+    return dateRecent(this.faker.fakerCore, options);
   }
 
   /**
@@ -389,32 +309,7 @@ export class SimpleDateModule extends SimpleModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    const { refDate = this.faker.defaultRefDate() } = options;
-    let { days = 1 } = options;
-    if (typeof days === 'number') {
-      days = { min: 0, max: days };
-    }
-
-    if (days.max <= 0) {
-      throw new FakerError('Days must be greater than 0.');
-    }
-
-    if (days.min >= days.max) {
-      throw new FakerError(
-        'The maximum amount of days must be greater than the minimum amount of days.'
-      );
-    }
-
-    const time = toDate(refDate);
-    const from = new Date(time);
-    from.setUTCDate(from.getUTCDate() + days.min);
-    const to = new Date(time);
-    to.setUTCDate(to.getUTCDate() + days.max);
-
-    return this.between({
-      from: from.getTime() + 1000,
-      to,
-    });
+    return dateSoon(this.faker.fakerCore, options);
   }
 
   /**
@@ -559,48 +454,7 @@ export class SimpleDateModule extends SimpleModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    const {
-      mode = 'age',
-      min = 18,
-      max = 80,
-      refDate: rawRefDate = this.faker.defaultRefDate(),
-    } = options;
-
-    const refDate = toDate(rawRefDate);
-    const refYear = refDate.getUTCFullYear();
-
-    switch (mode) {
-      case 'age': {
-        // Add one day to the `from` date to avoid generating the same date as the reference date.
-        const oneDay = 24 * 60 * 60 * 1000;
-        const from =
-          new Date(refDate).setUTCFullYear(refYear - max - 1) + oneDay;
-        const to = new Date(refDate).setUTCFullYear(refYear - min);
-
-        if (from > to) {
-          throw new FakerError(
-            `Max age ${max} should be greater than or equal to min age ${min}.`
-          );
-        }
-
-        return this.between({ from, to });
-      }
-
-      case 'year': {
-        // Avoid generating dates on the first and last date of the year
-        // to avoid running into other years depending on the timezone.
-        const from = new Date(Date.UTC(0, 0, 2)).setUTCFullYear(min);
-        const to = new Date(Date.UTC(0, 11, 30)).setUTCFullYear(max);
-
-        if (from > to) {
-          throw new FakerError(
-            `Max year ${max} should be greater than or equal to min year ${min}.`
-          );
-        }
-
-        return this.between({ from, to });
-      }
-    }
+    return dateBirthdate(this.faker.fakerCore, options);
   }
 }
 
@@ -631,6 +485,11 @@ export class SimpleDateModule extends SimpleModuleBase {
  * These methods have additional concerns about reproducibility, see [Reproducible Results](https://fakerjs.dev/guide/usage.html#reproducible-results).
  */
 export class DateModule extends SimpleDateModule {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree date' to update the methods from their respective files.
+   */
+
   constructor(protected readonly faker: Faker) {
     super(faker);
   }
@@ -670,21 +529,7 @@ export class DateModule extends SimpleDateModule {
       context?: boolean;
     } = {}
   ): string {
-    const { abbreviated = false, context = false } = options;
-
-    const source = this.faker.definitions.date.month;
-    let type: keyof DateEntryDefinition;
-    if (abbreviated) {
-      const useContext = context && source['abbr_context'] != null;
-      type = useContext ? 'abbr_context' : 'abbr';
-    } else {
-      const useContext = context && source['wide_context'] != null;
-      type = useContext ? 'wide_context' : 'wide';
-    }
-
-    const values = source[type];
-    assertLocaleData(values, 'date.month', type);
-    return this.faker.helpers.arrayElement(values);
+    return dateMonth(this.faker.fakerCore, options);
   }
 
   /**
@@ -722,21 +567,7 @@ export class DateModule extends SimpleDateModule {
       context?: boolean;
     } = {}
   ): string {
-    const { abbreviated = false, context = false } = options;
-
-    const source = this.faker.definitions.date.weekday;
-    let type: keyof DateEntryDefinition;
-    if (abbreviated) {
-      const useContext = context && source['abbr_context'] != null;
-      type = useContext ? 'abbr_context' : 'abbr';
-    } else {
-      const useContext = context && source['wide_context'] != null;
-      type = useContext ? 'wide_context' : 'wide';
-    }
-
-    const values = source[type];
-    assertLocaleData(values, 'date.weekday', type);
-    return this.faker.helpers.arrayElement(values);
+    return dateWeekday(this.faker.fakerCore, options);
   }
 
   /**
@@ -753,8 +584,6 @@ export class DateModule extends SimpleDateModule {
    * @since 9.0.0
    */
   timeZone(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.date.time_zone
-    );
+    return dateTimeZone(this.faker.fakerCore);
   }
 }

--- a/src/modules/date/month.ts
+++ b/src/modules/date/month.ts
@@ -1,0 +1,60 @@
+import type { FakerCore } from '../../core';
+import type { DateEntryDefinition } from '../../definitions';
+import { assertLocaleData } from '../../internal/locale-proxy';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random name of a month.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options to use.
+ * @param options.abbreviated Whether to return an abbreviation. Defaults to `false`.
+ * @param options.context Whether to return the name of a month in the context of a date. In the default `en` locale this has no effect, however, in other locales like `fr` or `ru`, this may affect grammar or capitalization, for example `'январь'` with `{ context: false }` and `'января'` with `{ context: true }` in `ru`. Defaults to `false`.
+ *
+ * @example
+ * month(fakerCore) // 'October'
+ * month(fakerCore, { abbreviated: true }) // 'Feb'
+ * month(fakerCore, { context: true }) // 'June'
+ * month(fakerCore, { abbreviated: true, context: true }) // 'Sep'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function month(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * Whether to return an abbreviation.
+     *
+     * @default false
+     */
+    abbreviated?: boolean;
+    /**
+     * Whether to return the name of a month in the context of a date.
+     *
+     * In the default `en` locale this has no effect,
+     * however, in other locales like `fr` or `ru`, this may affect grammar or capitalization,
+     * for example `'январь'` with `{ context: false }` and `'января'` with `{ context: true }` in `ru`.
+     *
+     * @default false
+     */
+    context?: boolean;
+  } = {}
+): string {
+  const { abbreviated = false, context = false } = options;
+
+  const source = fakerCore.locale.date.month;
+  let type: keyof DateEntryDefinition;
+  if (abbreviated) {
+    const useContext = context && source['abbr_context'] != null;
+    type = useContext ? 'abbr_context' : 'abbr';
+  } else {
+    const useContext = context && source['wide_context'] != null;
+    type = useContext ? 'wide_context' : 'wide';
+  }
+
+  const values = source[type];
+  assertLocaleData(values, 'date.month', type);
+  return arrayElement(fakerCore, values);
+}

--- a/src/modules/date/past.ts
+++ b/src/modules/date/past.ts
@@ -1,0 +1,74 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import { toDate } from '../../internal/date';
+import { getDefaultRefDate } from '../../utils/get-default-ref-date';
+import type { NumberOrRange } from '../../utils/types';
+import { between } from './between';
+
+/**
+ * Generates a random date in the past.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.years The range of years the date may be in the past. Either as a fixed amount of years or as a year range. Defaults to `1`.
+ * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `getDefaultRefDate(fakerCore)`.
+ *
+ * @throws {FakerError} If `years.max` is less than 0.
+ * @throws {FakerError} If `years.min` is greater than or equal to `years.max`.
+ *
+ * @see recent(fakerCore): For generating dates in the recent past (days instead of years).
+ *
+ * @example
+ * past(fakerCore) // '2021-12-03T05:40:44.408Z'
+ * past(fakerCore, { years: 10 }) // '2017-10-25T21:34:19.488Z'
+ * past(fakerCore, { years: { min: 4, max: 7 } }) // '2022-12-12T03:43:16.434Z'
+ * past(fakerCore, { years: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2017-08-18T02:59:12.350Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function past(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The range of years the date may be in the past.
+     *
+     * @default 1
+     */
+    years?: NumberOrRange;
+    /**
+     * The date to use as reference point for the newly generated date.
+     *
+     * @default getDefaultRefDate(fakerCore)
+     */
+    refDate?: string | Date | number;
+  } = {}
+): Date {
+  const { refDate = getDefaultRefDate(fakerCore) } = options;
+  let { years = 1 } = options;
+  if (typeof years === 'number') {
+    years = { min: 0, max: years };
+  }
+
+  if (years.max <= 0) {
+    throw new FakerError('Years must be greater than 0.');
+  }
+
+  if (years.min >= years.max) {
+    throw new FakerError(
+      'The maximum amount of years must be greater than the minimum amount of years.'
+    );
+  }
+
+  const time = toDate(refDate);
+  const from = new Date(time);
+  from.setUTCFullYear(from.getUTCFullYear() - years.max);
+  const to = new Date(time);
+  to.setUTCFullYear(to.getUTCFullYear() - years.min);
+
+  return between(fakerCore, {
+    from,
+    to: to.getTime() - 1000,
+  });
+}

--- a/src/modules/date/recent.ts
+++ b/src/modules/date/recent.ts
@@ -1,0 +1,88 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import { toDate } from '../../internal/date';
+import { getDefaultRefDate } from '../../utils/get-default-ref-date';
+import { between } from './between';
+
+/**
+ * Generates a random date in the recent past.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.days The range of days the date may be in the past. Either as a fixed amount of days or as a day range. Defaults to `1`.
+ * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `getDefaultRefDate(fakerCore)`.
+ *
+ * @throws {FakerError} If `days.max` is less than 0.
+ * @throws {FakerError} If `days.min` is greater than or equal to `days.max`.
+ *
+ * @see past(fakerCore): For generating dates further back in time (years instead of days).
+ *
+ * @example
+ * recent(fakerCore) // '2022-02-04T02:09:35.077Z'
+ * recent(fakerCore, { days: 10 }) // '2022-01-29T06:12:12.829Z'
+ * recent(fakerCore, { days: { min: 4, max: 7 } }) // '2022-02-02T17:54:01.818Z'
+ * recent(fakerCore, { days: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2019-12-27T18:11:19.117Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function recent(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The range of days the date may be in the past.
+     *
+     * @default 1
+     */
+    days?:
+      | number
+      | {
+          /**
+           * The minimum amount of days the date should be in the past.
+           *
+           * @default 0
+           */
+          min: number;
+          /**
+           * The maximum amount of days the date should be in the past.
+           *
+           * @default 1
+           */
+          max: number;
+        };
+    /**
+     * The date to use as reference point for the newly generated date.
+     *
+     * @default getDefaultRefDate(fakerCore)
+     */
+    refDate?: string | Date | number;
+  } = {}
+): Date {
+  const { refDate = getDefaultRefDate(fakerCore) } = options;
+  let { days = 1 } = options;
+  if (typeof days === 'number') {
+    days = { min: 0, max: days };
+  }
+
+  if (days.max <= 0) {
+    throw new FakerError('Days must be greater than 0.');
+  }
+
+  if (days.min >= days.max) {
+    throw new FakerError(
+      'The maximum amount of days must be greater than the minimum amount of days.'
+    );
+  }
+
+  const time = toDate(refDate);
+  const from = new Date(time);
+  from.setUTCDate(from.getUTCDate() - days.max);
+  const to = new Date(time);
+  to.setUTCDate(to.getUTCDate() - days.min);
+
+  return between(fakerCore, {
+    from,
+    to: to.getTime() - 1000,
+  });
+}

--- a/src/modules/date/soon.ts
+++ b/src/modules/date/soon.ts
@@ -1,0 +1,88 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import { toDate } from '../../internal/date';
+import { getDefaultRefDate } from '../../utils/get-default-ref-date';
+import { between } from './between';
+
+/**
+ * Generates a random date in the near future.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.days The range of days the date may be in the future. Either as a fixed amount of days or as a day range. Defaults to `1`.
+ * @param options.refDate The date to use as reference point for the newly generated date. Defaults to `getDefaultRefDate(fakerCore)`.
+ *
+ * @throws {FakerError} If `days.max` is less than 0.
+ * @throws {FakerError} If `days.min` is greater than or equal to `days.max`.
+ *
+ * @see future(fakerCore): For generating dates further in the future (years instead of days).
+ *
+ * @example
+ * soon(fakerCore) // '2022-02-05T09:55:39.216Z'
+ * soon(fakerCore, { days: 10 }) // '2022-02-11T05:14:39.138Z'
+ * soon(fakerCore, { days: { min: 4, max: 7 } }) // '2022-02-09T17:54:01.818Z'
+ * soon(fakerCore, { days: 10, refDate: '2020-01-01T00:00:00.000Z' }) // '2020-01-01T02:40:44.990Z'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function soon(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The range of days the date may be in the future.
+     *
+     * @default 1
+     */
+    days?:
+      | number
+      | {
+          /**
+           * The minimum amount of days the date should be in the future.
+           *
+           * @default 0
+           */
+          min: number;
+          /**
+           * The maximum amount of days the date should be in the future.
+           *
+           * @default 1
+           */
+          max: number;
+        };
+    /**
+     * The date to use as reference point for the newly generated date.
+     *
+     * @default getDefaultRefDate(fakerCore)
+     */
+    refDate?: string | Date | number;
+  } = {}
+): Date {
+  const { refDate = getDefaultRefDate(fakerCore) } = options;
+  let { days = 1 } = options;
+  if (typeof days === 'number') {
+    days = { min: 0, max: days };
+  }
+
+  if (days.max <= 0) {
+    throw new FakerError('Days must be greater than 0.');
+  }
+
+  if (days.min >= days.max) {
+    throw new FakerError(
+      'The maximum amount of days must be greater than the minimum amount of days.'
+    );
+  }
+
+  const time = toDate(refDate);
+  const from = new Date(time);
+  from.setUTCDate(from.getUTCDate() + days.min);
+  const to = new Date(time);
+  to.setUTCDate(to.getUTCDate() + days.max);
+
+  return between(fakerCore, {
+    from: from.getTime() + 1000,
+    to,
+  });
+}

--- a/src/modules/date/time-zone.ts
+++ b/src/modules/date/time-zone.ts
@@ -1,0 +1,23 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random IANA time zone name.
+ *
+ * The returned time zone is not tied to the current locale.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @see [IANA Time Zone Database](https://www.iana.org/time-zones)
+ * @see locationTimeZone(fakerCore): For generating a timezone based on the current locale.
+ *
+ * @example
+ * locationTimeZone(fakerCore) // 'Pacific/Guam'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function timeZone(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.date.time_zone);
+}

--- a/src/modules/date/weekday.ts
+++ b/src/modules/date/weekday.ts
@@ -1,0 +1,60 @@
+import type { FakerCore } from '../../core';
+import type { DateEntryDefinition } from '../../definitions';
+import { assertLocaleData } from '../../internal/locale-proxy';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random day of the week.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options to use.
+ * @param options.abbreviated Whether to return an abbreviation. Defaults to `false`.
+ * @param options.context Whether to return the day of the week in the context of a date. In the default `en` locale this has no effect, however, in other locales like `fr` or `ru`, this may affect grammar or capitalization, for example `'Lundi'` with `{ context: false }` and `'lundi'` with `{ context: true }` in `fr`. Defaults to `false`.
+ *
+ * @example
+ * weekday(fakerCore) // 'Monday'
+ * weekday(fakerCore, { abbreviated: true }) // 'Thu'
+ * weekday(fakerCore, { context: true }) // 'Thursday'
+ * weekday(fakerCore, { abbreviated: true, context: true }) // 'Fri'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function weekday(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * Whether to return an abbreviation.
+     *
+     * @default false
+     */
+    abbreviated?: boolean;
+    /**
+     * Whether to return the day of the week in the context of a date.
+     *
+     * In the default `en` locale this has no effect,
+     * however, in other locales like `fr` or `ru`, this may affect grammar or capitalization,
+     * for example `'Lundi'` with `{ context: false }` and `'lundi'` with `{ context: true }` in `fr`.
+     *
+     * @default false
+     */
+    context?: boolean;
+  } = {}
+): string {
+  const { abbreviated = false, context = false } = options;
+
+  const source = fakerCore.locale.date.weekday;
+  let type: keyof DateEntryDefinition;
+  if (abbreviated) {
+    const useContext = context && source['abbr_context'] != null;
+    type = useContext ? 'abbr_context' : 'abbr';
+  } else {
+    const useContext = context && source['wide_context'] != null;
+    type = useContext ? 'wide_context' : 'wide';
+  }
+
+  const values = source[type];
+  assertLocaleData(values, 'date.weekday', type);
+  return arrayElement(fakerCore, values);
+}

--- a/src/modules/person/_select-definition.ts
+++ b/src/modules/person/_select-definition.ts
@@ -1,0 +1,61 @@
+import type { FakerCore } from '../../core';
+import type { PersonEntryDefinition } from '../../definitions';
+import { arrayElement } from '../helpers/array-element';
+import { weightedArrayElement } from '../helpers/weighted-array-element';
+import type { SexType } from './sex-type';
+import { sexType } from './sex-type';
+
+/**
+ * Select a definition based on given sex.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param sex The sex to select the definition for.
+ * @param personEntry The definitions to select from.
+ *
+ * @returns Definition based on given sex.
+ */
+export function selectDefinition<T>(
+  fakerCore: FakerCore,
+  sex: SexType = sexType(fakerCore),
+  personEntry: PersonEntryDefinition<T>
+): T[] {
+  const { generic, female, male } = personEntry;
+
+  if (sex === 'generic') {
+    return (
+      generic ??
+      arrayElement(fakerCore, [female, male]) ??
+      // The last statement should never happen at run time. At this point in time,
+      // the entry will satisfy at least (generic || (female && male)).
+      // TS is not able to infer the type correctly.
+      []
+    );
+  }
+
+  const binary = sex === 'female' ? female : male;
+
+  if (binary != null) {
+    if (generic != null) {
+      return weightedArrayElement(fakerCore, [
+        {
+          weight: 3 * Math.sqrt(binary.length),
+          value: binary,
+        },
+        {
+          weight: Math.sqrt(generic.length),
+          value: generic,
+        },
+      ]);
+    }
+
+    return binary;
+  }
+
+  return (
+    generic ??
+    // The last statement should never happen at run time. At this point in time,
+    // the entry will satisfy at least (generic || (female && male)).
+    // TS is not able to infer the type correctly.
+    []
+  );
+}

--- a/src/modules/person/bio.ts
+++ b/src/modules/person/bio.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+
+/**
+ * Returns a random short biography
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * bio(fakerCore) // 'oatmeal advocate, veteran 🐠'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function bio(fakerCore: FakerCore): string {
+  return new Faker(fakerCore).helpers.fake(fakerCore.locale.person.bio_pattern);
+}

--- a/src/modules/person/first-name.ts
+++ b/src/modules/person/first-name.ts
@@ -1,5 +1,7 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
+import { selectDefinition } from './_select-definition';
+import type { SexType } from './sex-type';
 
 /**
  * Returns a random first name.

--- a/src/modules/person/first-name.ts
+++ b/src/modules/person/first-name.ts
@@ -1,0 +1,25 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random first name.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param sex The optional sex to use.
+ * Can be either `'female'` or `'male'`.
+ *
+ * @example
+ * firstName(fakerCore) // 'Antwan'
+ * firstName(fakerCore, 'female') // 'Victoria'
+ * firstName(fakerCore, 'male') // 'Tom'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function firstName(fakerCore: FakerCore, sex?: SexType): string {
+  return arrayElement(
+    fakerCore,
+    selectDefinition(fakerCore, sex, fakerCore.locale.person.first_name)
+  );
+}

--- a/src/modules/person/full-name.ts
+++ b/src/modules/person/full-name.ts
@@ -6,6 +6,8 @@ import { firstName as personFirstName } from './first-name';
 import { lastName as personLastName } from './last-name';
 import { middleName } from './middle-name';
 import { prefix } from './prefix';
+import type { SexType } from './sex-type';
+import { Sex } from './sex-type';
 import { suffix } from './suffix';
 
 /**
@@ -46,7 +48,7 @@ export function fullName(
     /**
      * The optional sex to use. Can be either `'female'` or `'male'`.
      *
-     * @default helpersArrayElement(fakerCore, ['female', 'male'])
+     * @default helpersArrayElement(fakerCore, [Sex.Female, Sex.Male])
      */
     sex?: SexType;
   } = {}

--- a/src/modules/person/full-name.ts
+++ b/src/modules/person/full-name.ts
@@ -1,0 +1,73 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+import { mustache } from '../helpers/mustache';
+import { weightedArrayElement } from '../helpers/weighted-array-element';
+import { firstName as personFirstName } from './first-name';
+import { lastName as personLastName } from './last-name';
+import { middleName } from './middle-name';
+import { prefix } from './prefix';
+import { suffix } from './suffix';
+
+/**
+ * Generates a random full name.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options An options object.
+ * @param options.firstName The optional first name to use. If not specified a random one will be chosen.
+ * @param options.lastName The optional last name to use. If not specified a random one will be chosen.
+ * @param options.sex The optional sex to use. Can be either `'female'` or `'male'`.
+ *
+ * @example
+ * fullName(fakerCore) // 'Allen Brown'
+ * fullName(fakerCore, { firstName: 'Joann' }) // 'Joann Osinski'
+ * fullName(fakerCore, { firstName: 'Marcella', sex: 'female' }) // 'Mrs. Marcella Huels'
+ * fullName(fakerCore, { lastName: 'Beer' }) // 'Mr. Alfonso Beer'
+ * fullName(fakerCore, { sex: 'male' }) // 'Fernando Schaefer'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function fullName(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The optional first name to use. If not specified a random one will be chosen.
+     *
+     * @default firstName(fakerCore, sex)
+     */
+    firstName?: string;
+    /**
+     * The optional last name to use. If not specified a random one will be chosen.
+     *
+     * @default lastName(fakerCore, sex)
+     */
+    lastName?: string;
+    /**
+     * The optional sex to use. Can be either `'female'` or `'male'`.
+     *
+     * @default helpersArrayElement(fakerCore, ['female', 'male'])
+     */
+    sex?: SexType;
+  } = {}
+): string {
+  const {
+    sex = arrayElement(fakerCore, [Sex.Female, Sex.Male]),
+    firstName = personFirstName(fakerCore, sex),
+    lastName = personLastName(fakerCore, sex),
+  } = options;
+
+  const fullNamePattern: string = weightedArrayElement(
+    fakerCore,
+    fakerCore.locale.person.name
+  );
+
+  const fullName = mustache(fakerCore, fullNamePattern, {
+    'person.prefix': () => prefix(fakerCore, sex),
+    'person.firstName': () => firstName,
+    'person.middleName': () => middleName(fakerCore, sex),
+    'person.lastName': () => lastName,
+    'person.suffix': () => suffix(fakerCore),
+  });
+  return fullName;
+}

--- a/src/modules/person/gender.ts
+++ b/src/modules/person/gender.ts
@@ -1,0 +1,20 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random gender.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @see sex(fakerCore): For generating a binary-gender value.
+ *
+ * @example
+ * gender(fakerCore) // 'Trans*Man'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function gender(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.person.gender);
+}

--- a/src/modules/person/index.ts
+++ b/src/modules/person/index.ts
@@ -1,1 +1,3 @@
 export * from './module';
+export { Sex } from './sex-type';
+export type { SexType } from './sex-type';

--- a/src/modules/person/job-area.ts
+++ b/src/modules/person/job-area.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random job area.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * jobArea(fakerCore) // 'Brand'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function jobArea(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.person.job_area);
+}

--- a/src/modules/person/job-descriptor.ts
+++ b/src/modules/person/job-descriptor.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random job descriptor.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * jobDescriptor(fakerCore) // 'Customer'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function jobDescriptor(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.person.job_descriptor);
+}

--- a/src/modules/person/job-title.ts
+++ b/src/modules/person/job-title.ts
@@ -1,0 +1,20 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+
+/**
+ * Generates a random job title.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * jobTitle(fakerCore) // 'Global Accounts Engineer'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function jobTitle(fakerCore: FakerCore): string {
+  return new Faker(fakerCore).helpers.fake(
+    fakerCore.locale.person.job_title_pattern
+  );
+}

--- a/src/modules/person/job-type.ts
+++ b/src/modules/person/job-type.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random job type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * jobType(fakerCore) // 'Assistant'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function jobType(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.person.job_type);
+}

--- a/src/modules/person/last-name.ts
+++ b/src/modules/person/last-name.ts
@@ -1,0 +1,36 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+import { arrayElement } from '../helpers/array-element';
+import { weightedArrayElement } from '../helpers/weighted-array-element';
+
+/**
+ * Returns a random last name.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param sex The optional sex to use.
+ * Can be either `'female'` or `'male'`.
+ *
+ * @example
+ * lastName(fakerCore) // 'Hauck'
+ * lastName(fakerCore, 'female') // 'Grady'
+ * lastName(fakerCore, 'male') // 'Barton'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function lastName(fakerCore: FakerCore, sex?: SexType): string {
+  const patterns = fakerCore.locale.raw.person?.last_name_pattern;
+  if (patterns != null) {
+    const pattern = weightedArrayElement(
+      fakerCore,
+      selectDefinition(fakerCore, sex, patterns)
+    );
+    return new Faker(fakerCore).helpers.fake(pattern);
+  }
+
+  return arrayElement(
+    fakerCore,
+    selectDefinition(fakerCore, sex, fakerCore.locale.person.last_name)
+  );
+}

--- a/src/modules/person/last-name.ts
+++ b/src/modules/person/last-name.ts
@@ -2,6 +2,8 @@ import type { FakerCore } from '../../core';
 import { Faker } from '../../faker';
 import { arrayElement } from '../helpers/array-element';
 import { weightedArrayElement } from '../helpers/weighted-array-element';
+import { selectDefinition } from './_select-definition';
+import type { SexType } from './sex-type';
 
 /**
  * Returns a random last name.

--- a/src/modules/person/middle-name.ts
+++ b/src/modules/person/middle-name.ts
@@ -1,0 +1,25 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random middle name.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param sex The optional sex to use.
+ * Can be either `'female'` or `'male'`.
+ *
+ * @example
+ * middleName(fakerCore) // 'James'
+ * middleName(fakerCore, 'female') // 'Eloise'
+ * middleName(fakerCore, 'male') // 'Asher'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function middleName(fakerCore: FakerCore, sex?: SexType): string {
+  return arrayElement(
+    fakerCore,
+    selectDefinition(fakerCore, sex, fakerCore.locale.person.middle_name)
+  );
+}

--- a/src/modules/person/middle-name.ts
+++ b/src/modules/person/middle-name.ts
@@ -1,5 +1,7 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
+import { selectDefinition } from './_select-definition';
+import type { SexType } from './sex-type';
 
 /**
  * Returns a random middle name.

--- a/src/modules/person/module.ts
+++ b/src/modules/person/module.ts
@@ -1,64 +1,20 @@
-import type { PersonEntryDefinition } from '../../definitions/person';
-import type { Faker } from '../../faker';
 import { ModuleBase } from '../../internal/module-base';
+import { bio as personBio } from './bio';
+import { firstName as personFirstName } from './first-name';
+import { fullName as personFullName } from './full-name';
+import { gender as personGender } from './gender';
+import { jobArea as personJobArea } from './job-area';
+import { jobDescriptor as personJobDescriptor } from './job-descriptor';
+import { jobTitle as personJobTitle } from './job-title';
+import { jobType as personJobType } from './job-type';
+import { lastName as personLastName } from './last-name';
+import { middleName as personMiddleName } from './middle-name';
+import { prefix as personPrefix } from './prefix';
+import { sex as personSex } from './sex';
 import type { SexType } from './sex-type';
-import { Sex } from './sex-type';
-
-// Temp duplicate
-/**
- * Select a definition based on given sex.
- *
- * @param faker Faker instance.
- * @param sex Sex.
- * @param personEntry Definitions.
- *
- * @returns Definition based on given sex.
- */
-function selectDefinition<T>(
-  faker: Faker,
-  sex: SexType = faker.person.sexType(),
-  personEntry: PersonEntryDefinition<T>
-): T[] {
-  const { generic, female, male } = personEntry;
-
-  if (sex === 'generic') {
-    return (
-      generic ??
-      faker.helpers.arrayElement([female, male]) ??
-      // The last statement should never happen at run time. At this point in time,
-      // the entry will satisfy at least (generic || (female && male)).
-      // TS is not able to infer the type correctly.
-      []
-    );
-  }
-
-  const binary = sex === 'female' ? female : male;
-
-  if (binary != null) {
-    if (generic != null) {
-      return faker.helpers.weightedArrayElement([
-        {
-          weight: 3 * Math.sqrt(binary.length),
-          value: binary,
-        },
-        {
-          weight: Math.sqrt(generic.length),
-          value: generic,
-        },
-      ]);
-    }
-
-    return binary;
-  }
-
-  return (
-    generic ??
-    // The last statement should never happen at run time. At this point in time,
-    // the entry will satisfy at least (generic || (female && male)).
-    // TS is not able to infer the type correctly.
-    []
-  );
-}
+import { sexType as personSexType } from './sex-type';
+import { suffix as personSuffix } from './suffix';
+import { zodiacSign as personZodiacSign } from './zodiac-sign';
 
 /**
  * Module to generate people's personal information such as names and job titles. Prior to Faker 8.0.0, this module was known as `faker.name`.
@@ -80,6 +36,11 @@ function selectDefinition<T>(
  * For personal contact information like phone numbers and email addresses, see the [`faker.phone`](https://fakerjs.dev/api/phone.html) and [`faker.internet`](https://fakerjs.dev/api/internet.html) modules.
  */
 export class PersonModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree person' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random first name.
    *
@@ -94,13 +55,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   firstName(sex?: SexType): string {
-    return this.faker.helpers.arrayElement(
-      selectDefinition(
-        this.faker,
-        sex,
-        this.faker.definitions.person.first_name
-      )
-    );
+    return personFirstName(this.faker.fakerCore, sex);
   }
 
   /**
@@ -117,17 +72,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   lastName(sex?: SexType): string {
-    const patterns = this.faker.definitions.raw.person?.last_name_pattern;
-    if (patterns != null) {
-      const pattern = this.faker.helpers.weightedArrayElement(
-        selectDefinition(this.faker, sex, patterns)
-      );
-      return this.faker.helpers.fake(pattern);
-    }
-
-    return this.faker.helpers.arrayElement(
-      selectDefinition(this.faker, sex, this.faker.definitions.person.last_name)
-    );
+    return personLastName(this.faker.fakerCore, sex);
   }
 
   /**
@@ -144,13 +89,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   middleName(sex?: SexType): string {
-    return this.faker.helpers.arrayElement(
-      selectDefinition(
-        this.faker,
-        sex,
-        this.faker.definitions.person.middle_name
-      )
-    );
+    return personMiddleName(this.faker.fakerCore, sex);
   }
 
   /**
@@ -187,29 +126,12 @@ export class PersonModule extends ModuleBase {
       /**
        * The optional sex to use. Can be either `'female'` or `'male'`.
        *
-       * @default faker.helpers.arrayElement(['female', 'male'])
+       * @default faker.helpers.arrayElement([Sex.Female, Sex.Male])
        */
       sex?: SexType;
     } = {}
   ): string {
-    const {
-      sex = this.faker.helpers.arrayElement([Sex.Female, Sex.Male]),
-      firstName = this.firstName(sex),
-      lastName = this.lastName(sex),
-    } = options;
-
-    const fullNamePattern: string = this.faker.helpers.weightedArrayElement(
-      this.faker.definitions.person.name
-    );
-
-    const fullName = this.faker.helpers.mustache(fullNamePattern, {
-      'person.prefix': () => this.prefix(sex),
-      'person.firstName': () => firstName,
-      'person.middleName': () => this.middleName(sex),
-      'person.lastName': () => lastName,
-      'person.suffix': () => this.suffix(),
-    });
-    return fullName;
+    return personFullName(this.faker.fakerCore, options);
   }
 
   /**
@@ -223,9 +145,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   gender(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.person.gender
-    );
+    return personGender(this.faker.fakerCore);
   }
 
   /**
@@ -243,7 +163,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   sex(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.person.sex);
+    return personSex(this.faker.fakerCore);
   }
 
   /**
@@ -274,13 +194,7 @@ export class PersonModule extends ModuleBase {
       includeGeneric?: boolean;
     } = {}
   ): SexType {
-    const { includeGeneric = false } = options;
-
-    if (includeGeneric) {
-      return this.faker.helpers.enumValue(Sex);
-    }
-
-    return this.faker.helpers.arrayElement([Sex.Female, Sex.Male]);
+    return personSexType(this.faker.fakerCore, options);
   }
 
   /**
@@ -292,7 +206,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   bio(): string {
-    return this.faker.helpers.fake(this.faker.definitions.person.bio_pattern);
+    return personBio(this.faker.fakerCore);
   }
 
   /**
@@ -308,9 +222,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   prefix(sex?: SexType): string {
-    return this.faker.helpers.arrayElement(
-      selectDefinition(this.faker, sex, this.faker.definitions.person.prefix)
-    );
+    return personPrefix(this.faker.fakerCore, sex);
   }
 
   /**
@@ -322,10 +234,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   suffix(): string {
-    // TODO @Shinigami92 2022-03-21: Add female_suffix and male_suffix
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.person.suffix
-    );
+    return personSuffix(this.faker.fakerCore);
   }
 
   /**
@@ -337,9 +246,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   jobTitle(): string {
-    return this.faker.helpers.fake(
-      this.faker.definitions.person.job_title_pattern
-    );
+    return personJobTitle(this.faker.fakerCore);
   }
 
   /**
@@ -351,9 +258,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   jobDescriptor(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.person.job_descriptor
-    );
+    return personJobDescriptor(this.faker.fakerCore);
   }
 
   /**
@@ -365,9 +270,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   jobArea(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.person.job_area
-    );
+    return personJobArea(this.faker.fakerCore);
   }
 
   /**
@@ -379,9 +282,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   jobType(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.person.job_type
-    );
+    return personJobType(this.faker.fakerCore);
   }
 
   /**
@@ -393,8 +294,6 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   zodiacSign(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.person.western_zodiac_sign
-    );
+    return personZodiacSign(this.faker.fakerCore);
   }
 }

--- a/src/modules/person/module.ts
+++ b/src/modules/person/module.ts
@@ -1,30 +1,10 @@
 import type { PersonEntryDefinition } from '../../definitions/person';
 import type { Faker } from '../../faker';
 import { ModuleBase } from '../../internal/module-base';
+import type { SexType } from './sex-type';
+import { Sex } from './sex-type';
 
-/**
- * The enum for values corresponding to a person's sex.
- */
-export enum Sex {
-  /**
-   * Is used for values that are primarily attributable to only females.
-   */
-  Female = 'female',
-  /**
-   * Is used for values that cannot clearly be attributed to a specific sex or are used for both sexes.
-   */
-  Generic = 'generic',
-  /**
-   * Is used for values that are primarily attributable to only males.
-   */
-  Male = 'male',
-}
-
-/**
- * The parameter type for values corresponding to a person's sex.
- */
-export type SexType = `${Sex}`;
-
+// Temp duplicate
 /**
  * Select a definition based on given sex.
  *

--- a/src/modules/person/prefix.ts
+++ b/src/modules/person/prefix.ts
@@ -1,0 +1,24 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random person prefix.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param sex The optional sex to use. Can be either `'female'` or `'male'`.
+ *
+ * @example
+ * prefix(fakerCore) // 'Miss'
+ * prefix(fakerCore, 'female') // 'Ms.'
+ * prefix(fakerCore, 'male') // 'Mr.'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function prefix(fakerCore: FakerCore, sex?: SexType): string {
+  return arrayElement(
+    fakerCore,
+    selectDefinition(fakerCore, sex, fakerCore.locale.person.prefix)
+  );
+}

--- a/src/modules/person/prefix.ts
+++ b/src/modules/person/prefix.ts
@@ -1,5 +1,7 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
+import { selectDefinition } from './_select-definition';
+import type { SexType } from './sex-type';
 
 /**
  * Returns a random person prefix.

--- a/src/modules/person/sex-type.ts
+++ b/src/modules/person/sex-type.ts
@@ -1,0 +1,44 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+import { enumValue } from '../helpers/enum-value';
+
+/**
+ * Returns a random sex type. The `SexType` is intended to be used in parameters and conditions.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.includeGeneric Whether `'generic'` should be included in the potential outputs.
+ * If `false`, this method only returns `'female'` and `'male'`.
+ * Default is `false`.
+ *
+ * @see gender(fakerCore): For generating a gender related value in forms.
+ * @see sex(fakerCore): For generating a binary-gender value in forms.
+ *
+ * @example
+ * sexType(fakerCore) // Sex.Female
+ * sexType(fakerCore, { includeGeneric: true }) // Sex.Generic
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function sexType(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * Whether `'generic'` should be included in the potential outputs.
+     * If `false`, this method only returns `'female'` and `'male'`.
+     *
+     * @default false
+     */
+    includeGeneric?: boolean;
+  } = {}
+): SexType {
+  const { includeGeneric = false } = options;
+
+  if (includeGeneric) {
+    return enumValue(fakerCore, Sex);
+  }
+
+  return arrayElement(fakerCore, [Sex.Female, Sex.Male]);
+}

--- a/src/modules/person/sex-type.ts
+++ b/src/modules/person/sex-type.ts
@@ -3,6 +3,29 @@ import { arrayElement } from '../helpers/array-element';
 import { enumValue } from '../helpers/enum-value';
 
 /**
+ * The enum for values corresponding to a person's sex.
+ */
+export enum Sex {
+  /**
+   * Is used for values that are primarily attributable to only females.
+   */
+  Female = 'female',
+  /**
+   * Is used for values that cannot clearly be attributed to a specific sex or are used for both sexes.
+   */
+  Generic = 'generic',
+  /**
+   * Is used for values that are primarily attributable to only males.
+   */
+  Male = 'male',
+}
+
+/**
+ * The parameter type for values corresponding to a person's sex.
+ */
+export type SexType = `${Sex}`;
+
+/**
  * Returns a random sex type. The `SexType` is intended to be used in parameters and conditions.
  *
  * @param fakerCore The FakerCore to use.

--- a/src/modules/person/sex.ts
+++ b/src/modules/person/sex.ts
@@ -1,0 +1,24 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random sex.
+ *
+ * Output of this method is localised, so it should not be used to fill the parameter `sex`
+ * available in some other modules for example `firstName(fakerCore)`.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @see gender(fakerCore): For generating a gender related value.
+ * @see sexType(fakerCore): For generating a sex value to be used as a parameter.
+ *
+ * @example
+ * sex(fakerCore) // 'female'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function sex(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.person.sex);
+}

--- a/src/modules/person/suffix.ts
+++ b/src/modules/person/suffix.ts
@@ -1,0 +1,19 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random person suffix.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * suffix(fakerCore) // 'DDS'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function suffix(fakerCore: FakerCore): string {
+  // TODO @Shinigami92 2022-03-21: Add female_suffix and male_suffix
+  return arrayElement(fakerCore, fakerCore.locale.person.suffix);
+}

--- a/src/modules/person/zodiac-sign.ts
+++ b/src/modules/person/zodiac-sign.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random zodiac sign.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * zodiacSign(fakerCore) // 'Pisces'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function zodiacSign(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.person.western_zodiac_sign);
+}

--- a/test/scripts/apidocs/verify-jsdoc-tags.spec.ts
+++ b/test/scripts/apidocs/verify-jsdoc-tags.spec.ts
@@ -186,8 +186,6 @@ ${examples}`;
                   const content = [];
 
                   const hasFakerCore = examples.includes('fakerCore');
-                  // TODO @ST-DDT 2026-04-19: Remove when past is migrated to SMF
-                  const hasTempPast = examples.includes('past(fakerCore');
 
                   if (hasFakerCore) {
                     rootImports.delete('fakerCore');
@@ -195,21 +193,14 @@ ${examples}`;
                     rootImports.add('en');
                   }
 
-                  if (hasTempPast) {
-                    rootImports.add('SimpleFaker');
-                  }
-
                   if (functionImports.length > 0) {
                     content.push(
                       '// functionImports',
 
-                      ...functionImports
-                        // TODO @ST-DDT 2026-04-19: Remove when past is migrated to SMF
-                        .filter(([functionName]) => functionName !== 'past')
-                        .map(
-                          ([functionName, importPath]) =>
-                            `import { ${functionName} } from '${importPath}';`
-                        )
+                      ...functionImports.map(
+                        ([functionName, importPath]) =>
+                          `import { ${functionName} } from '${importPath}';`
+                      )
                     );
                   }
 
@@ -225,12 +216,6 @@ ${examples}`;
                       '// fakerCore',
                       `import { createFakerCore } from '${relativeImportPath}/core';`,
                       `const fakerCore = createFakerCore({ locale: [en, base] });`
-                    );
-                  }
-
-                  if (hasTempPast) {
-                    content.push(
-                      'const past = new SimpleFaker(fakerCore).date.past;'
                     );
                   }
 


### PR DESCRIPTION
Continuation of #4032

- #4032

---

Transforms the person module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next (after the date module has been merged)
2. Run `pnpm tsx scripts/temp-transform-once.ts person`
4. Cherry-pick `refactor: transform person module`
5. Cherry-pick `chore: allow person module`
6. Run `pnpm run generate:module-tree` or `pnpm run generate:module-tree date`