### PR TITLE
feat(airline): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -1,4 +1,5 @@
 export const ALLOWED_MODULES = new Set([
+  'AirlineModule',
   'DatatypeModule',
   'DateModule',
   'HelpersModule',

--- a/src/definitions/airline.ts
+++ b/src/definitions/airline.ts
@@ -1,4 +1,6 @@
-import type { Airline, Airplane, Airport } from '../modules/airline';
+import type { Airline } from '../modules/airline/airline';
+import type { Airplane } from '../modules/airline/airplane';
+import type { Airport } from '../modules/airline/airport';
 import type { LocaleEntry } from './definitions';
 
 export type AirlineDefinition = LocaleEntry<{

--- a/src/modules/airline/aircraft-type.ts
+++ b/src/modules/airline/aircraft-type.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { enumValue } from '../helpers/enum-value';
+
+/**
+ * Returns a random aircraft type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * aircraftType(fakerCore) // 'narrowbody'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function aircraftType(fakerCore: FakerCore): AircraftType {
+  return enumValue(fakerCore, Aircraft);
+}

--- a/src/modules/airline/aircraft-type.ts
+++ b/src/modules/airline/aircraft-type.ts
@@ -1,6 +1,14 @@
 import type { FakerCore } from '../../core';
 import { enumValue } from '../helpers/enum-value';
 
+export enum Aircraft {
+  Narrowbody = 'narrowbody',
+  Regional = 'regional',
+  Widebody = 'widebody',
+}
+
+export type AircraftType = `${Aircraft}`;
+
 /**
  * Returns a random aircraft type.
  *

--- a/src/modules/airline/airline.ts
+++ b/src/modules/airline/airline.ts
@@ -1,6 +1,17 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export interface Airline {
+  /**
+   * The name of the airline (e.g. `'American Airlines'`).
+   */
+  readonly name: string;
+  /**
+   * The 2 character IATA code of the airline (e.g. `'AA'`).
+   */
+  readonly iataCode: string;
+}
+
 /**
  * Generates a random airline.
  *

--- a/src/modules/airline/airline.ts
+++ b/src/modules/airline/airline.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random airline.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * airline(fakerCore) // { name: 'American Airlines', iataCode: 'AA' }
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function airline(fakerCore: FakerCore): Airline {
+  return arrayElement(fakerCore, fakerCore.locale.airline.airline);
+}

--- a/src/modules/airline/airplane.ts
+++ b/src/modules/airline/airplane.ts
@@ -1,6 +1,17 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export interface Airplane {
+  /**
+   * The name of the airplane (e.g. `'Airbus A321'`).
+   */
+  readonly name: string;
+  /**
+   * The IATA code of the airplane (e.g. `'321'`).
+   */
+  readonly iataTypeCode: string;
+}
+
 /**
  * Generates a random airplane.
  *

--- a/src/modules/airline/airplane.ts
+++ b/src/modules/airline/airplane.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random airplane.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * airplane(fakerCore) // { name: 'Airbus A321neo', iataTypeCode: '32Q' }
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function airplane(fakerCore: FakerCore): Airplane {
+  return arrayElement(fakerCore, fakerCore.locale.airline.airplane);
+}

--- a/src/modules/airline/airport.ts
+++ b/src/modules/airline/airport.ts
@@ -1,6 +1,17 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export interface Airport {
+  /**
+   * The name of the airport (e.g. `'Dallas Fort Worth International Airport'`).
+   */
+  readonly name: string;
+  /**
+   * The IATA code of the airport (e.g. `'DFW'`).
+   */
+  readonly iataCode: string;
+}
+
 /**
  * Generates a random airport.
  *

--- a/src/modules/airline/airport.ts
+++ b/src/modules/airline/airport.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random airport.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * airport(fakerCore) // { name: 'Dallas Fort Worth International Airport', iataCode: 'DFW' }
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function airport(fakerCore: FakerCore): Airport {
+  return arrayElement(fakerCore, fakerCore.locale.airline.airport);
+}

--- a/src/modules/airline/flight-number.ts
+++ b/src/modules/airline/flight-number.ts
@@ -1,0 +1,56 @@
+import type { FakerCore } from '../../core';
+import type { NumberOrRange } from '../../utils/types';
+import { numeric } from '../string/numeric';
+
+/**
+ * Returns a random flight number. Flight numbers are always 1 to 4 digits long. Sometimes they are
+ * used without leading zeros (e.g.: `American Airlines flight 425`) and sometimes with leading
+ * zeros, often with the airline code prepended (e.g.: `AA0425`).
+ *
+ * To generate a flight number prepended with an airline code, combine this function with the
+ * `airline()` function and use template literals:
+ * ```
+ * `${airline(fakerCore).iataCode}${flightNumber(fakerCore, { addLeadingZeros: true })}` // 'AA0798'
+ * ```
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use.
+ * @param options.length The number or range of digits to generate. Defaults to `{ min: 1, max: 4 }`.
+ * @param options.addLeadingZeros Whether to pad the flight number up to 4 digits with leading zeros. Defaults to `false`.
+ *
+ * @example
+ * flightNumber(fakerCore) // '2405'
+ * flightNumber(fakerCore, { addLeadingZeros: true }) // '0249'
+ * flightNumber(fakerCore, { addLeadingZeros: true, length: 2 }) // '0042'
+ * flightNumber(fakerCore, { addLeadingZeros: true, length: { min: 2, max: 3 } }) // '0624'
+ * flightNumber(fakerCore, { length: 3 }) // '425'
+ * flightNumber(fakerCore, { length: { min: 2, max: 3 } }) // '84'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function flightNumber(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The number or range of digits to generate.
+     *
+     * @default { min: 1, max: 4 }
+     */
+    length?: NumberOrRange;
+    /**
+     * Whether to pad the flight number up to 4 digits with leading zeros.
+     *
+     * @default false
+     */
+    addLeadingZeros?: boolean;
+  } = {}
+): string {
+  const { length = { min: 1, max: 4 }, addLeadingZeros = false } = options;
+  const flightNumber = numeric(fakerCore, {
+    length,
+    allowLeadingZeros: false,
+  });
+  return addLeadingZeros ? flightNumber.padStart(4, '0') : flightNumber;
+}

--- a/src/modules/airline/index.ts
+++ b/src/modules/airline/index.ts
@@ -1,1 +1,12 @@
+/**
+ * IATA stands for [International Air Transport Association](https://iata.org).
+ * It's the trade association for the world's airlines and it is
+ * responsible for setting standards relating to many aspects of airline
+ * operations.
+ */
+export { Aircraft } from './aircraft-type';
+export type { AircraftType } from './aircraft-type';
+export type { Airline } from './airline';
+export type { Airplane } from './airplane';
+export type { Airport } from './airport';
 export * from './module';

--- a/src/modules/airline/module.ts
+++ b/src/modules/airline/module.ts
@@ -1,59 +1,12 @@
 import { ModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
-
-export enum Aircraft {
-  Narrowbody = 'narrowbody',
-  Regional = 'regional',
-  Widebody = 'widebody',
-}
-
-export type AircraftType = `${Aircraft}`;
-
-export interface Airline {
-  /**
-   * The name of the airline (e.g. `'American Airlines'`).
-   */
-  readonly name: string;
-  /**
-   * The 2 character [IATA](https://iata.org) code of the airline (e.g. `'AA'`).
-   */
-  readonly iataCode: string;
-}
-
-export interface Airplane {
-  /**
-   * The name of the airplane (e.g. `'Airbus A321'`).
-   */
-  readonly name: string;
-  /**
-   * The [IATA](https://iata.org) code of the airplane (e.g. `'321'`).
-   */
-  readonly iataTypeCode: string;
-}
-
-export interface Airport {
-  /**
-   * The name of the airport (e.g. `'Dallas Fort Worth International Airport'`).
-   */
-  readonly name: string;
-  /**
-   * The [IATA](https://iata.org) code of the airport (e.g. `'DFW'`).
-   */
-  readonly iataCode: string;
-}
-
-const numerics = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-const visuallySimilarCharacters = ['0', 'O', '1', 'I', 'L'];
-const aircraftTypeMaxRows: Record<AircraftType, number> = {
-  regional: 20,
-  narrowbody: 35,
-  widebody: 60,
-};
-const aircraftTypeSeats: Record<AircraftType, string[]> = {
-  regional: ['A', 'B', 'C', 'D'],
-  narrowbody: ['A', 'B', 'C', 'D', 'E', 'F'],
-  widebody: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K'],
-};
+import type { AircraftType } from './aircraft-type';
+import { Aircraft } from './aircraft-type';
+import type { Airline } from './airline';
+import type { Airplane } from './airplane';
+import type { Airport } from './airport';
+import { numerics, visuallySimilarCharacters } from './record-locator';
+import { aircraftTypeMaxRows, aircraftTypeSeats } from './seat';
 
 /**
  * Module to generate airline and airport related data according to [International Air Transport Association (IATA)](https://iata.org) standards.

--- a/src/modules/airline/module.ts
+++ b/src/modules/airline/module.ts
@@ -1,12 +1,16 @@
 import { ModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
 import type { AircraftType } from './aircraft-type';
-import { Aircraft } from './aircraft-type';
+import { aircraftType as airlineAircraftType } from './aircraft-type';
 import type { Airline } from './airline';
+import { airline as airlineAirline } from './airline';
 import type { Airplane } from './airplane';
+import { airplane as airlineAirplane } from './airplane';
 import type { Airport } from './airport';
-import { numerics, visuallySimilarCharacters } from './record-locator';
-import { aircraftTypeMaxRows, aircraftTypeSeats } from './seat';
+import { airport as airlineAirport } from './airport';
+import { flightNumber as airlineFlightNumber } from './flight-number';
+import { recordLocator as airlineRecordLocator } from './record-locator';
+import { seat as airlineSeat } from './seat';
 
 /**
  * Module to generate airline and airport related data according to [International Air Transport Association (IATA)](https://iata.org) standards.
@@ -26,6 +30,11 @@ import { aircraftTypeMaxRows, aircraftTypeSeats } from './seat';
  * - To generate sample passenger data, you can use the methods of the [`faker.person`](https://fakerjs.dev/api/person.html) module.
  */
 export class AirlineModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree airline' to update the methods from their respective files.
+   */
+
   /**
    * Generates a random airport.
    *
@@ -35,9 +44,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airport(): Airport {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.airline.airport
-    );
+    return airlineAirport(this.faker.fakerCore);
   }
 
   /**
@@ -49,9 +56,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airline(): Airline {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.airline.airline
-    );
+    return airlineAirline(this.faker.fakerCore);
   }
 
   /**
@@ -63,9 +68,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airplane(): Airplane {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.airline.airplane
-    );
+    return airlineAirplane(this.faker.fakerCore);
   }
 
   /**
@@ -101,22 +104,7 @@ export class AirlineModule extends ModuleBase {
       allowVisuallySimilarCharacters?: boolean;
     } = {}
   ): string {
-    const { allowNumerics = false, allowVisuallySimilarCharacters = false } =
-      options;
-    const excludedChars: string[] = [];
-    if (!allowNumerics) {
-      excludedChars.push(...numerics);
-    }
-
-    if (!allowVisuallySimilarCharacters) {
-      excludedChars.push(...visuallySimilarCharacters);
-    }
-
-    return this.faker.string.alphanumeric({
-      length: 6,
-      casing: 'upper',
-      exclude: excludedChars,
-    });
+    return airlineRecordLocator(this.faker.fakerCore, options);
   }
 
   /**
@@ -142,12 +130,7 @@ export class AirlineModule extends ModuleBase {
       aircraftType?: AircraftType;
     } = {}
   ): string {
-    const { aircraftType = Aircraft.Narrowbody } = options;
-    const maxRow = aircraftTypeMaxRows[aircraftType];
-    const allowedSeats = aircraftTypeSeats[aircraftType];
-    const row = this.faker.number.int({ min: 1, max: maxRow });
-    const seat = this.faker.helpers.arrayElement(allowedSeats);
-    return `${row}${seat}`;
+    return airlineSeat(this.faker.fakerCore, options);
   }
 
   /**
@@ -159,7 +142,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   aircraftType(): AircraftType {
-    return this.faker.helpers.enumValue(Aircraft);
+    return airlineAircraftType(this.faker.fakerCore);
   }
 
   /**
@@ -203,11 +186,6 @@ export class AirlineModule extends ModuleBase {
       addLeadingZeros?: boolean;
     } = {}
   ): string {
-    const { length = { min: 1, max: 4 }, addLeadingZeros = false } = options;
-    const flightNumber = this.faker.string.numeric({
-      length,
-      allowLeadingZeros: false,
-    });
-    return addLeadingZeros ? flightNumber.padStart(4, '0') : flightNumber;
+    return airlineFlightNumber(this.faker.fakerCore, options);
   }
 }

--- a/src/modules/airline/record-locator.ts
+++ b/src/modules/airline/record-locator.ts
@@ -1,0 +1,57 @@
+import type { FakerCore } from '../../core';
+import { alphanumeric } from '../string/alphanumeric';
+
+/**
+ * Generates a random [record locator](https://en.wikipedia.org/wiki/Record_locator). Record locators
+ * are used by airlines to identify reservations. They're also known as booking reference numbers,
+ * locator codes, confirmation codes, or reservation codes.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use.
+ * @param options.allowNumerics Whether to allow numeric characters. Defaults to `false`.
+ * @param options.allowVisuallySimilarCharacters Whether to allow visually similar characters such as '1' and 'I'. Defaults to `false`.
+ *
+ * @example
+ * recordLocator(fakerCore) // 'KIFRWE'
+ * recordLocator(fakerCore, { allowNumerics: true }) // 'E5TYEM'
+ * recordLocator(fakerCore, { allowVisuallySimilarCharacters: true }) // 'ANZNEI'
+ * recordLocator(fakerCore, { allowNumerics: true, allowVisuallySimilarCharacters: true }) // '1Z2Z3E'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function recordLocator(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * Whether to allow numeric characters.
+     *
+     * @default false
+     */
+    allowNumerics?: boolean;
+    /**
+     * Whether to allow visually similar characters such as '1' and 'I'.
+     *
+     * @default false
+     */
+    allowVisuallySimilarCharacters?: boolean;
+  } = {}
+): string {
+  const { allowNumerics = false, allowVisuallySimilarCharacters = false } =
+    options;
+  const excludedChars: string[] = [];
+  if (!allowNumerics) {
+    excludedChars.push(...numerics);
+  }
+
+  if (!allowVisuallySimilarCharacters) {
+    excludedChars.push(...visuallySimilarCharacters);
+  }
+
+  return alphanumeric(fakerCore, {
+    length: 6,
+    casing: 'upper',
+    exclude: excludedChars,
+  });
+}

--- a/src/modules/airline/record-locator.ts
+++ b/src/modules/airline/record-locator.ts
@@ -1,6 +1,11 @@
 import type { FakerCore } from '../../core';
 import { alphanumeric } from '../string/alphanumeric';
 
+// Temp export
+export const numerics = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+// Temp export
+export const visuallySimilarCharacters = ['0', 'O', '1', 'I', 'L'];
+
 /**
  * Generates a random [record locator](https://en.wikipedia.org/wiki/Record_locator). Record locators
  * are used by airlines to identify reservations. They're also known as booking reference numbers,

--- a/src/modules/airline/record-locator.ts
+++ b/src/modules/airline/record-locator.ts
@@ -1,10 +1,8 @@
 import type { FakerCore } from '../../core';
 import { alphanumeric } from '../string/alphanumeric';
 
-// Temp export
-export const numerics = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-// Temp export
-export const visuallySimilarCharacters = ['0', 'O', '1', 'I', 'L'];
+const numerics = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+const visuallySimilarCharacters = ['0', 'O', '1', 'I', 'L'];
 
 /**
  * Generates a random [record locator](https://en.wikipedia.org/wiki/Record_locator). Record locators

--- a/src/modules/airline/seat.ts
+++ b/src/modules/airline/seat.ts
@@ -1,0 +1,38 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+import { int } from '../number/int';
+
+/**
+ * Generates a random seat.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use.
+ * @param options.aircraftType The aircraft type. Can be one of `narrowbody`, `regional`, `widebody`. Defaults to `narrowbody`.
+ *
+ * @example
+ * seat(fakerCore) // '22C'
+ * seat(fakerCore, { aircraftType: 'regional' }) // '7A'
+ * seat(fakerCore, { aircraftType: 'widebody' }) // '42K'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function seat(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The aircraft type. Can be one of `narrowbody`, `regional`, `widebody`.
+     *
+     * @default 'narrowbody'
+     */
+    aircraftType?: AircraftType;
+  } = {}
+): string {
+  const { aircraftType = Aircraft.Narrowbody } = options;
+  const maxRow = aircraftTypeMaxRows[aircraftType];
+  const allowedSeats = aircraftTypeSeats[aircraftType];
+  const row = int(fakerCore, { min: 1, max: maxRow });
+  const seat = arrayElement(fakerCore, allowedSeats);
+  return `${row}${seat}`;
+}

--- a/src/modules/airline/seat.ts
+++ b/src/modules/airline/seat.ts
@@ -1,6 +1,21 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 import { int } from '../number/int';
+import type { AircraftType } from './aircraft-type';
+import { Aircraft } from './aircraft-type';
+
+// Temp export
+export const aircraftTypeMaxRows: Record<AircraftType, number> = {
+  regional: 20,
+  narrowbody: 35,
+  widebody: 60,
+};
+// Temp export
+export const aircraftTypeSeats: Record<AircraftType, string[]> = {
+  regional: ['A', 'B', 'C', 'D'],
+  narrowbody: ['A', 'B', 'C', 'D', 'E', 'F'],
+  widebody: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K'],
+};
 
 /**
  * Generates a random seat.

--- a/src/modules/airline/seat.ts
+++ b/src/modules/airline/seat.ts
@@ -4,14 +4,12 @@ import { int } from '../number/int';
 import type { AircraftType } from './aircraft-type';
 import { Aircraft } from './aircraft-type';
 
-// Temp export
-export const aircraftTypeMaxRows: Record<AircraftType, number> = {
+const aircraftTypeMaxRows: Record<AircraftType, number> = {
   regional: 20,
   narrowbody: 35,
   widebody: 60,
 };
-// Temp export
-export const aircraftTypeSeats: Record<AircraftType, string[]> = {
+const aircraftTypeSeats: Record<AircraftType, string[]> = {
   regional: ['A', 'B', 'C', 'D'],
   narrowbody: ['A', 'B', 'C', 'D', 'E', 'F'],
   widebody: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K'],


### PR DESCRIPTION
Continuation of #4033

- #4033

---

Transforms the airline module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts airline`
4. Cherry-pick `refactor: transform airline module`
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. Cherry-pick `chore: remove temp exports`