### PR TITLE
docs: expose createFakerCore in apidocs

### DIFF
--- a/scripts/apidocs/processing/method.ts
+++ b/scripts/apidocs/processing/method.ts
@@ -137,8 +137,10 @@ function getAllFunctions(
 
 export function processUtilityFunctions(project: Project): RawApiDocsMethod[] {
   return processMethodLikes(
-    Object.values(getAllFunctions(project)).filter((fn) =>
-      fn.getSourceFile().getFilePath().includes('/src/utils/')
+    Object.values(getAllFunctions(project)).filter(
+      (fn) =>
+        fn.getSourceFile().getFilePath().includes('/src/utils/') ||
+        fn.getSourceFile().getFilePath().includes('/src/core.ts')
     ),
     (f) => f.getNameOrThrow()
   );

--- a/test/scripts/apidocs/__snapshots__/verify-jsdoc-tags.spec.ts.snap
+++ b/test/scripts/apidocs/__snapshots__/verify-jsdoc-tags.spec.ts.snap
@@ -36,6 +36,7 @@ exports[`check docs completeness > all modules and methods are present 1`] = `
   [
     "utils",
     [
+      "createFakerCore",
       "generateMersenne32Randomizer",
       "generateMersenne53Randomizer",
       "getDefaultRefDate",


### PR DESCRIPTION
We expose `createFakerCore` as public API, but don't mention it in our apidocs.

https://github.com/faker-js/faker/blob/0e0c2b7b187fa59bc411b7e60a32897e745bba6b/src/index.ts#L2

I added it to the utils page, although it isn't in the utils folder.

Preview:

- https://deploy-preview-4040.fakerjs.dev/api/utils.html#createfakercore

---

Alternatively, move it into utils.

