### PR TITLE
feat(database): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -5,6 +5,7 @@ export const ALLOWED_MODULES = new Set([
   'ColorModule',
   'CommerceModule',
   'CompanyModule',
+  'DatabaseModule',
   'DatatypeModule',
   'DateModule',
   'HelpersModule',

--- a/src/modules/database/collation.ts
+++ b/src/modules/database/collation.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random database collation.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * collation(fakerCore) // 'utf8_unicode_ci'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function collation(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.database.collation);
+}

--- a/src/modules/database/column.ts
+++ b/src/modules/database/column.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random database column name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * column(fakerCore) // 'createdAt'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function column(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.database.column);
+}

--- a/src/modules/database/engine.ts
+++ b/src/modules/database/engine.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random database engine.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * engine(fakerCore) // 'ARCHIVE'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function engine(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.database.engine);
+}

--- a/src/modules/database/module.ts
+++ b/src/modules/database/module.ts
@@ -1,4 +1,9 @@
 import { ModuleBase } from '../../internal/module-base';
+import { collation as databaseCollation } from './collation';
+import { column as databaseColumn } from './column';
+import { engine as databaseEngine } from './engine';
+import { mongodbObjectId as databaseMongodbObjectId } from './mongodb-object-id';
+import { type as databaseType } from './type';
 
 /**
  * Module to generate database related entries.
@@ -10,6 +15,11 @@ import { ModuleBase } from '../../internal/module-base';
  * For the NoSQL database MongoDB, [`mongodbObjectId()`](https://fakerjs.dev/api/database.html#mongodbobjectid) provides a random ID.
  */
 export class DatabaseModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree database' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random database column name.
    *
@@ -19,9 +29,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   column(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.database.column
-    );
+    return databaseColumn(this.faker.fakerCore);
   }
 
   /**
@@ -33,9 +41,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   type(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.database.type
-    );
+    return databaseType(this.faker.fakerCore);
   }
 
   /**
@@ -47,9 +53,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   collation(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.database.collation
-    );
+    return databaseCollation(this.faker.fakerCore);
   }
 
   /**
@@ -61,9 +65,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   engine(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.database.engine
-    );
+    return databaseEngine(this.faker.fakerCore);
   }
 
   /**
@@ -75,10 +77,6 @@ export class DatabaseModule extends ModuleBase {
    * @since 6.2.0
    */
   mongodbObjectId(): string {
-    return this.faker.string.hexadecimal({
-      length: 24,
-      casing: 'lower',
-      prefix: '',
-    });
+    return databaseMongodbObjectId(this.faker.fakerCore);
   }
 }

--- a/src/modules/database/mongodb-object-id.ts
+++ b/src/modules/database/mongodb-object-id.ts
@@ -1,0 +1,22 @@
+import type { FakerCore } from '../../core';
+import { hexadecimal } from '../string/hexadecimal';
+
+/**
+ * Returns a MongoDB [ObjectId](https://docs.mongodb.com/manual/reference/method/ObjectId/) string.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * mongodbObjectId(fakerCore) // 'e175cac316a79afdd0ad3afb'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function mongodbObjectId(fakerCore: FakerCore): string {
+  return hexadecimal(fakerCore, {
+    length: 24,
+    casing: 'lower',
+    prefix: '',
+  });
+}

--- a/src/modules/database/type.ts
+++ b/src/modules/database/type.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random database column type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * type(fakerCore) // 'timestamp'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function type(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.database.type);
+}


### PR DESCRIPTION
Continuation of #4053

- #4053

---

Transforms the database module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts database`
4. ~~Cherry-pick `refactor: transform database module`~~
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~