### PR TITLE
feat(book): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -1,6 +1,7 @@
 export const ALLOWED_MODULES = new Set([
   'AirlineModule',
   'AnimalModule',
+  'BookModule',
   'DatatypeModule',
   'DateModule',
   'HelpersModule',

--- a/src/modules/book/author.ts
+++ b/src/modules/book/author.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random author name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * author(fakerCore) // 'William Shakespeare'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function author(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.book.author);
+}

--- a/src/modules/book/format.ts
+++ b/src/modules/book/format.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random book format.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * format(fakerCore) // 'Hardcover'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function format(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.book.format);
+}

--- a/src/modules/book/genre.ts
+++ b/src/modules/book/genre.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random genre.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * genre(fakerCore) // 'Fantasy'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function genre(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.book.genre);
+}

--- a/src/modules/book/module.ts
+++ b/src/modules/book/module.ts
@@ -1,4 +1,10 @@
 import { ModuleBase } from '../../internal/module-base';
+import { author as bookAuthor } from './author';
+import { format as bookFormat } from './format';
+import { genre as bookGenre } from './genre';
+import { publisher as bookPublisher } from './publisher';
+import { series as bookSeries } from './series';
+import { title as bookTitle } from './title';
 
 /**
  * Module to generate book related entries.
@@ -17,6 +23,11 @@ import { ModuleBase } from '../../internal/module-base';
  * All values may be localized.
  */
 export class BookModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree book' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random author name.
    *
@@ -26,7 +37,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   author(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.book.author);
+    return bookAuthor(this.faker.fakerCore);
   }
 
   /**
@@ -38,7 +49,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   format(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.book.format);
+    return bookFormat(this.faker.fakerCore);
   }
 
   /**
@@ -50,7 +61,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   genre(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.book.genre);
+    return bookGenre(this.faker.fakerCore);
   }
 
   /**
@@ -62,9 +73,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   publisher(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.book.publisher
-    );
+    return bookPublisher(this.faker.fakerCore);
   }
 
   /**
@@ -76,7 +85,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   series(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.book.series);
+    return bookSeries(this.faker.fakerCore);
   }
 
   /**
@@ -88,6 +97,6 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   title(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.book.title);
+    return bookTitle(this.faker.fakerCore);
   }
 }

--- a/src/modules/book/publisher.ts
+++ b/src/modules/book/publisher.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random publisher.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * publisher(fakerCore) // 'Addison-Wesley'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function publisher(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.book.publisher);
+}

--- a/src/modules/book/series.ts
+++ b/src/modules/book/series.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random series.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * series(fakerCore) // 'Harry Potter'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function series(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.book.series);
+}

--- a/src/modules/book/title.ts
+++ b/src/modules/book/title.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random title.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * title(fakerCore) // 'Romeo and Juliet'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function title(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.book.title);
+}


### PR DESCRIPTION
Continuation of #4047

- #4047

---

Transforms the animal module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts book`
4. ~~Cherry-pick `refactor: transform book module`~~
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~