### PR TITLE
feat(company): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -4,6 +4,7 @@ export const ALLOWED_MODULES = new Set([
   'BookModule',
   'ColorModule',
   'CommerceModule',
+  'CompanyModule',
   'DatatypeModule',
   'DateModule',
   'HelpersModule',

--- a/src/modules/company/buzz-adjective.ts
+++ b/src/modules/company/buzz-adjective.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random buzz adjective that can be used to demonstrate data being viewed by a manager.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * buzzAdjective(fakerCore) // 'one-to-one'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function buzzAdjective(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.company.buzz_adjective);
+}

--- a/src/modules/company/buzz-noun.ts
+++ b/src/modules/company/buzz-noun.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random buzz noun that can be used to demonstrate data being viewed by a manager.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * buzzNoun(fakerCore) // 'paradigms'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function buzzNoun(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.company.buzz_noun);
+}

--- a/src/modules/company/buzz-phrase.ts
+++ b/src/modules/company/buzz-phrase.ts
@@ -1,0 +1,24 @@
+import type { FakerCore } from '../../core';
+import { buzzAdjective } from './buzz-adjective';
+import { buzzNoun } from './buzz-noun';
+import { buzzVerb } from './buzz-verb';
+
+/**
+ * Generates a random buzz phrase that can be used to demonstrate data being viewed by a manager.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * buzzPhrase(fakerCore) // 'cultivate synergistic e-markets'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function buzzPhrase(fakerCore: FakerCore): string {
+  return [
+    buzzVerb(fakerCore),
+    buzzAdjective(fakerCore),
+    buzzNoun(fakerCore),
+  ].join(' ');
+}

--- a/src/modules/company/buzz-verb.ts
+++ b/src/modules/company/buzz-verb.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random buzz verb that can be used to demonstrate data being viewed by a manager.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * buzzVerb(fakerCore) // 'empower'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function buzzVerb(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.company.buzz_verb);
+}

--- a/src/modules/company/catch-phrase-adjective.ts
+++ b/src/modules/company/catch-phrase-adjective.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random catch phrase adjective that can be displayed to an end user.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * catchPhraseAdjective(fakerCore) // 'Multi-tiered'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function catchPhraseAdjective(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.company.adjective);
+}

--- a/src/modules/company/catch-phrase-descriptor.ts
+++ b/src/modules/company/catch-phrase-descriptor.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random catch phrase descriptor that can be displayed to an end user.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * catchPhraseDescriptor(fakerCore) // 'composite'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function catchPhraseDescriptor(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.company.descriptor);
+}

--- a/src/modules/company/catch-phrase-noun.ts
+++ b/src/modules/company/catch-phrase-noun.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random catch phrase noun that can be displayed to an end user.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * catchPhraseNoun(fakerCore) // 'leverage'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function catchPhraseNoun(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.company.noun);
+}

--- a/src/modules/company/catch-phrase.ts
+++ b/src/modules/company/catch-phrase.ts
@@ -1,0 +1,24 @@
+import type { FakerCore } from '../../core';
+import { catchPhraseAdjective } from './catch-phrase-adjective';
+import { catchPhraseDescriptor } from './catch-phrase-descriptor';
+import { catchPhraseNoun } from './catch-phrase-noun';
+
+/**
+ * Generates a random catch phrase that can be displayed to an end user.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * catchPhrase(fakerCore) // 'Upgradable systematic flexibility'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function catchPhrase(fakerCore: FakerCore): string {
+  return [
+    catchPhraseAdjective(fakerCore),
+    catchPhraseDescriptor(fakerCore),
+    catchPhraseNoun(fakerCore),
+  ].join(' ');
+}

--- a/src/modules/company/module.ts
+++ b/src/modules/company/module.ts
@@ -1,4 +1,13 @@
 import { ModuleBase } from '../../internal/module-base';
+import { buzzAdjective as companyBuzzAdjective } from './buzz-adjective';
+import { buzzNoun as companyBuzzNoun } from './buzz-noun';
+import { buzzPhrase as companyBuzzPhrase } from './buzz-phrase';
+import { buzzVerb as companyBuzzVerb } from './buzz-verb';
+import { catchPhrase as companyCatchPhrase } from './catch-phrase';
+import { catchPhraseAdjective as companyCatchPhraseAdjective } from './catch-phrase-adjective';
+import { catchPhraseDescriptor as companyCatchPhraseDescriptor } from './catch-phrase-descriptor';
+import { catchPhraseNoun as companyCatchPhraseNoun } from './catch-phrase-noun';
+import { name as companyName } from './name';
 
 /**
  * Module to generate company related entries.
@@ -15,6 +24,11 @@ import { ModuleBase } from '../../internal/module-base';
  * - For finance-related entries, use [`faker.finance`](https://fakerjs.dev/api/finance.html).
  */
 export class CompanyModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree company' to update the methods from their respective files.
+   */
+
   /**
    * Generates a random company name.
    *
@@ -24,7 +38,7 @@ export class CompanyModule extends ModuleBase {
    * @since 7.4.0
    */
   name(): string {
-    return this.faker.helpers.fake(this.faker.definitions.company.name_pattern);
+    return companyName(this.faker.fakerCore);
   }
 
   /**
@@ -36,11 +50,7 @@ export class CompanyModule extends ModuleBase {
    * @since 2.0.1
    */
   catchPhrase(): string {
-    return [
-      this.catchPhraseAdjective(),
-      this.catchPhraseDescriptor(),
-      this.catchPhraseNoun(),
-    ].join(' ');
+    return companyCatchPhrase(this.faker.fakerCore);
   }
 
   /**
@@ -52,7 +62,7 @@ export class CompanyModule extends ModuleBase {
    * @since 8.0.0
    */
   buzzPhrase(): string {
-    return [this.buzzVerb(), this.buzzAdjective(), this.buzzNoun()].join(' ');
+    return companyBuzzPhrase(this.faker.fakerCore);
   }
 
   /**
@@ -64,9 +74,7 @@ export class CompanyModule extends ModuleBase {
    * @since 2.0.1
    */
   catchPhraseAdjective(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.company.adjective
-    );
+    return companyCatchPhraseAdjective(this.faker.fakerCore);
   }
 
   /**
@@ -78,9 +86,7 @@ export class CompanyModule extends ModuleBase {
    * @since 2.0.1
    */
   catchPhraseDescriptor(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.company.descriptor
-    );
+    return companyCatchPhraseDescriptor(this.faker.fakerCore);
   }
 
   /**
@@ -92,7 +98,7 @@ export class CompanyModule extends ModuleBase {
    * @since 2.0.1
    */
   catchPhraseNoun(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.company.noun);
+    return companyCatchPhraseNoun(this.faker.fakerCore);
   }
 
   /**
@@ -104,9 +110,7 @@ export class CompanyModule extends ModuleBase {
    * @since 8.0.0
    */
   buzzAdjective(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.company.buzz_adjective
-    );
+    return companyBuzzAdjective(this.faker.fakerCore);
   }
 
   /**
@@ -118,9 +122,7 @@ export class CompanyModule extends ModuleBase {
    * @since 8.0.0
    */
   buzzVerb(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.company.buzz_verb
-    );
+    return companyBuzzVerb(this.faker.fakerCore);
   }
 
   /**
@@ -132,8 +134,6 @@ export class CompanyModule extends ModuleBase {
    * @since 8.0.0
    */
   buzzNoun(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.company.buzz_noun
-    );
+    return companyBuzzNoun(this.faker.fakerCore);
   }
 }

--- a/src/modules/company/name.ts
+++ b/src/modules/company/name.ts
@@ -1,0 +1,20 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+
+/**
+ * Generates a random company name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * name(fakerCore) // 'Zieme, Hauck and McClure'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function name(fakerCore: FakerCore): string {
+  return new Faker(fakerCore).helpers.fake(
+    fakerCore.locale.company.name_pattern
+  );
+}


### PR DESCRIPTION
Continuation of #4052

- #4052

---

Transforms the company module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts company`
4. ~~Cherry-pick `refactor: transform company module`~~
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~