### PR TITLE
feat(animal): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -1,5 +1,6 @@
 export const ALLOWED_MODULES = new Set([
   'AirlineModule',
+  'AnimalModule',
   'DatatypeModule',
   'DateModule',
   'HelpersModule',

--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -1,4 +1,5 @@
 export const ALLOWED_MODULES = new Set([
+  'AirlineModule',
   'DatatypeModule',
   'DateModule',
   'HelpersModule',

--- a/src/definitions/airline.ts
+++ b/src/definitions/airline.ts
@@ -1,4 +1,6 @@
-import type { Airline, Airplane, Airport } from '../modules/airline';
+import type { Airline } from '../modules/airline/airline';
+import type { Airplane } from '../modules/airline/airplane';
+import type { Airport } from '../modules/airline/airport';
 import type { LocaleEntry } from './definitions';
 
 export type AirlineDefinition = LocaleEntry<{

--- a/src/modules/airline/aircraft-type.ts
+++ b/src/modules/airline/aircraft-type.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { enumValue } from '../helpers/enum-value';
+
+/**
+ * Returns a random aircraft type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * aircraftType(fakerCore) // 'narrowbody'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function aircraftType(fakerCore: FakerCore): AircraftType {
+  return enumValue(fakerCore, Aircraft);
+}

--- a/src/modules/airline/aircraft-type.ts
+++ b/src/modules/airline/aircraft-type.ts
@@ -1,6 +1,14 @@
 import type { FakerCore } from '../../core';
 import { enumValue } from '../helpers/enum-value';
 
+export enum Aircraft {
+  Narrowbody = 'narrowbody',
+  Regional = 'regional',
+  Widebody = 'widebody',
+}
+
+export type AircraftType = `${Aircraft}`;
+
 /**
  * Returns a random aircraft type.
  *

--- a/src/modules/airline/airline.ts
+++ b/src/modules/airline/airline.ts
@@ -1,6 +1,17 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export interface Airline {
+  /**
+   * The name of the airline (e.g. `'American Airlines'`).
+   */
+  readonly name: string;
+  /**
+   * The 2 character IATA code of the airline (e.g. `'AA'`).
+   */
+  readonly iataCode: string;
+}
+
 /**
  * Generates a random airline.
  *

--- a/src/modules/airline/airline.ts
+++ b/src/modules/airline/airline.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random airline.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * airline(fakerCore) // { name: 'American Airlines', iataCode: 'AA' }
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function airline(fakerCore: FakerCore): Airline {
+  return arrayElement(fakerCore, fakerCore.locale.airline.airline);
+}

--- a/src/modules/airline/airplane.ts
+++ b/src/modules/airline/airplane.ts
@@ -1,6 +1,17 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export interface Airplane {
+  /**
+   * The name of the airplane (e.g. `'Airbus A321'`).
+   */
+  readonly name: string;
+  /**
+   * The IATA code of the airplane (e.g. `'321'`).
+   */
+  readonly iataTypeCode: string;
+}
+
 /**
  * Generates a random airplane.
  *

--- a/src/modules/airline/airplane.ts
+++ b/src/modules/airline/airplane.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random airplane.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * airplane(fakerCore) // { name: 'Airbus A321neo', iataTypeCode: '32Q' }
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function airplane(fakerCore: FakerCore): Airplane {
+  return arrayElement(fakerCore, fakerCore.locale.airline.airplane);
+}

--- a/src/modules/airline/airport.ts
+++ b/src/modules/airline/airport.ts
@@ -1,6 +1,17 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export interface Airport {
+  /**
+   * The name of the airport (e.g. `'Dallas Fort Worth International Airport'`).
+   */
+  readonly name: string;
+  /**
+   * The IATA code of the airport (e.g. `'DFW'`).
+   */
+  readonly iataCode: string;
+}
+
 /**
  * Generates a random airport.
  *

--- a/src/modules/airline/airport.ts
+++ b/src/modules/airline/airport.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random airport.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * airport(fakerCore) // { name: 'Dallas Fort Worth International Airport', iataCode: 'DFW' }
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function airport(fakerCore: FakerCore): Airport {
+  return arrayElement(fakerCore, fakerCore.locale.airline.airport);
+}

--- a/src/modules/airline/flight-number.ts
+++ b/src/modules/airline/flight-number.ts
@@ -1,0 +1,56 @@
+import type { FakerCore } from '../../core';
+import type { NumberOrRange } from '../../utils/types';
+import { numeric } from '../string/numeric';
+
+/**
+ * Returns a random flight number. Flight numbers are always 1 to 4 digits long. Sometimes they are
+ * used without leading zeros (e.g.: `American Airlines flight 425`) and sometimes with leading
+ * zeros, often with the airline code prepended (e.g.: `AA0425`).
+ *
+ * To generate a flight number prepended with an airline code, combine this function with the
+ * `airline()` function and use template literals:
+ * ```
+ * `${airline(fakerCore).iataCode}${flightNumber(fakerCore, { addLeadingZeros: true })}` // 'AA0798'
+ * ```
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use.
+ * @param options.length The number or range of digits to generate. Defaults to `{ min: 1, max: 4 }`.
+ * @param options.addLeadingZeros Whether to pad the flight number up to 4 digits with leading zeros. Defaults to `false`.
+ *
+ * @example
+ * flightNumber(fakerCore) // '2405'
+ * flightNumber(fakerCore, { addLeadingZeros: true }) // '0249'
+ * flightNumber(fakerCore, { addLeadingZeros: true, length: 2 }) // '0042'
+ * flightNumber(fakerCore, { addLeadingZeros: true, length: { min: 2, max: 3 } }) // '0624'
+ * flightNumber(fakerCore, { length: 3 }) // '425'
+ * flightNumber(fakerCore, { length: { min: 2, max: 3 } }) // '84'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function flightNumber(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The number or range of digits to generate.
+     *
+     * @default { min: 1, max: 4 }
+     */
+    length?: NumberOrRange;
+    /**
+     * Whether to pad the flight number up to 4 digits with leading zeros.
+     *
+     * @default false
+     */
+    addLeadingZeros?: boolean;
+  } = {}
+): string {
+  const { length = { min: 1, max: 4 }, addLeadingZeros = false } = options;
+  const flightNumber = numeric(fakerCore, {
+    length,
+    allowLeadingZeros: false,
+  });
+  return addLeadingZeros ? flightNumber.padStart(4, '0') : flightNumber;
+}

--- a/src/modules/airline/index.ts
+++ b/src/modules/airline/index.ts
@@ -1,1 +1,12 @@
+/**
+ * IATA stands for [International Air Transport Association](https://iata.org).
+ * It's the trade association for the world's airlines and it is
+ * responsible for setting standards relating to many aspects of airline
+ * operations.
+ */
+export { Aircraft } from './aircraft-type';
+export type { AircraftType } from './aircraft-type';
+export type { Airline } from './airline';
+export type { Airplane } from './airplane';
+export type { Airport } from './airport';
 export * from './module';

--- a/src/modules/airline/module.ts
+++ b/src/modules/airline/module.ts
@@ -1,59 +1,12 @@
 import { ModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
-
-export enum Aircraft {
-  Narrowbody = 'narrowbody',
-  Regional = 'regional',
-  Widebody = 'widebody',
-}
-
-export type AircraftType = `${Aircraft}`;
-
-export interface Airline {
-  /**
-   * The name of the airline (e.g. `'American Airlines'`).
-   */
-  readonly name: string;
-  /**
-   * The 2 character [IATA](https://iata.org) code of the airline (e.g. `'AA'`).
-   */
-  readonly iataCode: string;
-}
-
-export interface Airplane {
-  /**
-   * The name of the airplane (e.g. `'Airbus A321'`).
-   */
-  readonly name: string;
-  /**
-   * The [IATA](https://iata.org) code of the airplane (e.g. `'321'`).
-   */
-  readonly iataTypeCode: string;
-}
-
-export interface Airport {
-  /**
-   * The name of the airport (e.g. `'Dallas Fort Worth International Airport'`).
-   */
-  readonly name: string;
-  /**
-   * The [IATA](https://iata.org) code of the airport (e.g. `'DFW'`).
-   */
-  readonly iataCode: string;
-}
-
-const numerics = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-const visuallySimilarCharacters = ['0', 'O', '1', 'I', 'L'];
-const aircraftTypeMaxRows: Record<AircraftType, number> = {
-  regional: 20,
-  narrowbody: 35,
-  widebody: 60,
-};
-const aircraftTypeSeats: Record<AircraftType, string[]> = {
-  regional: ['A', 'B', 'C', 'D'],
-  narrowbody: ['A', 'B', 'C', 'D', 'E', 'F'],
-  widebody: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K'],
-};
+import type { AircraftType } from './aircraft-type';
+import { Aircraft } from './aircraft-type';
+import type { Airline } from './airline';
+import type { Airplane } from './airplane';
+import type { Airport } from './airport';
+import { numerics, visuallySimilarCharacters } from './record-locator';
+import { aircraftTypeMaxRows, aircraftTypeSeats } from './seat';
 
 /**
  * Module to generate airline and airport related data according to [International Air Transport Association (IATA)](https://iata.org) standards.

--- a/src/modules/airline/module.ts
+++ b/src/modules/airline/module.ts
@@ -1,12 +1,16 @@
 import { ModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
 import type { AircraftType } from './aircraft-type';
-import { Aircraft } from './aircraft-type';
+import { aircraftType as airlineAircraftType } from './aircraft-type';
 import type { Airline } from './airline';
+import { airline as airlineAirline } from './airline';
 import type { Airplane } from './airplane';
+import { airplane as airlineAirplane } from './airplane';
 import type { Airport } from './airport';
-import { numerics, visuallySimilarCharacters } from './record-locator';
-import { aircraftTypeMaxRows, aircraftTypeSeats } from './seat';
+import { airport as airlineAirport } from './airport';
+import { flightNumber as airlineFlightNumber } from './flight-number';
+import { recordLocator as airlineRecordLocator } from './record-locator';
+import { seat as airlineSeat } from './seat';
 
 /**
  * Module to generate airline and airport related data according to [International Air Transport Association (IATA)](https://iata.org) standards.
@@ -26,6 +30,11 @@ import { aircraftTypeMaxRows, aircraftTypeSeats } from './seat';
  * - To generate sample passenger data, you can use the methods of the [`faker.person`](https://fakerjs.dev/api/person.html) module.
  */
 export class AirlineModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree airline' to update the methods from their respective files.
+   */
+
   /**
    * Generates a random airport.
    *
@@ -35,9 +44,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airport(): Airport {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.airline.airport
-    );
+    return airlineAirport(this.faker.fakerCore);
   }
 
   /**
@@ -49,9 +56,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airline(): Airline {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.airline.airline
-    );
+    return airlineAirline(this.faker.fakerCore);
   }
 
   /**
@@ -63,9 +68,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airplane(): Airplane {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.airline.airplane
-    );
+    return airlineAirplane(this.faker.fakerCore);
   }
 
   /**
@@ -101,22 +104,7 @@ export class AirlineModule extends ModuleBase {
       allowVisuallySimilarCharacters?: boolean;
     } = {}
   ): string {
-    const { allowNumerics = false, allowVisuallySimilarCharacters = false } =
-      options;
-    const excludedChars: string[] = [];
-    if (!allowNumerics) {
-      excludedChars.push(...numerics);
-    }
-
-    if (!allowVisuallySimilarCharacters) {
-      excludedChars.push(...visuallySimilarCharacters);
-    }
-
-    return this.faker.string.alphanumeric({
-      length: 6,
-      casing: 'upper',
-      exclude: excludedChars,
-    });
+    return airlineRecordLocator(this.faker.fakerCore, options);
   }
 
   /**
@@ -142,12 +130,7 @@ export class AirlineModule extends ModuleBase {
       aircraftType?: AircraftType;
     } = {}
   ): string {
-    const { aircraftType = Aircraft.Narrowbody } = options;
-    const maxRow = aircraftTypeMaxRows[aircraftType];
-    const allowedSeats = aircraftTypeSeats[aircraftType];
-    const row = this.faker.number.int({ min: 1, max: maxRow });
-    const seat = this.faker.helpers.arrayElement(allowedSeats);
-    return `${row}${seat}`;
+    return airlineSeat(this.faker.fakerCore, options);
   }
 
   /**
@@ -159,7 +142,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   aircraftType(): AircraftType {
-    return this.faker.helpers.enumValue(Aircraft);
+    return airlineAircraftType(this.faker.fakerCore);
   }
 
   /**
@@ -203,11 +186,6 @@ export class AirlineModule extends ModuleBase {
       addLeadingZeros?: boolean;
     } = {}
   ): string {
-    const { length = { min: 1, max: 4 }, addLeadingZeros = false } = options;
-    const flightNumber = this.faker.string.numeric({
-      length,
-      allowLeadingZeros: false,
-    });
-    return addLeadingZeros ? flightNumber.padStart(4, '0') : flightNumber;
+    return airlineFlightNumber(this.faker.fakerCore, options);
   }
 }

--- a/src/modules/airline/record-locator.ts
+++ b/src/modules/airline/record-locator.ts
@@ -1,0 +1,57 @@
+import type { FakerCore } from '../../core';
+import { alphanumeric } from '../string/alphanumeric';
+
+/**
+ * Generates a random [record locator](https://en.wikipedia.org/wiki/Record_locator). Record locators
+ * are used by airlines to identify reservations. They're also known as booking reference numbers,
+ * locator codes, confirmation codes, or reservation codes.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use.
+ * @param options.allowNumerics Whether to allow numeric characters. Defaults to `false`.
+ * @param options.allowVisuallySimilarCharacters Whether to allow visually similar characters such as '1' and 'I'. Defaults to `false`.
+ *
+ * @example
+ * recordLocator(fakerCore) // 'KIFRWE'
+ * recordLocator(fakerCore, { allowNumerics: true }) // 'E5TYEM'
+ * recordLocator(fakerCore, { allowVisuallySimilarCharacters: true }) // 'ANZNEI'
+ * recordLocator(fakerCore, { allowNumerics: true, allowVisuallySimilarCharacters: true }) // '1Z2Z3E'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function recordLocator(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * Whether to allow numeric characters.
+     *
+     * @default false
+     */
+    allowNumerics?: boolean;
+    /**
+     * Whether to allow visually similar characters such as '1' and 'I'.
+     *
+     * @default false
+     */
+    allowVisuallySimilarCharacters?: boolean;
+  } = {}
+): string {
+  const { allowNumerics = false, allowVisuallySimilarCharacters = false } =
+    options;
+  const excludedChars: string[] = [];
+  if (!allowNumerics) {
+    excludedChars.push(...numerics);
+  }
+
+  if (!allowVisuallySimilarCharacters) {
+    excludedChars.push(...visuallySimilarCharacters);
+  }
+
+  return alphanumeric(fakerCore, {
+    length: 6,
+    casing: 'upper',
+    exclude: excludedChars,
+  });
+}

--- a/src/modules/airline/record-locator.ts
+++ b/src/modules/airline/record-locator.ts
@@ -1,6 +1,11 @@
 import type { FakerCore } from '../../core';
 import { alphanumeric } from '../string/alphanumeric';
 
+// Temp export
+export const numerics = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+// Temp export
+export const visuallySimilarCharacters = ['0', 'O', '1', 'I', 'L'];
+
 /**
  * Generates a random [record locator](https://en.wikipedia.org/wiki/Record_locator). Record locators
  * are used by airlines to identify reservations. They're also known as booking reference numbers,

--- a/src/modules/airline/record-locator.ts
+++ b/src/modules/airline/record-locator.ts
@@ -1,10 +1,8 @@
 import type { FakerCore } from '../../core';
 import { alphanumeric } from '../string/alphanumeric';
 
-// Temp export
-export const numerics = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-// Temp export
-export const visuallySimilarCharacters = ['0', 'O', '1', 'I', 'L'];
+const numerics = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+const visuallySimilarCharacters = ['0', 'O', '1', 'I', 'L'];
 
 /**
  * Generates a random [record locator](https://en.wikipedia.org/wiki/Record_locator). Record locators

--- a/src/modules/airline/seat.ts
+++ b/src/modules/airline/seat.ts
@@ -1,0 +1,38 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+import { int } from '../number/int';
+
+/**
+ * Generates a random seat.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use.
+ * @param options.aircraftType The aircraft type. Can be one of `narrowbody`, `regional`, `widebody`. Defaults to `narrowbody`.
+ *
+ * @example
+ * seat(fakerCore) // '22C'
+ * seat(fakerCore, { aircraftType: 'regional' }) // '7A'
+ * seat(fakerCore, { aircraftType: 'widebody' }) // '42K'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function seat(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The aircraft type. Can be one of `narrowbody`, `regional`, `widebody`.
+     *
+     * @default 'narrowbody'
+     */
+    aircraftType?: AircraftType;
+  } = {}
+): string {
+  const { aircraftType = Aircraft.Narrowbody } = options;
+  const maxRow = aircraftTypeMaxRows[aircraftType];
+  const allowedSeats = aircraftTypeSeats[aircraftType];
+  const row = int(fakerCore, { min: 1, max: maxRow });
+  const seat = arrayElement(fakerCore, allowedSeats);
+  return `${row}${seat}`;
+}

--- a/src/modules/airline/seat.ts
+++ b/src/modules/airline/seat.ts
@@ -1,6 +1,21 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 import { int } from '../number/int';
+import type { AircraftType } from './aircraft-type';
+import { Aircraft } from './aircraft-type';
+
+// Temp export
+export const aircraftTypeMaxRows: Record<AircraftType, number> = {
+  regional: 20,
+  narrowbody: 35,
+  widebody: 60,
+};
+// Temp export
+export const aircraftTypeSeats: Record<AircraftType, string[]> = {
+  regional: ['A', 'B', 'C', 'D'],
+  narrowbody: ['A', 'B', 'C', 'D', 'E', 'F'],
+  widebody: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K'],
+};
 
 /**
  * Generates a random seat.

--- a/src/modules/airline/seat.ts
+++ b/src/modules/airline/seat.ts
@@ -4,14 +4,12 @@ import { int } from '../number/int';
 import type { AircraftType } from './aircraft-type';
 import { Aircraft } from './aircraft-type';
 
-// Temp export
-export const aircraftTypeMaxRows: Record<AircraftType, number> = {
+const aircraftTypeMaxRows: Record<AircraftType, number> = {
   regional: 20,
   narrowbody: 35,
   widebody: 60,
 };
-// Temp export
-export const aircraftTypeSeats: Record<AircraftType, string[]> = {
+const aircraftTypeSeats: Record<AircraftType, string[]> = {
   regional: ['A', 'B', 'C', 'D'],
   narrowbody: ['A', 'B', 'C', 'D', 'E', 'F'],
   widebody: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K'],

--- a/src/modules/animal/bear.ts
+++ b/src/modules/animal/bear.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random bear species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * bear(fakerCore) // 'Asian black bear'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function bear(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.bear);
+}

--- a/src/modules/animal/bird.ts
+++ b/src/modules/animal/bird.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random bird species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * bird(fakerCore) // 'Buller's Shearwater'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function bird(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.bird);
+}

--- a/src/modules/animal/cat.ts
+++ b/src/modules/animal/cat.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random cat breed.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * cat(fakerCore) // 'Singapura'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function cat(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.cat);
+}

--- a/src/modules/animal/cetacean.ts
+++ b/src/modules/animal/cetacean.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random cetacean species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * cetacean(fakerCore) // 'Spinner Dolphin'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function cetacean(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.cetacean);
+}

--- a/src/modules/animal/cow.ts
+++ b/src/modules/animal/cow.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random cow species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * cow(fakerCore) // 'Brava'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function cow(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.cow);
+}

--- a/src/modules/animal/crocodilia.ts
+++ b/src/modules/animal/crocodilia.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random crocodilian species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * crocodilia(fakerCore) // 'Philippine Crocodile'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function crocodilia(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.crocodilia);
+}

--- a/src/modules/animal/dog.ts
+++ b/src/modules/animal/dog.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random dog breed.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * dog(fakerCore) // 'Irish Water Spaniel'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function dog(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.dog);
+}

--- a/src/modules/animal/fish.ts
+++ b/src/modules/animal/fish.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random fish species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * fish(fakerCore) // 'Mandarin fish'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function fish(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.fish);
+}

--- a/src/modules/animal/horse.ts
+++ b/src/modules/animal/horse.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random horse breed.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * horse(fakerCore) // 'Swedish Warmblood'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function horse(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.horse);
+}

--- a/src/modules/animal/insect.ts
+++ b/src/modules/animal/insect.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random insect species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * insect(fakerCore) // 'Pyramid ant'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function insect(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.insect);
+}

--- a/src/modules/animal/lion.ts
+++ b/src/modules/animal/lion.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random lion species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * lion(fakerCore) // 'Northeast Congo Lion'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function lion(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.lion);
+}

--- a/src/modules/animal/module.ts
+++ b/src/modules/animal/module.ts
@@ -1,4 +1,20 @@
 import { ModuleBase } from '../../internal/module-base';
+import { bear as animalBear } from './bear';
+import { bird as animalBird } from './bird';
+import { cat as animalCat } from './cat';
+import { cetacean as animalCetacean } from './cetacean';
+import { cow as animalCow } from './cow';
+import { crocodilia as animalCrocodilia } from './crocodilia';
+import { dog as animalDog } from './dog';
+import { fish as animalFish } from './fish';
+import { horse as animalHorse } from './horse';
+import { insect as animalInsect } from './insect';
+import { lion as animalLion } from './lion';
+import { petName as animalPetName } from './pet-name';
+import { rabbit as animalRabbit } from './rabbit';
+import { rodent as animalRodent } from './rodent';
+import { snake as animalSnake } from './snake';
+import { type as animalType } from './type';
 
 /**
  * Module to generate animal related entries.
@@ -12,6 +28,11 @@ import { ModuleBase } from '../../internal/module-base';
  * All values may be localized.
  */
 export class AnimalModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree animal' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random dog breed.
    *
@@ -21,7 +42,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   dog(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.dog);
+    return animalDog(this.faker.fakerCore);
   }
 
   /**
@@ -33,7 +54,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   cat(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.cat);
+    return animalCat(this.faker.fakerCore);
   }
 
   /**
@@ -45,7 +66,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   snake(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.snake);
+    return animalSnake(this.faker.fakerCore);
   }
 
   /**
@@ -57,7 +78,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   bear(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.bear);
+    return animalBear(this.faker.fakerCore);
   }
 
   /**
@@ -69,7 +90,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   lion(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.lion);
+    return animalLion(this.faker.fakerCore);
   }
 
   /**
@@ -81,9 +102,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   cetacean(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.animal.cetacean
-    );
+    return animalCetacean(this.faker.fakerCore);
   }
 
   /**
@@ -95,7 +114,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   horse(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.horse);
+    return animalHorse(this.faker.fakerCore);
   }
 
   /**
@@ -107,7 +126,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   bird(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.bird);
+    return animalBird(this.faker.fakerCore);
   }
 
   /**
@@ -119,7 +138,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   cow(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.cow);
+    return animalCow(this.faker.fakerCore);
   }
 
   /**
@@ -131,7 +150,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   fish(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.fish);
+    return animalFish(this.faker.fakerCore);
   }
 
   /**
@@ -143,9 +162,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   crocodilia(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.animal.crocodilia
-    );
+    return animalCrocodilia(this.faker.fakerCore);
   }
 
   /**
@@ -157,9 +174,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   insect(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.animal.insect
-    );
+    return animalInsect(this.faker.fakerCore);
   }
 
   /**
@@ -171,9 +186,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   rabbit(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.animal.rabbit
-    );
+    return animalRabbit(this.faker.fakerCore);
   }
 
   /**
@@ -185,9 +198,7 @@ export class AnimalModule extends ModuleBase {
    * @since 7.4.0
    */
   rodent(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.animal.rodent
-    );
+    return animalRodent(this.faker.fakerCore);
   }
 
   /**
@@ -199,7 +210,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   type(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.animal.type);
+    return animalType(this.faker.fakerCore);
   }
 
   /**
@@ -211,8 +222,6 @@ export class AnimalModule extends ModuleBase {
    * @since 9.2.0
    */
   petName(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.animal.pet_name
-    );
+    return animalPetName(this.faker.fakerCore);
   }
 }

--- a/src/modules/animal/pet-name.ts
+++ b/src/modules/animal/pet-name.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random pet name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * petName(fakerCore) // 'Coco'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function petName(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.pet_name);
+}

--- a/src/modules/animal/rabbit.ts
+++ b/src/modules/animal/rabbit.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random rabbit species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * rabbit(fakerCore) // 'Florida White'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function rabbit(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.rabbit);
+}

--- a/src/modules/animal/rodent.ts
+++ b/src/modules/animal/rodent.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random rodent breed.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * rodent(fakerCore) // 'Cuscomys ashanika'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function rodent(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.rodent);
+}

--- a/src/modules/animal/snake.ts
+++ b/src/modules/animal/snake.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random snake species.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * snake(fakerCore) // 'Eyelash viper'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function snake(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.snake);
+}

--- a/src/modules/animal/type.ts
+++ b/src/modules/animal/type.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random animal type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * type(fakerCore) // 'crocodile'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function type(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.animal.type);
+}


### PR DESCRIPTION
Continuation of #4046

- #4046

---

Transforms the animal module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts animal`
4. ~~Cherry-pick `refactor: transform animal module`~~
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~