### PR TITLE
feat(food): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -5,6 +5,7 @@ export const ALLOWED_MODULES = new Set([
   'ColorModule',
   'CommerceModule',
   'CompanyModule',
+  'DatabaseModule',
   'DatatypeModule',
   'DateModule',
   'HelpersModule',

--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -8,6 +8,7 @@ export const ALLOWED_MODULES = new Set([
   'DatabaseModule',
   'DatatypeModule',
   'DateModule',
+  'FoodModule',
   'HelpersModule',
   'NumberModule',
   'PersonModule',

--- a/src/modules/database/collation.ts
+++ b/src/modules/database/collation.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random database collation.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * collation(fakerCore) // 'utf8_unicode_ci'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function collation(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.database.collation);
+}

--- a/src/modules/database/column.ts
+++ b/src/modules/database/column.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random database column name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * column(fakerCore) // 'createdAt'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function column(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.database.column);
+}

--- a/src/modules/database/engine.ts
+++ b/src/modules/database/engine.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random database engine.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * engine(fakerCore) // 'ARCHIVE'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function engine(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.database.engine);
+}

--- a/src/modules/database/module.ts
+++ b/src/modules/database/module.ts
@@ -1,4 +1,9 @@
 import { ModuleBase } from '../../internal/module-base';
+import { collation as databaseCollation } from './collation';
+import { column as databaseColumn } from './column';
+import { engine as databaseEngine } from './engine';
+import { mongodbObjectId as databaseMongodbObjectId } from './mongodb-object-id';
+import { type as databaseType } from './type';
 
 /**
  * Module to generate database related entries.
@@ -10,6 +15,11 @@ import { ModuleBase } from '../../internal/module-base';
  * For the NoSQL database MongoDB, [`mongodbObjectId()`](https://fakerjs.dev/api/database.html#mongodbobjectid) provides a random ID.
  */
 export class DatabaseModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree database' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random database column name.
    *
@@ -19,9 +29,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   column(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.database.column
-    );
+    return databaseColumn(this.faker.fakerCore);
   }
 
   /**
@@ -33,9 +41,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   type(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.database.type
-    );
+    return databaseType(this.faker.fakerCore);
   }
 
   /**
@@ -47,9 +53,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   collation(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.database.collation
-    );
+    return databaseCollation(this.faker.fakerCore);
   }
 
   /**
@@ -61,9 +65,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   engine(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.database.engine
-    );
+    return databaseEngine(this.faker.fakerCore);
   }
 
   /**
@@ -75,10 +77,6 @@ export class DatabaseModule extends ModuleBase {
    * @since 6.2.0
    */
   mongodbObjectId(): string {
-    return this.faker.string.hexadecimal({
-      length: 24,
-      casing: 'lower',
-      prefix: '',
-    });
+    return databaseMongodbObjectId(this.faker.fakerCore);
   }
 }

--- a/src/modules/database/mongodb-object-id.ts
+++ b/src/modules/database/mongodb-object-id.ts
@@ -1,0 +1,22 @@
+import type { FakerCore } from '../../core';
+import { hexadecimal } from '../string/hexadecimal';
+
+/**
+ * Returns a MongoDB [ObjectId](https://docs.mongodb.com/manual/reference/method/ObjectId/) string.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * mongodbObjectId(fakerCore) // 'e175cac316a79afdd0ad3afb'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function mongodbObjectId(fakerCore: FakerCore): string {
+  return hexadecimal(fakerCore, {
+    length: 24,
+    casing: 'lower',
+    prefix: '',
+  });
+}

--- a/src/modules/database/type.ts
+++ b/src/modules/database/type.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random database column type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * type(fakerCore) // 'timestamp'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function type(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.database.type);
+}

--- a/src/modules/food/adjective.ts
+++ b/src/modules/food/adjective.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random dish adjective.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * adjective(fakerCore) // 'crispy'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function adjective(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.food.adjective);
+}

--- a/src/modules/food/description.ts
+++ b/src/modules/food/description.ts
@@ -1,0 +1,20 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+
+/**
+ * Generates a random dish description.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * description(fakerCore) // 'An exquisite ostrich roast, infused with the essence of longan, slow-roasted to bring out its natural flavors and served with a side of creamy red cabbage'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function description(fakerCore: FakerCore): string {
+  return new Faker(fakerCore).helpers.fake(
+    fakerCore.locale.food.description_pattern
+  );
+}

--- a/src/modules/food/dish.ts
+++ b/src/modules/food/dish.ts
@@ -3,13 +3,12 @@ import { Faker } from '../../faker';
 import { boolean } from '../datatype/boolean';
 import { arrayElement } from '../helpers/array-element';
 
-// Temp export
 /**
  * Converts the given string to title case.
  *
  * @param text The text to convert.
  */
-export function toTitleCase(text: string): string {
+function toTitleCase(text: string): string {
   return text
     .split(' ')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))

--- a/src/modules/food/dish.ts
+++ b/src/modules/food/dish.ts
@@ -1,0 +1,27 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+import { boolean } from '../datatype/boolean';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random dish name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * dish(fakerCore) // 'Tagine-Rubbed Venison Salad'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function dish(fakerCore: FakerCore): string {
+  // A 50/50 mix of specific dishes and dish_patterns
+  if (boolean(fakerCore)) {
+    return toTitleCase(
+      new Faker(fakerCore).helpers.fake(fakerCore.locale.food.dish_pattern)
+    );
+  }
+
+  return toTitleCase(arrayElement(fakerCore, fakerCore.locale.food.dish));
+}

--- a/src/modules/food/dish.ts
+++ b/src/modules/food/dish.ts
@@ -3,6 +3,19 @@ import { Faker } from '../../faker';
 import { boolean } from '../datatype/boolean';
 import { arrayElement } from '../helpers/array-element';
 
+// Temp export
+/**
+ * Converts the given string to title case.
+ *
+ * @param text The text to convert.
+ */
+export function toTitleCase(text: string): string {
+  return text
+    .split(' ')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
 /**
  * Generates a random dish name.
  *

--- a/src/modules/food/ethnic-category.ts
+++ b/src/modules/food/ethnic-category.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random food's ethnic category.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * ethnicCategory(fakerCore) // 'Italian'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function ethnicCategory(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.food.ethnic_category);
+}

--- a/src/modules/food/fruit.ts
+++ b/src/modules/food/fruit.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random fruit name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * fruit(fakerCore) // 'lemon'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function fruit(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.food.fruit);
+}

--- a/src/modules/food/ingredient.ts
+++ b/src/modules/food/ingredient.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random ingredient name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * ingredient(fakerCore) // 'butter'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function ingredient(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.food.ingredient);
+}

--- a/src/modules/food/meat.ts
+++ b/src/modules/food/meat.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random meat.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * meat(fakerCore) // 'venison'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function meat(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.food.meat);
+}

--- a/src/modules/food/module.ts
+++ b/src/modules/food/module.ts
@@ -1,16 +1,5 @@
 import { ModuleBase } from '../../internal/module-base';
-
-/**
- * Converts the given string to title case.
- *
- * @param text The text to convert.
- */
-function toTitleCase(text: string): string {
-  return text
-    .split(' ')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
+import { toTitleCase } from './dish';
 
 /**
  * Module for generating food-related data.

--- a/src/modules/food/module.ts
+++ b/src/modules/food/module.ts
@@ -1,5 +1,13 @@
 import { ModuleBase } from '../../internal/module-base';
-import { toTitleCase } from './dish';
+import { adjective as foodAdjective } from './adjective';
+import { description as foodDescription } from './description';
+import { dish as foodDish } from './dish';
+import { ethnicCategory as foodEthnicCategory } from './ethnic-category';
+import { fruit as foodFruit } from './fruit';
+import { ingredient as foodIngredient } from './ingredient';
+import { meat as foodMeat } from './meat';
+import { spice as foodSpice } from './spice';
+import { vegetable as foodVegetable } from './vegetable';
 
 /**
  * Module for generating food-related data.
@@ -11,6 +19,11 @@ import { toTitleCase } from './dish';
  * You can also generate individual components of a dish such as [spices](https://fakerjs.dev/api/food.html#spice), [vegetables](https://fakerjs.dev/api/food.html#vegetable), [meats](https://fakerjs.dev/api/food.html#meat), [fruits](https://fakerjs.dev/api/food.html#fruit), or generic [ingredients](https://fakerjs.dev/api/food.html#ingredient).
  */
 export class FoodModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree food' to update the methods from their respective files.
+   */
+
   /**
    * Generates a random dish adjective.
    *
@@ -20,9 +33,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   adjective(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.food.adjective
-    );
+    return foodAdjective(this.faker.fakerCore);
   }
 
   /**
@@ -34,9 +45,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   description(): string {
-    return this.faker.helpers.fake(
-      this.faker.definitions.food.description_pattern
-    );
+    return foodDescription(this.faker.fakerCore);
   }
 
   /**
@@ -48,16 +57,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   dish(): string {
-    // A 50/50 mix of specific dishes and dish_patterns
-    if (this.faker.datatype.boolean()) {
-      return toTitleCase(
-        this.faker.helpers.fake(this.faker.definitions.food.dish_pattern)
-      );
-    }
-
-    return toTitleCase(
-      this.faker.helpers.arrayElement(this.faker.definitions.food.dish)
-    );
+    return foodDish(this.faker.fakerCore);
   }
 
   /**
@@ -69,9 +69,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   ethnicCategory(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.food.ethnic_category
-    );
+    return foodEthnicCategory(this.faker.fakerCore);
   }
 
   /**
@@ -83,7 +81,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   fruit(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.food.fruit);
+    return foodFruit(this.faker.fakerCore);
   }
 
   /**
@@ -95,9 +93,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   ingredient(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.food.ingredient
-    );
+    return foodIngredient(this.faker.fakerCore);
   }
 
   /**
@@ -109,7 +105,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   meat(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.food.meat);
+    return foodMeat(this.faker.fakerCore);
   }
 
   /**
@@ -121,7 +117,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   spice(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.food.spice);
+    return foodSpice(this.faker.fakerCore);
   }
 
   /**
@@ -133,8 +129,6 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   vegetable(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.food.vegetable
-    );
+    return foodVegetable(this.faker.fakerCore);
   }
 }

--- a/src/modules/food/spice.ts
+++ b/src/modules/food/spice.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random spice name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * spice(fakerCore) // 'chilli'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function spice(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.food.spice);
+}

--- a/src/modules/food/vegetable.ts
+++ b/src/modules/food/vegetable.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random vegetable name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * vegetable(fakerCore) // 'broccoli'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function vegetable(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.food.vegetable);
+}


### PR DESCRIPTION
Continuation of #4054

- #4054

---

Transforms the food module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts food`
4. Cherry-pick `refactor: transform food module`
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. Cherry-pick `chore: remove temp exports`