### PR TITLE
docs: explode FakerOptions constructor parameter

### DIFF
--- a/scripts/apidocs/processing/parameter.ts
+++ b/scripts/apidocs/processing/parameter.ts
@@ -27,6 +27,7 @@ import {
   getTypeText,
   isOptionsLikeType,
   isRangeType,
+  newFakerOptionsLocaleType,
 } from './type';
 
 /**
@@ -248,14 +249,24 @@ function processComplexParameterProperty(
     ? getDescription(memberTag)
     : getDescription(jsdocs);
 
+  let typeText = getTypeText(propertyType, {
+    abbreviate: false,
+    stripUndefined: true,
+  });
+
+  if (
+    declaration.getName() === 'locale' &&
+    declaration.getParent()?.getType().getSymbol()?.getName() === 'FakerOptions'
+  ) {
+    // Prevent the 'LocaleProxy' type from being exploded into unreadable mess.
+    typeText = newFakerOptionsLocaleType();
+  }
+
   return [
     {
       name: `${name}.${parameter.getName()}${getNameSuffix(propertyType)}`,
       type: attachShadowTypeDescriptions(
-        getTypeText(propertyType, {
-          abbreviate: false,
-          stripUndefined: true,
-        }),
+        typeText,
         getShadowTypeDescriptions(declaration.getTypeNode())
       ),
       default: getDefault(jsdocs) ?? extractSummaryDefault(description),

--- a/scripts/apidocs/processing/type.ts
+++ b/scripts/apidocs/processing/type.ts
@@ -201,10 +201,11 @@ export function getTypeText(
 
 export function isOptionsLikeType(type: Type): boolean {
   return (
-    type.isObject() &&
-    type.isAnonymous() &&
-    type.getCallSignatures().length === 0 &&
-    type.getTupleElements().length === 0
+    (type.isObject() &&
+      type.isAnonymous() &&
+      type.getCallSignatures().length === 0 &&
+      type.getTupleElements().length === 0) ||
+    (type.getSymbol() ?? type.getAliasSymbol())?.getName() === 'FakerOptions'
   );
 }
 
@@ -389,4 +390,17 @@ function newShadowType(
     resolvedType,
     text: displayText,
   };
+}
+
+/**
+ * Helper to create a type for `FakerOptions.locale` as `LocaleProxy` gets exploded into an unreadable mess by TypeScript.
+ *
+ * @returns RawApiDocsUnionType
+ */
+export function newFakerOptionsLocaleType(): RawApiDocsUnionType {
+  return newUnionType([
+    newSimpleType('LocaleProxy'),
+    newSimpleType('LocaleDefinition'),
+    newArrayType(newSimpleType('LocaleDefinition')),
+  ]);
 }


### PR DESCRIPTION
Treat the `FakerOptions` constructor parameter as an `options` type and document nested properties.

| v9 | v10 | New |
| --- | --- | --- |
| [Docs](https://v9.fakerjs.dev/api/simpleFaker.html#constructor) | [Docs](https://v10.fakerjs.dev/api/simpleFaker.html#constructor) | [Docs](https://deploy-preview-4042.fakerjs.dev/api/simpleFaker.html#constructor) |
| <img width="688" height="759" alt="grafik" src="https://github.com/user-attachments/assets/73e18e9d-ea9a-4a93-9091-41d373752a39" /> | <img width="688" height="135" alt="grafik" src="https://github.com/user-attachments/assets/4b8d981a-b999-4062-8bb1-dcd769fc2be0" /> | <img width="688" height="1325" alt="grafik" src="https://github.com/user-attachments/assets/fb6a883e-c51a-47d1-9b6a-ed2505a80783" /> |

This may be worth backporting to v10.
