### PR TITLE
chore: add explicit default to SimpleFaker constructor

### DIFF
--- a/src/simple-faker.ts
+++ b/src/simple-faker.ts
@@ -118,7 +118,7 @@ export class SimpleFaker {
    *
    * @since 8.1.0
    */
-  constructor(options?: FakerOptions) {
+  constructor(options: FakerOptions = {}) {
     this.fakerCore = createFakerCore(options);
   }
 


### PR DESCRIPTION
Most of our optional `option` objects have an explicit empty default object.
We could apply the same for the `SimpleFaker` constructor.
This mainly affects the documentation and doesn't have an impact on the usage or functionality.

### Preview

| Old | New |
| --- | --- |
| [Docs](https://fakerjs.dev/api/simpleFaker.html#constructor) | [Docs](https://deploy-preview-4041.fakerjs.dev/api/simpleFaker.html#constructor) |
| <img width="688" height="135" alt="grafik" src="https://github.com/user-attachments/assets/c8bd02f6-4fae-4b25-8bd7-49df42f0ce55" /> | <img width="688" height="135" alt="grafik" src="https://github.com/user-attachments/assets/6067ddb2-8baa-480e-96fa-d6d45a0b91c6" /> |