### PR TITLE
infra: enable import/no-duplicates lint rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
     //#region import
     // name: 'import overrides'
     'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+    'import/no-duplicates': 'error',
     //#endregion
 
     //#region typescript


### PR DESCRIPTION
I randomly ran across this issue in one of my scripts.

Prevents:

````ts
import {  newFakerOptionsLocaleType } from './type'; // ⚠️ Duplicate import
import type { RawApiDocsType } from './type';
import {  isOptionsLikeType } from './type';
````

