### PR TITLE
infra(lint): enable jsdoc-js/require-throws

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -292,6 +292,7 @@ export default defineConfig({
     'jsdoc-js/require-returns': 'off',
     'jsdoc-js/require-returns-check': 'error',
     'jsdoc-js/require-returns-description': 'error',
+    'jsdoc-js/require-throws': 'error',
     'jsdoc-js/require-throws-type': 'error',
     'jsdoc-js/require-yields': 'error',
     'jsdoc-js/require-yields-check': 'error',

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -113,6 +113,8 @@ export class Faker extends SimpleFaker {
    * Refer to the `seed()` method for more information.
    * Defaults to a random seed.
    *
+   * @throws {FakerError} If the `locale` option does not contain at least one locale definition.
+   *
    * @example
    * import { Faker, es } from '@faker-js/faker';
    * // const { Faker, es } = require('@faker-js/faker');

--- a/src/internal/locale-proxy.ts
+++ b/src/internal/locale-proxy.ts
@@ -100,6 +100,8 @@ export function createLocaleProxy(
  *
  * @param value The value to check.
  * @param path The path to the locale data.
+ *
+ * @throws {FakerError} If the locale data are missing or not applicable to this locale.
  */
 export function assertLocaleData<T>(
   value: T,

--- a/src/modules/commerce/module.ts
+++ b/src/modules/commerce/module.ts
@@ -276,6 +276,8 @@ export class CommerceModule extends ModuleBase {
    * or `13` (13-digit format). Defaults to `13`.
    * @param options.separator The separator to use in the format. Defaults to `'-'`.
    *
+   * @throws {FakerError} If no registrant length is defined for the generated group.
+   *
    * @example
    * faker.commerce.isbn() // '978-0-692-82459-7'
    * faker.commerce.isbn(10) // '1-155-36404-X'

--- a/src/modules/helpers/_eval.ts
+++ b/src/modules/helpers/_eval.ts
@@ -55,6 +55,8 @@ const REGEX_DOT_OR_BRACKET = /\.|\(/;
  * @param faker The faker instance to resolve array elements.
  * @param entrypoints The entrypoints to use when evaluating the expression.
  *
+ * @throws {FakerError} If the expression is empty or cannot be resolved.
+ *
  * @see faker.helpers.fake() If you wish to have a string with multiple expressions.
  *
  * @example
@@ -110,6 +112,8 @@ export function fakeEval(
  *
  * @param input The input string to parse.
  * @param entrypoints The entrypoints to attempt the call on.
+ *
+ * @throws {FakerError} If the function call is not followed by a dot, an opening parenthesis, or the end of the expression.
  */
 function evalProcessFunction(
   input: string,
@@ -143,6 +147,8 @@ function evalProcessFunction(
  * Tries to find the parameters of a function call.
  *
  * @param input The input string to parse.
+ *
+ * @throws {FakerError} If the closing parenthesis is missing.
  */
 function findParams(input: string): [continueIndex: number, params: unknown[]] {
   let index = input.indexOf(')', 1);
@@ -179,6 +185,8 @@ function findParams(input: string): [continueIndex: number, params: unknown[]] {
  *
  * @param input The input string to parse.
  * @param entrypoints The entrypoints to resolve on.
+ *
+ * @throws {FakerError} If an expression part is empty, or a dot is not followed by a property name.
  */
 function evalProcessExpression(
   input: string,

--- a/src/modules/helpers/from-reg-exp.ts
+++ b/src/modules/helpers/from-reg-exp.ts
@@ -83,6 +83,8 @@ function replaceUnquantifiedRegExpTokens(
  *
  * @returns a random number based on the given quantifier parameters.
  *
+ * @throws {FakerError} If the quantifier symbol is not one of `?`, `*` or `+`.
+ *
  * @example
  * getRepetitionsBasedOnQuantifierParameters(fakerCore, '*', null, null) // 3
  * getRepetitionsBasedOnQuantifierParameters(fakerCore, null, 10, null) // 10

--- a/src/modules/location/module.ts
+++ b/src/modules/location/module.ts
@@ -221,6 +221,8 @@ export class LocationModule extends SimpleLocationModule {
    * By default, a random format is used from the locale zip formats.
    * This won't be used if the state option is specified.
    *
+   * @throws {FakerError} If the locale has no zip code definition for the given state.
+   *
    * @see faker.helpers.replaceSymbols(): For more information about how the pattern is used.
    *
    * @example

--- a/src/modules/phone/module.ts
+++ b/src/modules/phone/module.ts
@@ -15,6 +15,8 @@ export class PhoneModule extends ModuleBase {
    * @param options Options object
    * @param options.style Style of the phone number. Defaults to `'human'`.
    *
+   * @throws {Error} If the current locale has no definitions for the given style.
+   *
    * @see faker.string.numeric(): For generating a random string of numbers.
    * @see faker.helpers.fromRegExp(): For generating a phone number matching a regular expression.
    *

--- a/src/modules/string/from-characters.ts
+++ b/src/modules/string/from-characters.ts
@@ -15,6 +15,8 @@ import { rangeToNumber } from '../helpers/range-to-number';
  * @param length.min The minimum length of the string to generate.
  * @param length.max The maximum length of the string to generate.
  *
+ * @throws {FakerError} If there are no characters to select from.
+ *
  * @example
  * fromCharacters(fakerCore, 'abc') // 'c'
  * fromCharacters(fakerCore, ['a', 'b', 'c']) // 'a'

--- a/src/modules/system/module.ts
+++ b/src/modules/system/module.ts
@@ -156,6 +156,8 @@ export class SystemModule extends ModuleBase {
    *
    * @param mimeType Valid [mime-type](https://github.com/jshttp/mime-db/blob/master/db.json)
    *
+   * @throws {FakerError} If the given mime type is not supported.
+   *
    * @example
    * faker.system.fileExt() // 'emf'
    * faker.system.fileExt('application/json') // 'json'

--- a/src/modules/word/module.ts
+++ b/src/modules/word/module.ts
@@ -331,6 +331,8 @@ export class WordModule extends ModuleBase {
    *
    * Defaults to `'fail'`.
    *
+   * @throws {FakerError} If no matching word data are available for the current locale.
+   *
    * @example
    * faker.word.sample() // 'incidentally'
    * faker.word.sample(5) // 'fruit'

--- a/test/support/seeded-runs.ts
+++ b/test/support/seeded-runs.ts
@@ -160,6 +160,8 @@ class TestGenerator<
    * @param args The arguments to call it with.
    * @param extraStackFrames Additional stack frames to add into the stacktrace.
    * @param repetitions The number of times to call it.
+   *
+   * @throws {Error} If the method is not found in the module.
    */
   private callAndVerify<TMethodName extends MethodOf<TModule>>(
     method: TMethodName,


### PR DESCRIPTION
Closes #4021.

Turning on `jsdoc-js/require-throws` flagged 14 functions that can throw without documenting it. I went through each one and wrote the `@throws` from the actual throw site rather than guessing at it, so the conditions match what the code really does:

| | |
|---|---|
| `Faker` constructor | empty `locale` option |
| `assertLocaleData` | locale data missing or not applicable |
| `commerce.isbn` | no registrant length for the generated group |
| `fakeEval` | expression empty or unresolvable |
| `evalProcessFunction` | unexpected character after a call |
| `findParams` | missing closing parenthesis |
| `evalProcessExpression` | empty part, or a dot with no property name |
| `getRepetitionsBasedOnQuantifierParameters` | unknown quantifier symbol |
| `location.zipCode` | no zip definition for the given state |
| `phone.number` | no definitions for the style in this locale |
| `fromCharacters` | no characters to select from |
| `system.fileExt` | unsupported mime type |
| `word.sample` | no matching word data for the locale |
| `seeded-runs` `it` helper | method not found on the module |

The rule is set to `error` rather than `warn`, per @ST-DDT's question on the issue, so new ones can't creep back in.

Two of these throw a plain `Error` rather than a `FakerError` — `phone.number()` and the seeded-runs helper. I documented them as `{Error}` instead of quietly converting them, since changing the error type is a behaviour change and belongs in its own PR if you want it.

One note on scope: CONTRIBUTING asks to keep a PR to a single module where possible, and this one can't be — the rule only goes to `error` once every site is documented, so it's all of them or none. Happy to split it up if you'd rather review it module by module.

`pnpm lint` is clean with the rule at `error`, `oxfmt --check` passes, and the touched modules' specs run 3067 passed. (`pnpm ts-check` fails on `test/simple-faker.spec.ts` with `Cannot find module '..'` both with and without this change — it needs a build first, so it's not from this.)
