### PR TITLE
infra: revert oxfmt config changes

### DIFF
--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -14,12 +14,9 @@ export const formatOptions: FormatConfig = {
   printWidth: 80,
   sortImports: {
     groups: [
-      ['type-builtin', 'value-builtin'],
-      ['type-external', 'value-external'],
-      ['type-internal', 'value-internal'],
-      ['type-parent', 'value-parent'],
-      ['type-sibling', 'value-sibling'],
-      ['type-index', 'value-index'],
+      ['builtin', 'external', 'internal'],
+      { newlinesBetween: false },
+      ['parent', 'sibling', 'index'],
     ],
     newlinesBetween: false,
     order: 'asc',


### PR DESCRIPTION
Cleanup oxfmt config, because the previous changes did not work as expected.

Elements inside nested arrays are treated as the same level, thus splitting type imports from value imports doesn't have an impact.