### PR TITLE
feat(image): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -11,6 +11,7 @@ export const ALLOWED_MODULES = new Set([
   'FoodModule',
   'HackerModule',
   'HelpersModule',
+  'ImageModule',
   'NumberModule',
   'PersonModule',
   'StringModule',

--- a/src/modules/image/avatar-git-hub.ts
+++ b/src/modules/image/avatar-git-hub.ts
@@ -1,0 +1,21 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+import { int } from '../number/int';
+
+/**
+ * Generates a random avatar from GitHub.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @remark This method generates a random string representing an URL from GitHub by using a random user ID. Faker is not responsible for the content of the image or the service providing it.
+ *
+ * @example
+ * avatarGitHub(fakerCore)
+ * // 'https://avatars.githubusercontent.com/u/97165289'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function avatarGitHub(fakerCore: FakerCore): string {
+  return `https://avatars.githubusercontent.com/u/${int(fakerCore, 100000000)}`;
+}

--- a/src/modules/image/avatar-git-hub.ts
+++ b/src/modules/image/avatar-git-hub.ts
@@ -1,12 +1,12 @@
 import type { FakerCore } from '../../core';
-import { Faker } from '../../faker';
 import { int } from '../number/int';
 
 /**
  * Generates a random avatar from GitHub.
  *
- * @param fakerCore The FakerCore to use.
  * @remark This method generates a random string representing an URL from GitHub by using a random user ID. Faker is not responsible for the content of the image or the service providing it.
+ *
+ * @param fakerCore The FakerCore to use.
  *
  * @example
  * avatarGitHub(fakerCore)

--- a/src/modules/image/avatar.ts
+++ b/src/modules/image/avatar.ts
@@ -1,12 +1,14 @@
 import type { FakerCore } from '../../core';
-import { Faker } from '../../faker';
 import { arrayElement } from '../helpers/array-element';
+import { avatarGitHub } from './avatar-git-hub';
+import { personPortrait } from './person-portrait';
 
 /**
  * Generates a random avatar image url.
  *
- * @param fakerCore The FakerCore to use.
  * @remark This method sometimes generates a random string representing an URL from GitHub by using a random user ID. Faker is not responsible for the content of the image or the service providing it.
+ *
+ * @param fakerCore The FakerCore to use.
  *
  * @example
  * avatar(fakerCore)
@@ -18,9 +20,6 @@ import { arrayElement } from '../helpers/array-element';
  */
 export function avatar(fakerCore: FakerCore): string {
   // Add new avatar providers here, when adding a new one.
-  const avatarMethod = arrayElement(fakerCore, [
-    this.personPortrait,
-    this.avatarGitHub,
-  ]);
-  return avatarMethod();
+  const avatarMethod = arrayElement(fakerCore, [personPortrait, avatarGitHub]);
+  return avatarMethod(fakerCore);
 }

--- a/src/modules/image/avatar.ts
+++ b/src/modules/image/avatar.ts
@@ -1,0 +1,26 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random avatar image url.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @remark This method sometimes generates a random string representing an URL from GitHub by using a random user ID. Faker is not responsible for the content of the image or the service providing it.
+ *
+ * @example
+ * avatar(fakerCore)
+ * // 'https://avatars.githubusercontent.com/u/97165289'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function avatar(fakerCore: FakerCore): string {
+  // Add new avatar providers here, when adding a new one.
+  const avatarMethod = arrayElement(fakerCore, [
+    this.personPortrait,
+    this.avatarGitHub,
+  ]);
+  return avatarMethod();
+}

--- a/src/modules/image/data-uri.ts
+++ b/src/modules/image/data-uri.ts
@@ -1,0 +1,71 @@
+import type { FakerCore } from '../../core';
+import { toBase64 } from '../../internal/base64';
+import { rgb } from '../color/rgb';
+import { arrayElement } from '../helpers/array-element';
+import { int } from '../number/int';
+
+/**
+ * Generates a random data uri containing an URL-encoded SVG image or a Base64-encoded SVG image.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options Options for generating a data uri.
+ * @param options.width The width of the image. Defaults to a random integer between `1` and `3999`.
+ * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.
+ * @param options.color The color of the image. Must be a color supported by svg. Defaults to a random color.
+ * @param options.type The type of the image. Defaults to a random type.
+ *
+ * @example
+ * dataUri(fakerCore) // 'data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http...'
+ * dataUri(fakerCore, { type: 'svg-base64' }) // 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3...'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function dataUri(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The width of the image.
+     *
+     * @default numberInt(fakerCore, { min: 1, max: 3999 })
+     */
+    width?: number;
+    /**
+     * The height of the image.
+     *
+     * @default numberInt(fakerCore, { min: 1, max: 3999 })
+     */
+    height?: number;
+    /**
+     * The color of the image. Must be a color supported by svg.
+     *
+     * @default colorRgb(fakerCore)
+     */
+    color?: string;
+    /**
+     * The type of the image to return. Consisting of
+     * the file extension and the used encoding.
+     *
+     * @default helpersArrayElement(fakerCore, ['svg-uri', 'svg-base64'])
+     */
+    type?: 'svg-uri' | 'svg-base64';
+  } = {}
+): string {
+  const {
+    width = int(fakerCore, { min: 1, max: 3999 }),
+    height = int(fakerCore, { min: 1, max: 3999 }),
+    color = rgb(fakerCore),
+    type = arrayElement(fakerCore, ['svg-uri', 'svg-base64']),
+  } = options;
+
+  const svgString = `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" baseProfile="full" width="${width}" height="${height}"><rect width="100%" height="100%" fill="${color}"/><text x="${
+    width / 2
+  }" y="${
+    height / 2
+  }" font-size="20" alignment-baseline="middle" text-anchor="middle" fill="white">${width}x${height}</text></svg>`;
+
+  return type === 'svg-uri'
+    ? `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svgString)}`
+    : `data:image/svg+xml;base64,${toBase64(svgString)}`;
+}

--- a/src/modules/image/module.ts
+++ b/src/modules/image/module.ts
@@ -1,7 +1,12 @@
-import { toBase64 } from '../../internal/base64';
-import { deprecated } from '../../internal/deprecated';
 import { ModuleBase } from '../../internal/module-base';
 import type { SexType } from '../person';
+import { avatar as imageAvatar } from './avatar';
+import { avatarGitHub as imageAvatarGitHub } from './avatar-git-hub';
+import { dataUri as imageDataUri } from './data-uri';
+import { personPortrait as imagePersonPortrait } from './person-portrait';
+import { url as imageUrl } from './url';
+import { urlLoremFlickr as imageUrlLoremFlickr } from './url-lorem-flickr';
+import { urlPicsumPhotos as imageUrlPicsumPhotos } from './url-picsum-photos';
 
 /**
  * Module to generate images.
@@ -20,6 +25,11 @@ import type { SexType } from '../person';
  * If you think an image method/category is missing, please [open an issue/vote for an existing one](https://github.com/faker-js/faker/issues/3810).
  */
 export class ImageModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree image' to update the methods from their respective files.
+   */
+
   /**
    * Generates a random avatar image url.
    *
@@ -32,12 +42,7 @@ export class ImageModule extends ModuleBase {
    * @since 2.0.1
    */
   avatar(): string {
-    // Add new avatar providers here, when adding a new one.
-    const avatarMethod = this.faker.helpers.arrayElement([
-      this.personPortrait,
-      this.avatarGitHub,
-    ]);
-    return avatarMethod();
+    return imageAvatar(this.faker.fakerCore);
   }
 
   /**
@@ -52,9 +57,7 @@ export class ImageModule extends ModuleBase {
    * @since 8.0.0
    */
   avatarGitHub(): string {
-    return `https://avatars.githubusercontent.com/u/${this.faker.number.int(
-      100000000
-    )}`;
+    return imageAvatarGitHub(this.faker.fakerCore);
   }
 
   /**
@@ -90,16 +93,7 @@ export class ImageModule extends ModuleBase {
       size?: 512 | 256 | 128 | 64 | 32;
     } = {}
   ): string {
-    const { size = 512 } = options;
-    let { sex = this.faker.person.sexType() } = options;
-
-    if (sex === 'generic') {
-      sex = this.faker.person.sexType();
-    }
-
-    const baseURL =
-      'https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait';
-    return `${baseURL}/${sex}/${size}/${this.faker.number.int({ min: 0, max: 99 })}.jpg`;
+    return imagePersonPortrait(this.faker.fakerCore, options);
   }
 
   /**
@@ -132,18 +126,7 @@ export class ImageModule extends ModuleBase {
       height?: number;
     } = {}
   ): string {
-    const {
-      width = this.faker.number.int({ min: 1, max: 3999 }),
-      height = this.faker.number.int({ min: 1, max: 3999 }),
-    } = options;
-
-    const urlMethod = this.faker.helpers.arrayElement([
-      ({ width, height }: { width?: number; height?: number }) =>
-        this.urlPicsumPhotos({ width, height, grayscale: false, blur: 0 }),
-      // Other providers may be added back here in future versions.
-    ]);
-
-    return urlMethod({ width, height });
+    return imageUrl(this.faker.fakerCore, options);
   }
 
   /**
@@ -186,22 +169,7 @@ export class ImageModule extends ModuleBase {
       category?: string;
     } = {}
   ): string {
-    deprecated({
-      deprecated: 'faker.image.urlLoremFlickr()',
-      proposed: 'faker.image.url()',
-      since: '10.1.0',
-      until: '11.0.0',
-    });
-
-    const {
-      width = this.faker.number.int({ min: 1, max: 3999 }),
-      height = this.faker.number.int({ min: 1, max: 3999 }),
-      category,
-    } = options;
-
-    return `https://loremflickr.com/${width}/${height}${
-      category == null ? '' : `/${category}`
-    }?lock=${this.faker.number.int()}`;
+    return imageUrlLoremFlickr(this.faker.fakerCore, options);
   }
 
   /**
@@ -253,36 +221,7 @@ export class ImageModule extends ModuleBase {
       blur?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
     } = {}
   ): string {
-    const {
-      width = this.faker.number.int({ min: 1, max: 3999 }),
-      height = this.faker.number.int({ min: 1, max: 3999 }),
-      grayscale = this.faker.datatype.boolean(),
-      blur = this.faker.number.int({ max: 10 }),
-    } = options;
-
-    let url = `https://picsum.photos/seed/${this.faker.string.alphanumeric({
-      length: { min: 5, max: 10 },
-    })}/${width}/${height}`;
-
-    const hasValidBlur = typeof blur === 'number' && blur >= 1 && blur <= 10;
-
-    if (grayscale || hasValidBlur) {
-      url += '?';
-
-      if (grayscale) {
-        url += `grayscale`;
-      }
-
-      if (grayscale && hasValidBlur) {
-        url += '&';
-      }
-
-      if (hasValidBlur) {
-        url += `blur=${blur}`;
-      }
-    }
-
-    return url;
+    return imageUrlPicsumPhotos(this.faker.fakerCore, options);
   }
 
   /**
@@ -329,21 +268,6 @@ export class ImageModule extends ModuleBase {
       type?: 'svg-uri' | 'svg-base64';
     } = {}
   ): string {
-    const {
-      width = this.faker.number.int({ min: 1, max: 3999 }),
-      height = this.faker.number.int({ min: 1, max: 3999 }),
-      color = this.faker.color.rgb(),
-      type = this.faker.helpers.arrayElement(['svg-uri', 'svg-base64']),
-    } = options;
-
-    const svgString = `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" baseProfile="full" width="${width}" height="${height}"><rect width="100%" height="100%" fill="${color}"/><text x="${
-      width / 2
-    }" y="${
-      height / 2
-    }" font-size="20" alignment-baseline="middle" text-anchor="middle" fill="white">${width}x${height}</text></svg>`;
-
-    return type === 'svg-uri'
-      ? `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svgString)}`
-      : `data:image/svg+xml;base64,${toBase64(svgString)}`;
+    return imageDataUri(this.faker.fakerCore, options);
   }
 }

--- a/src/modules/image/person-portrait.ts
+++ b/src/modules/image/person-portrait.ts
@@ -1,0 +1,52 @@
+import type { FakerCore } from '../../core';
+import { int } from '../number/int';
+import type { SexType } from '../person';
+import { sexType } from '../person/sex-type';
+
+/**
+ * Generates a random square portrait (avatar) of a person.
+ * These are static images of fictional people created by an AI, Stable Diffusion 3.
+ * The image URLs are served via the JSDelivr CDN and subject to their [terms of use](https://www.jsdelivr.com/terms).
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options Options for generating an AI avatar.
+ * @param options.sex The sex of the person for the avatar. Can be `'female'` or `'male'`. If not provided or `'generic'`, defaults to a random selection.
+ * @param options.size The size of the image. Can be `512`, `256`, `128`, `64` or `32`. If not provided, defaults to `512`.
+ *
+ * @example
+ * personPortrait(fakerCore) // 'https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/female/512/57.jpg'
+ * personPortrait(fakerCore, { sex: 'male', size: '128' }) // 'https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait/male/128/27.jpg'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function personPortrait(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The sex of the person for the avatar.
+     * Can be `'female'` or `'male'`. `'generic'` uses a random selection.
+     *
+     * @default personSexType(fakerCore)
+     */
+    sex?: SexType;
+    /**
+     * The size of the image.
+     * Can be `512`, `256`, `128`, `64` or `32`.
+     *
+     * @default 512
+     */
+    size?: 512 | 256 | 128 | 64 | 32;
+  } = {}
+): string {
+  const { size = 512 } = options;
+  let { sex = sexType(fakerCore) } = options;
+
+  if (sex === 'generic') {
+    sex = sexType(fakerCore);
+  }
+
+  const baseURL = 'https://cdn.jsdelivr.net/gh/faker-js/assets-person-portrait';
+  return `${baseURL}/${sex}/${size}/${int(fakerCore, { min: 0, max: 99 })}.jpg`;
+}

--- a/src/modules/image/url-lorem-flickr.ts
+++ b/src/modules/image/url-lorem-flickr.ts
@@ -1,16 +1,13 @@
 import type { FakerCore } from '../../core';
-import { Faker } from '../../faker';
 import { deprecated } from '../../internal/deprecated';
 import { int } from '../number/int';
-import { url } from './url';
-import { urlLoremFlickr } from './url-lorem-flickr';
 
 /**
  * Generates a random image url provided via https://loremflickr.com.
  *
- * @param fakerCore The FakerCore to use.
  * @remark This method generates a random string representing an URL from loremflickr. Faker is not responsible for the content of the image or the service providing it.
  *
+ * @param fakerCore The FakerCore to use.
  * @param options Options for generating a URL for an image.
  * @param options.width The width of the image. Defaults to a random integer between `1` and `3999`.
  * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.
@@ -24,9 +21,9 @@ import { urlLoremFlickr } from './url-lorem-flickr';
  *
  * @since 11.0.0
  *
- * @experimental
- *
  * @deprecated LoremFlickr is no longer available, and image links will be broken. Use `url(fakerCore)` instead.
+ *
+ * @experimental
  */
 export function urlLoremFlickr(
   fakerCore: FakerCore,

--- a/src/modules/image/url-lorem-flickr.ts
+++ b/src/modules/image/url-lorem-flickr.ts
@@ -1,0 +1,68 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+import { deprecated } from '../../internal/deprecated';
+import { int } from '../number/int';
+import { url } from './url';
+import { urlLoremFlickr } from './url-lorem-flickr';
+
+/**
+ * Generates a random image url provided via https://loremflickr.com.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @remark This method generates a random string representing an URL from loremflickr. Faker is not responsible for the content of the image or the service providing it.
+ *
+ * @param options Options for generating a URL for an image.
+ * @param options.width The width of the image. Defaults to a random integer between `1` and `3999`.
+ * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.
+ * @param options.category Category to use for the image.
+ *
+ * @example
+ * urlLoremFlickr(fakerCore) // 'https://loremflickr.com/640/480?lock=1234'
+ * urlLoremFlickr(fakerCore, { width: 128 }) // 'https://loremflickr.com/128/480?lock=1234'
+ * urlLoremFlickr(fakerCore, { height: 128 }) // 'https://loremflickr.com/640/128?lock=1234'
+ * urlLoremFlickr(fakerCore, { category: 'nature' }) // 'https://loremflickr.com/640/480/nature?lock=1234'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ *
+ * @deprecated LoremFlickr is no longer available, and image links will be broken. Use `url(fakerCore)` instead.
+ */
+export function urlLoremFlickr(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The width of the image.
+     *
+     * @default numberInt(fakerCore, { min: 1, max: 3999 })
+     */
+    width?: number;
+    /**
+     * The height of the image.
+     *
+     * @default numberInt(fakerCore, { min: 1, max: 3999 })
+     */
+    height?: number;
+    /**
+     * Category to use for the image.
+     */
+    category?: string;
+  } = {}
+): string {
+  deprecated({
+    deprecated: 'urlLoremFlickr(fakerCore)',
+    proposed: 'url(fakerCore)',
+    since: '10.1.0',
+    until: '11.0.0',
+  });
+
+  const {
+    width = int(fakerCore, { min: 1, max: 3999 }),
+    height = int(fakerCore, { min: 1, max: 3999 }),
+    category,
+  } = options;
+
+  return `https://loremflickr.com/${width}/${height}${
+    category == null ? '' : `/${category}`
+  }?lock=${int(fakerCore)}`;
+}

--- a/src/modules/image/url-picsum-photos.ts
+++ b/src/modules/image/url-picsum-photos.ts
@@ -1,0 +1,90 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+import { boolean } from '../datatype/boolean';
+import { int } from '../number/int';
+import { alphanumeric } from '../string/alphanumeric';
+
+/**
+ * Generates a random image url provided via https://picsum.photos.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @remark This method generates a random string representing an URL from picsum.photos. Faker is not responsible for the content of the image or the service providing it.
+ *
+ * @param options Options for generating a URL for an image.
+ * @param options.width The width of the image. Defaults to a random integer between `1` and `3999`.
+ * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.
+ * @param options.grayscale Whether the image should be grayscale. Defaults to a random boolean value.
+ * @param options.blur Whether the image should be blurred. `0` disables the blur. Defaults to a random integer between `0` and `10`.
+ *
+ * @example
+ * urlPicsumPhotos(fakerCore) // 'https://picsum.photos/seed/NWbJM2B/640/480'
+ * urlPicsumPhotos(fakerCore, { width: 128 }) // 'https://picsum.photos/seed/NWbJM2B/128/480'
+ * urlPicsumPhotos(fakerCore, { height: 128 }) // 'https://picsum.photos/seed/NWbJM2B/640/128'
+ * urlPicsumPhotos(fakerCore, { grayscale: true }) // 'https://picsum.photos/seed/NWbJM2B/640/480?grayscale'
+ * urlPicsumPhotos(fakerCore, { blur: 4 }) // 'https://picsum.photos/seed/NWbJM2B/640/480?blur=4'
+ * urlPicsumPhotos(fakerCore, { blur: 4, grayscale: true }) // 'https://picsum.photos/seed/NWbJM2B/640/480?grayscale&blur=4'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function urlPicsumPhotos(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The width of the image.
+     *
+     * @default numberInt(fakerCore, { min: 1, max: 3999 })
+     */
+    width?: number;
+    /**
+     * The height of the image.
+     *
+     * @default numberInt(fakerCore, { min: 1, max: 3999 })
+     */
+    height?: number;
+    /**
+     * Whether the image should be grayscale.
+     *
+     * @default datatypeBoolean(fakerCore)
+     */
+    grayscale?: boolean;
+    /**
+     * Whether the image should be blurred. `0` disables the blur.
+     *
+     * @default numberInt(fakerCore, { max: 10 })
+     */
+    blur?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+  } = {}
+): string {
+  const {
+    width = int(fakerCore, { min: 1, max: 3999 }),
+    height = int(fakerCore, { min: 1, max: 3999 }),
+    grayscale = boolean(fakerCore),
+    blur = int(fakerCore, { max: 10 }),
+  } = options;
+
+  let url = `https://picsum.photos/seed/${alphanumeric(fakerCore, {
+    length: { min: 5, max: 10 },
+  })}/${width}/${height}`;
+
+  const hasValidBlur = typeof blur === 'number' && blur >= 1 && blur <= 10;
+
+  if (grayscale || hasValidBlur) {
+    url += '?';
+
+    if (grayscale) {
+      url += `grayscale`;
+    }
+
+    if (grayscale && hasValidBlur) {
+      url += '&';
+    }
+
+    if (hasValidBlur) {
+      url += `blur=${blur}`;
+    }
+  }
+
+  return url;
+}

--- a/src/modules/image/url-picsum-photos.ts
+++ b/src/modules/image/url-picsum-photos.ts
@@ -1,5 +1,4 @@
 import type { FakerCore } from '../../core';
-import { Faker } from '../../faker';
 import { boolean } from '../datatype/boolean';
 import { int } from '../number/int';
 import { alphanumeric } from '../string/alphanumeric';
@@ -7,9 +6,9 @@ import { alphanumeric } from '../string/alphanumeric';
 /**
  * Generates a random image url provided via https://picsum.photos.
  *
- * @param fakerCore The FakerCore to use.
  * @remark This method generates a random string representing an URL from picsum.photos. Faker is not responsible for the content of the image or the service providing it.
  *
+ * @param fakerCore The FakerCore to use.
  * @param options Options for generating a URL for an image.
  * @param options.width The width of the image. Defaults to a random integer between `1` and `3999`.
  * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.

--- a/src/modules/image/url.ts
+++ b/src/modules/image/url.ts
@@ -1,5 +1,4 @@
 import type { FakerCore } from '../../core';
-import { Faker } from '../../faker';
 import { arrayElement } from '../helpers/array-element';
 import { int } from '../number/int';
 import { urlPicsumPhotos } from './url-picsum-photos';
@@ -7,9 +6,9 @@ import { urlPicsumPhotos } from './url-picsum-photos';
 /**
  * Generates a random image url.
  *
- * @param fakerCore The FakerCore to use.
  * @remark This method generates a random string representing an URL from an external provider. Faker is not responsible for the content of the image or the service providing it.
  *
+ * @param fakerCore The FakerCore to use.
  * @param options Options for generating a URL for an image.
  * @param options.width The width of the image. Defaults to a random integer between `1` and `3999`.
  * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.

--- a/src/modules/image/url.ts
+++ b/src/modules/image/url.ts
@@ -1,0 +1,53 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+import { arrayElement } from '../helpers/array-element';
+import { int } from '../number/int';
+import { urlPicsumPhotos } from './url-picsum-photos';
+
+/**
+ * Generates a random image url.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @remark This method generates a random string representing an URL from an external provider. Faker is not responsible for the content of the image or the service providing it.
+ *
+ * @param options Options for generating a URL for an image.
+ * @param options.width The width of the image. Defaults to a random integer between `1` and `3999`.
+ * @param options.height The height of the image. Defaults to a random integer between `1` and `3999`.
+ *
+ * @example
+ * url(fakerCore) // 'https://picsum.photos/seed/NWbJM2B/640/480'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function url(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The width of the image.
+     *
+     * @default numberInt(fakerCore, { min: 1, max: 3999 })
+     */
+    width?: number;
+    /**
+     * The height of the image.
+     *
+     * @default numberInt(fakerCore, { min: 1, max: 3999 })
+     */
+    height?: number;
+  } = {}
+): string {
+  const {
+    width = int(fakerCore, { min: 1, max: 3999 }),
+    height = int(fakerCore, { min: 1, max: 3999 }),
+  } = options;
+
+  const urlMethod = arrayElement(fakerCore, [
+    ({ width, height }: { width?: number; height?: number }) =>
+      urlPicsumPhotos(fakerCore, { width, height, grayscale: false, blur: 0 }),
+    // Other providers may be added back here in future versions.
+  ]);
+
+  return urlMethod({ width, height });
+}


### PR DESCRIPTION
Continuation of #4057

- #4057

---

Transforms the image module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts image`
4. Cherry-pick `refactor: transform image module`
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~