### PR TITLE
feat(internet): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -12,6 +12,7 @@ export const ALLOWED_MODULES = new Set([
   'HackerModule',
   'HelpersModule',
   'ImageModule',
+  'InternetModule',
   'LocationModule',
   'LoremModule',
   'MedicalModule',

--- a/src/definitions/internet.ts
+++ b/src/definitions/internet.ts
@@ -1,4 +1,5 @@
-import type { EmojiType, HTTPStatusCodeType } from '../modules/internet';
+import type { EmojiType } from '../modules/internet/emoji';
+import type { HTTPStatusCodeType } from '../modules/internet/http-status-code';
 import type { LocaleEntry } from './definitions';
 
 /**

--- a/src/modules/internet/display-name.ts
+++ b/src/modules/internet/display-name.ts
@@ -1,0 +1,66 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+import { int } from '../number/int';
+import { firstName as personFirstName } from '../person/first-name';
+import { lastName as personLastName } from '../person/last-name';
+
+/**
+ * Generates a display name using the given person's name as base.
+ * The resulting display name may use one or both of the provided names.
+ * If the input names include Unicode characters, the resulting display name will contain Unicode characters.
+ * It will not contain spaces.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options An options object.
+ * @param options.firstName The optional first name to use. If not specified, a random one will be chosen.
+ * @param options.lastName The optional last name to use. If not specified, a random one will be chosen.
+ *
+ * @see username(fakerCore): For generating a plain ASCII username.
+ *
+ * @example
+ * displayName(fakerCore) // 'Nettie_Zboncak40'
+ * displayName(fakerCore, { firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne98' - note surname not used.
+ * displayName(fakerCore, { firstName: 'John', lastName: 'Doe' }) // 'John.Doe'
+ * displayName(fakerCore, { firstName: 'Hélene', lastName: 'Müller' }) // 'Hélene_Müller11'
+ * displayName(fakerCore, { firstName: 'Фёдор', lastName: 'Достоевский' }) // 'Фёдор.Достоевский50'
+ * displayName(fakerCore, { firstName: '大羽', lastName: '陳' }) // '大羽.陳'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function displayName(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The optional first name to use.
+     *
+     * @default personFirstName(fakerCore)
+     */
+    firstName?: string;
+    /**
+     * The optional last name to use.
+     *
+     * @default personLastName(fakerCore)
+     */
+    lastName?: string;
+  } = {}
+): string {
+  const {
+    firstName = personFirstName(fakerCore),
+    lastName = personLastName(fakerCore),
+  } = options;
+
+  const separator = arrayElement(fakerCore, ['.', '_']);
+  const disambiguator = int(fakerCore, 99);
+  const strategies: Array<() => string> = [
+    () => `${firstName}${disambiguator}`,
+    () => `${firstName}${separator}${lastName}`,
+    () => `${firstName}${separator}${lastName}${disambiguator}`,
+  ];
+
+  let result = arrayElement(fakerCore, strategies)();
+  result = result.replaceAll("'", '');
+  result = result.replaceAll(' ', '');
+  return result;
+}

--- a/src/modules/internet/domain-name.ts
+++ b/src/modules/internet/domain-name.ts
@@ -1,0 +1,19 @@
+import type { FakerCore } from '../../core';
+import { domainSuffix } from './domain-suffix';
+import { domainWord } from './domain-word';
+
+/**
+ * Generates a random domain name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * domainName(fakerCore) // 'slow-timer.info'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function domainName(fakerCore: FakerCore): string {
+  return `${domainWord(fakerCore)}.${domainSuffix(fakerCore)}`;
+}

--- a/src/modules/internet/domain-suffix.ts
+++ b/src/modules/internet/domain-suffix.ts
@@ -1,0 +1,19 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random domain suffix.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * domainSuffix(fakerCore) // 'com'
+ * domainSuffix(fakerCore) // 'name'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function domainSuffix(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.internet.domain_suffix);
+}

--- a/src/modules/internet/domain-word.ts
+++ b/src/modules/internet/domain-word.ts
@@ -1,0 +1,25 @@
+import type { FakerCore } from '../../core';
+import { adjective } from '../word/adjective';
+import { noun } from '../word/noun';
+
+/**
+ * Generates a random domain word.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * domainWord(fakerCore) // 'close-reality'
+ * domainWord(fakerCore) // 'weird-cytoplasm'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function domainWord(fakerCore: FakerCore): string {
+  // Generate an ASCII "word" in the form `noun-adjective`
+  // For locales with non-ASCII characters, we fall back to lorem words, or a random string
+
+  const word1 = makeValidDomainWordSlug(fakerCore, adjective(fakerCore));
+  const word2 = makeValidDomainWordSlug(fakerCore, noun(fakerCore));
+  return `${word1}-${word2}`.toLowerCase();
+}

--- a/src/modules/internet/domain-word.ts
+++ b/src/modules/internet/domain-word.ts
@@ -1,6 +1,45 @@
 import type { FakerCore } from '../../core';
+import { slugify } from '../helpers/slugify';
+import { word as loremWord } from '../lorem/word';
+import { alpha } from '../string/alpha';
 import { adjective } from '../word/adjective';
 import { noun } from '../word/noun';
+
+/**
+ * Checks whether the given string is a valid slug for `domainWord`s.
+ *
+ * @param slug The slug to check.
+ */
+function isValidDomainWordSlug(slug: string): boolean {
+  return /^[a-z][a-z-]*[a-z]$/i.exec(slug) !== null;
+}
+
+// Temp export
+/**
+ * Tries various ways to produce a valid domain word slug, falling back to a random string if needed.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param word The initial word to slugify.
+ */
+export function makeValidDomainWordSlug(
+  fakerCore: FakerCore,
+  word: string
+): string {
+  const slug1 = slugify(fakerCore, word);
+  if (isValidDomainWordSlug(slug1)) {
+    return slug1;
+  }
+
+  const slug2 = slugify(fakerCore, loremWord(fakerCore));
+  if (isValidDomainWordSlug(slug2)) {
+    return slug2;
+  }
+
+  return alpha(fakerCore, {
+    casing: 'lower',
+    length: { min: 4, max: 8 },
+  });
+}
 
 /**
  * Generates a random domain word.

--- a/src/modules/internet/domain-word.ts
+++ b/src/modules/internet/domain-word.ts
@@ -14,17 +14,13 @@ function isValidDomainWordSlug(slug: string): boolean {
   return /^[a-z][a-z-]*[a-z]$/i.exec(slug) !== null;
 }
 
-// Temp export
 /**
  * Tries various ways to produce a valid domain word slug, falling back to a random string if needed.
  *
  * @param fakerCore The FakerCore to use.
  * @param word The initial word to slugify.
  */
-export function makeValidDomainWordSlug(
-  fakerCore: FakerCore,
-  word: string
-): string {
+function makeValidDomainWordSlug(fakerCore: FakerCore, word: string): string {
   const slug1 = slugify(fakerCore, word);
   if (isValidDomainWordSlug(slug1)) {
     return slug1;

--- a/src/modules/internet/email.ts
+++ b/src/modules/internet/email.ts
@@ -1,0 +1,87 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+import { username } from './username';
+
+/**
+ * Generates an email address using the given person's name as base.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The options to use.
+ * @param options.firstName The optional first name to use. If not specified, a random one will be chosen.
+ * @param options.lastName The optional last name to use. If not specified, a random one will be chosen.
+ * @param options.provider The mail provider domain to use. If not specified, a random free mail provider will be chosen.
+ * @param options.allowSpecialCharacters Whether special characters such as ``.!#$%&'*+-/=?^_`{|}~`` should be included
+ * in the email address. Defaults to `false`.
+ *
+ * @example
+ * email(fakerCore) // 'Kassandra4@hotmail.com'
+ * email(fakerCore, { firstName: 'Jeanne'}) // 'Jeanne63@yahoo.com'
+ * email(fakerCore, { firstName: 'Jeanne'}) // 'Jeanne_Smith63@yahoo.com'
+ * email(fakerCore, { firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne.Doe63@yahoo.com'
+ * email(fakerCore, { firstName: 'Jeanne', lastName: 'Doe', provider: 'example.fakerjs.dev' }) // 'Jeanne_Doe88@example.fakerjs.dev'
+ * email(fakerCore, { firstName: 'Jeanne', lastName: 'Doe', provider: 'example.fakerjs.dev', allowSpecialCharacters: true }) // 'Jeanne%Doe88@example.fakerjs.dev'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function email(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The optional first name to use.
+     *
+     * @default personFirstName(fakerCore)
+     */
+    firstName?: string;
+    /**
+     * The optional last name to use.
+     *
+     * @default personLastName(fakerCore)
+     */
+    lastName?: string;
+    /**
+     * The mail provider domain to use. If not specified, a random free mail provider will be chosen.
+     */
+    provider?: string;
+    /**
+     * Whether special characters such as ``.!#$%&'*+-/=?^_`{|}~`` should be included in the email address.
+     *
+     * @default false
+     */
+    allowSpecialCharacters?: boolean;
+  } = {}
+): string {
+  const {
+    firstName,
+    lastName,
+    provider = arrayElement(fakerCore, fakerCore.locale.internet.free_email),
+    allowSpecialCharacters = false,
+  } = options;
+
+  let localPart: string = username(fakerCore, { firstName, lastName });
+  // Strip any special characters from the local part of the email address
+  // This could happen if invalid chars are passed in manually in the firstName/lastName
+  localPart = localPart.replaceAll(/[^A-Za-z0-9._+-]+/g, '');
+
+  // The local part of an email address is limited to 64 chars per RFC 3696
+  // We limit to 50 chars to be more realistic
+  localPart = localPart.substring(0, 50);
+  if (allowSpecialCharacters) {
+    const usernameChars: string[] = [...'._-'];
+    const specialChars: string[] = [...".!#$%&'*+-/=?^_`{|}~"];
+    localPart = localPart.replace(
+      arrayElement(fakerCore, usernameChars),
+      arrayElement(fakerCore, specialChars)
+    );
+  }
+
+  // local parts may not contain two or more consecutive . characters
+  localPart = localPart.replaceAll(/\.{2,}/g, '.');
+
+  // local parts may not start with or end with a . character
+  localPart = localPart.replace(/^\./, '');
+  localPart = localPart.replace(/\.$/, '');
+
+  return `${localPart}@${provider}`;
+}

--- a/src/modules/internet/emoji.ts
+++ b/src/modules/internet/emoji.ts
@@ -1,6 +1,18 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export type EmojiType =
+  | 'smiley'
+  | 'body'
+  | 'person'
+  | 'nature'
+  | 'food'
+  | 'travel'
+  | 'activity'
+  | 'object'
+  | 'symbol'
+  | 'flag';
+
 /**
  * Generates a random emoji.
  *

--- a/src/modules/internet/emoji.ts
+++ b/src/modules/internet/emoji.ts
@@ -1,0 +1,35 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random emoji.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options Options object.
+ * @param options.types A list of the emoji types that should be included. Possible values are `'smiley'`, `'body'`, `'person'`, `'nature'`, `'food'`, `'travel'`, `'activity'`, `'object'`, `'symbol'`, `'flag'`. By default, emojis from any type will be included.
+ *
+ * @example
+ * emoji(fakerCore) // '🥰'
+ * emoji(fakerCore, { types: ['food', 'nature'] }) // '🥐'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function emoji(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * A list of the emoji types that should be used.
+     *
+     * @default Object.keys(faker.definitions.internet.emoji)
+     */
+    types?: ReadonlyArray<EmojiType>;
+  } = {}
+): string {
+  const {
+    types = Object.keys(fakerCore.locale.internet.emoji) as EmojiType[],
+  } = options;
+  const emojiType = arrayElement(fakerCore, types);
+  return arrayElement(fakerCore, fakerCore.locale.internet.emoji[emojiType]);
+}

--- a/src/modules/internet/example-email.ts
+++ b/src/modules/internet/example-email.ts
@@ -1,0 +1,62 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+import { email } from './email';
+
+/**
+ * Generates an email address using an example mail provider using the given person's name as base.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options An options object.
+ * @param options.firstName The optional first name to use. If not specified, a random one will be chosen.
+ * @param options.lastName The optional last name to use. If not specified, a random one will be chosen.
+ * @param options.allowSpecialCharacters Whether special characters such as ``.!#$%&'*+-/=?^_`{|}~`` should be included
+ * in the email address. Defaults to `false`.
+ *
+ * @example
+ * exampleEmail(fakerCore) // 'Helmer.Graham23@example.com'
+ * exampleEmail(fakerCore, { firstName: 'Jeanne' }) // 'Jeanne96@example.net'
+ * exampleEmail(fakerCore, { firstName: 'Jeanne' }) // 'Jeanne.Smith96@example.net'
+ * exampleEmail(fakerCore, { firstName: 'Jeanne', lastName: 'Doe' }) // 'Jeanne_Doe96@example.net'
+ * exampleEmail(fakerCore, { firstName: 'Jeanne', lastName: 'Doe', allowSpecialCharacters: true }) // 'Jeanne%Doe88@example.com'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function exampleEmail(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The optional first name to use.
+     *
+     * @default personFirstName(fakerCore)
+     */
+    firstName?: string;
+    /**
+     * The optional last name to use.
+     *
+     * @default personLastName(fakerCore)
+     */
+    lastName?: string;
+    /**
+     * Whether special characters such as ``.!#$%&'*+-/=?^_`{|}~`` should be included in the email address.
+     *
+     * @default false
+     */
+    allowSpecialCharacters?: boolean;
+  } = {}
+): string {
+  const { firstName, lastName, allowSpecialCharacters = false } = options;
+
+  const provider = arrayElement(
+    fakerCore,
+    fakerCore.locale.internet.example_email
+  );
+
+  return email(fakerCore, {
+    firstName,
+    lastName,
+    provider,
+    allowSpecialCharacters,
+  });
+}

--- a/src/modules/internet/http-method.ts
+++ b/src/modules/internet/http-method.ts
@@ -1,0 +1,35 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random http method.
+ *
+ * Can be either of the following:
+ *
+ * - `GET`
+ * - `POST`
+ * - `PUT`
+ * - `DELETE`
+ * - `PATCH`
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * httpMethod(fakerCore) // 'PATCH'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function httpMethod(
+  fakerCore: FakerCore
+): 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' {
+  const httpMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] = [
+    'GET',
+    'POST',
+    'PUT',
+    'DELETE',
+    'PATCH',
+  ];
+  return arrayElement(fakerCore, httpMethods);
+}

--- a/src/modules/internet/http-status-code.ts
+++ b/src/modules/internet/http-status-code.ts
@@ -1,0 +1,40 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random HTTP status code.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options Options object.
+ * @param options.types A list of the HTTP status code types that should be used.
+ *
+ * @example
+ * httpStatusCode(fakerCore) // 200
+ * httpStatusCode(fakerCore, { types: ['success', 'serverError'] }) // 500
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function httpStatusCode(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * A list of the HTTP status code types that should be used.
+     *
+     * @default Object.keys(faker.definitions.internet.http_status_code)
+     */
+    types?: ReadonlyArray<HTTPStatusCodeType>;
+  } = {}
+): number {
+  const {
+    types = Object.keys(
+      fakerCore.locale.internet.http_status_code
+    ) as HTTPStatusCodeType[],
+  } = options;
+  const httpStatusCodeType = arrayElement(fakerCore, types);
+  return arrayElement(
+    fakerCore,
+    fakerCore.locale.internet.http_status_code[httpStatusCodeType]
+  );
+}

--- a/src/modules/internet/http-status-code.ts
+++ b/src/modules/internet/http-status-code.ts
@@ -1,6 +1,13 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export type HTTPStatusCodeType =
+  | 'informational'
+  | 'success'
+  | 'clientError'
+  | 'serverError'
+  | 'redirection';
+
 /**
  * Generates a random HTTP status code.
  *
@@ -22,7 +29,7 @@ export function httpStatusCode(
     /**
      * A list of the HTTP status code types that should be used.
      *
-     * @default Object.keys(faker.definitions.internet.http_status_code)
+     * @default Object.keys(fakerCore.locale.internet.http_status_code)
      */
     types?: ReadonlyArray<HTTPStatusCodeType>;
   } = {}

--- a/src/modules/internet/index.ts
+++ b/src/modules/internet/index.ts
@@ -1,1 +1,6 @@
+export type { EmojiType } from './emoji';
+export type { HTTPStatusCodeType } from './http-status-code';
+export { IPv4Network } from './ipv4';
+export type { IPv4NetworkType } from './ipv4';
 export * from './module';
+export type { HTTPProtocolType } from './url';

--- a/src/modules/internet/ip.ts
+++ b/src/modules/internet/ip.ts
@@ -1,0 +1,21 @@
+import type { FakerCore } from '../../core';
+import { boolean } from '../datatype/boolean';
+import { ipv4 } from './ipv4';
+import { ipv6 } from './ipv6';
+
+/**
+ * Generates a random IPv4 or IPv6 address.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * ip(fakerCore) // '245.108.222.0'
+ * ip(fakerCore) // '4e5:f9c5:4337:abfd:9caf:1135:41ad:d8d3'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function ip(fakerCore: FakerCore): string {
+  return boolean(fakerCore) ? ipv4(fakerCore) : ipv6(fakerCore);
+}

--- a/src/modules/internet/ipv4.ts
+++ b/src/modules/internet/ipv4.ts
@@ -2,6 +2,83 @@ import type { FakerCore } from '../../core';
 import { FakerError } from '../../errors/faker-error';
 import { int } from '../number/int';
 
+export enum IPv4Network {
+  /**
+   * Equivalent to: `0.0.0.0/0`
+   */
+  Any = 'any',
+  /**
+   * Equivalent to: `127.0.0.0/8`
+   *
+   * @see [RFC1122](https://www.rfc-editor.org/rfc/rfc1122)
+   */
+  Loopback = 'loopback',
+  /**
+   * Equivalent to: `10.0.0.0/8`
+   *
+   * @see [RFC1918](https://www.rfc-editor.org/rfc/rfc1918)
+   */
+  PrivateA = 'private-a',
+  /**
+   * Equivalent to: `172.16.0.0/12`
+   *
+   * @see [RFC1918](https://www.rfc-editor.org/rfc/rfc1918)
+   */
+  PrivateB = 'private-b',
+  /**
+   * Equivalent to: `192.168.0.0/16`
+   *
+   * @see [RFC1918](https://www.rfc-editor.org/rfc/rfc1918)
+   */
+  PrivateC = 'private-c',
+  /**
+   * Equivalent to: `192.0.2.0/24`
+   *
+   * @see [RFC5737](https://www.rfc-editor.org/rfc/rfc5737)
+   */
+  TestNet1 = 'test-net-1',
+  /**
+   * Equivalent to: `198.51.100.0/24`
+   *
+   * @see [RFC5737](https://www.rfc-editor.org/rfc/rfc5737)
+   */
+  TestNet2 = 'test-net-2',
+  /**
+   * Equivalent to: `203.0.113.0/24`
+   *
+   * @see [RFC5737](https://www.rfc-editor.org/rfc/rfc5737)
+   */
+  TestNet3 = 'test-net-3',
+  /**
+   * Equivalent to: `169.254.0.0/16`
+   *
+   * @see [RFC3927](https://www.rfc-editor.org/rfc/rfc3927)
+   */
+  LinkLocal = 'link-local',
+  /**
+   * Equivalent to: `224.0.0.0/4`
+   *
+   * @see [RFC5771](https://www.rfc-editor.org/rfc/rfc5771)
+   */
+  Multicast = 'multicast',
+}
+
+export type IPv4NetworkType = `${IPv4Network}`;
+
+// Temp export
+export const ipv4Networks: Record<IPv4Network, string> = {
+  [IPv4Network.Any]: '0.0.0.0/0',
+  [IPv4Network.Loopback]: '127.0.0.0/8',
+  [IPv4Network.PrivateA]: '10.0.0.0/8',
+  [IPv4Network.PrivateB]: '172.16.0.0/12',
+  [IPv4Network.PrivateC]: '192.168.0.0/16',
+  [IPv4Network.TestNet1]: '192.0.2.0/24',
+  [IPv4Network.TestNet2]: '198.51.100.0/24',
+  [IPv4Network.TestNet3]: '203.0.113.0/24',
+  [IPv4Network.LinkLocal]: '169.254.0.0/16',
+  [IPv4Network.Multicast]: '224.0.0.0/4',
+};
+
 /**
  * Generates a random IPv4 address.
  *
@@ -99,7 +176,6 @@ export function ipv4(
         network?: IPv4NetworkType;
       }
 ): string;
-
 export function ipv4(
   fakerCore: FakerCore,
   options: { cidrBlock?: string; network?: IPv4NetworkType } = {}

--- a/src/modules/internet/ipv4.ts
+++ b/src/modules/internet/ipv4.ts
@@ -65,8 +65,7 @@ export enum IPv4Network {
 
 export type IPv4NetworkType = `${IPv4Network}`;
 
-// Temp export
-export const ipv4Networks: Record<IPv4Network, string> = {
+const ipv4Networks: Record<IPv4Network, string> = {
   [IPv4Network.Any]: '0.0.0.0/0',
   [IPv4Network.Loopback]: '127.0.0.0/8',
   [IPv4Network.PrivateA]: '10.0.0.0/8',

--- a/src/modules/internet/ipv4.ts
+++ b/src/modules/internet/ipv4.ts
@@ -1,0 +1,146 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import { int } from '../number/int';
+
+/**
+ * Generates a random IPv4 address.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.cidrBlock The optional CIDR block to use. Must be in the format `x.x.x.x/y`. Defaults to `'0.0.0.0/0'`.
+ *
+ * @throws {FakerError} If the resolved CIDR block does not use the format `x.x.x.x/y`.
+ * @throws {FakerError} If the resolved CIDR block has a prefix length greater than 32.
+ * @throws {FakerError} If the resolved CIDR block contains an octet greater than 255.
+ *
+ * @example
+ * ipv4(fakerCore) // '245.108.222.0'
+ * ipv4(fakerCore, { cidrBlock: '192.168.0.0/16' }) // '192.168.215.224'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function ipv4(
+  fakerCore: FakerCore,
+  options?: {
+    /**
+     * The optional CIDR block to use. Must be in the format `x.x.x.x/y`.
+     *
+     * @default '0.0.0.0/0'
+     */
+    cidrBlock?: string;
+  }
+): string;
+/**
+ * Generates a random IPv4 address.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.network The optional network to use. This is intended as an alias for well-known `cidrBlock`s. Defaults to `'any'`.
+ *
+ * @example
+ * ipv4(fakerCore) // '245.108.222.0'
+ * ipv4(fakerCore, { network: 'private-a' }) // '10.199.154.205'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function ipv4(
+  fakerCore: FakerCore,
+  options?: {
+    /**
+     * The optional network to use. This is intended as an alias for well-known `cidrBlock`s.
+     *
+     * @default 'any'
+     */
+    network?: IPv4NetworkType;
+  }
+): string;
+/**
+ * Generates a random IPv4 address.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.cidrBlock The optional CIDR block to use. Must be in the format `x.x.x.x/y`. Defaults to `'0.0.0.0/0'`.
+ * @param options.network The optional network to use. This is intended as an alias for well-known `cidrBlock`s. Defaults to `'any'`.
+ *
+ * @throws {FakerError} If the resolved CIDR block does not use the format `x.x.x.x/y`.
+ * @throws {FakerError} If the resolved CIDR block has a prefix length greater than 32.
+ * @throws {FakerError} If the resolved CIDR block contains an octet greater than 255.
+ *
+ * @example
+ * ipv4(fakerCore) // '245.108.222.0'
+ * ipv4(fakerCore, { cidrBlock: '192.168.0.0/16' }) // '192.168.215.224'
+ * ipv4(fakerCore, { network: 'private-a' }) // '10.199.154.205'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function ipv4(
+  fakerCore: FakerCore,
+  options?:
+    | {
+        /**
+         * The optional CIDR block to use. Must be in the format `x.x.x.x/y`.
+         *
+         * @default '0.0.0.0/0'
+         */
+        cidrBlock?: string;
+      }
+    | {
+        /**
+         * The optional network to use. This is intended as an alias for well-known `cidrBlock`s.
+         *
+         * @default 'any'
+         */
+        network?: IPv4NetworkType;
+      }
+): string;
+
+export function ipv4(
+  fakerCore: FakerCore,
+  options: { cidrBlock?: string; network?: IPv4NetworkType } = {}
+): string {
+  const { network = 'any', cidrBlock = ipv4Networks[network] } = options;
+
+  if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2}$/.test(cidrBlock)) {
+    throw new FakerError(
+      `Invalid CIDR block provided: ${cidrBlock}. Must be in the format x.x.x.x/y.`
+    );
+  }
+
+  const [ipText, subnet] = cidrBlock.split('/', 2);
+  const subnetValue = Number.parseInt(subnet, 10);
+  if (subnetValue > 32) {
+    throw new FakerError(
+      `Invalid CIDR block provided: ${cidrBlock}. Prefix length must be between 0 and 32.`
+    );
+  }
+
+  const octets = ipText.split('.').map(Number);
+  if (octets.some((octet) => octet > 255)) {
+    throw new FakerError(
+      `Invalid CIDR block provided: ${cidrBlock}. Each octet must be between 0 and 255.`
+    );
+  }
+
+  if (subnetValue === 32) {
+    return ipText;
+  }
+
+  const subnetMask = 0xffffffff >>> subnetValue;
+  const [rawIp1, rawIp2, rawIp3, rawIp4] = octets;
+  const rawIp = (rawIp1 << 24) | (rawIp2 << 16) | (rawIp3 << 8) | rawIp4;
+  const networkIp = rawIp & ~subnetMask;
+  const hostOffset = int(fakerCore, subnetMask);
+  const ip = networkIp | hostOffset;
+  return [
+    (ip >>> 24) & 0xff,
+    (ip >>> 16) & 0xff,
+    (ip >>> 8) & 0xff,
+    ip & 0xff,
+  ].join('.');
+}

--- a/src/modules/internet/ipv6.ts
+++ b/src/modules/internet/ipv6.ts
@@ -1,0 +1,24 @@
+import type { FakerCore } from '../../core';
+import { hexadecimal } from '../string/hexadecimal';
+
+/**
+ * Generates a random IPv6 address.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * ipv6(fakerCore) // '269f:1230:73e3:318d:842b:daab:326d:897b'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function ipv6(fakerCore: FakerCore): string {
+  return Array.from({ length: 8 }, () =>
+    hexadecimal(fakerCore, {
+      length: 4,
+      casing: 'lower',
+      prefix: '',
+    })
+  ).join(':');
+}

--- a/src/modules/internet/jwt-algorithm.ts
+++ b/src/modules/internet/jwt-algorithm.ts
@@ -1,0 +1,21 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random JWT (JSON Web Token) Algorithm.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @see jwt(fakerCore): For generating random JWT (JSON Web Token).
+ *
+ * @example
+ * jwtAlgorithm(fakerCore) // 'HS256'
+ * jwtAlgorithm(fakerCore) // 'RS512'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function jwtAlgorithm(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.internet.jwt_algorithm);
+}

--- a/src/modules/internet/jwt.ts
+++ b/src/modules/internet/jwt.ts
@@ -1,0 +1,99 @@
+import type { FakerCore } from '../../core';
+import { toBase64Url } from '../../internal/base64';
+import { getDefaultRefDate } from '../../utils/get-default-ref-date';
+import { name } from '../company/name';
+import { anytime } from '../date/anytime';
+import { recent } from '../date/recent';
+import { soon } from '../date/soon';
+import { alphanumeric } from '../string/alphanumeric';
+import { uuid } from '../string/uuid';
+import { jwtAlgorithm } from './jwt-algorithm';
+
+/**
+ * Generates a random JWT (JSON Web Token).
+ *
+ * Please note that this method generates a random signature instead of a valid one.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object.
+ * @param options.header The Header to use for the token. Defaults to a random object with the following fields: `alg` and `typ`.
+ * @param options.payload The Payload to use for the token. Defaults to a random object with the following fields: `iat`, `exp`, `nbf`, `iss`, `sub`, `aud`, and `jti`.
+ * @param options.refDate The date to use as reference point for the newly generated date.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7519
+ * @see jwtAlgorithm(fakerCore): For generating random JWT (JSON Web Token) Algorithm.
+ *
+ * @example
+ * jwt(fakerCore) // 'eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MzI2MzgxMDYsImV4cCI6MTczMjY5MjUwOSwibmJmIjoxNzA1MDgxNjQ4LCJpc3MiOiJHdXRrb3dza2kgYW5kIFNvbnMiLCJzdWIiOiJlMzQxZjMwNS0yM2I2LTRkYmQtOTY2ZC1iNDRiZmM0ZGIzMGUiLCJhdWQiOiI0YzMwZGE3Yi0zZDUzLTQ4OGUtYTAyZC0zOWI2MDZiZmYxMTciLCJqdGkiOiJiMGZmOTMzOC04ODMwLTRmNDgtYjA3Ny1kNDNmMjU2OGZlYzAifQ.oDLVR73M0u5SjMPlc1aruxbdK7l2titXSeo9J5M1JUd65a1X9MhCz7FOobtX8eaj'
+ * jwt(fakerCore, { header: { alg: 'HS256' }}) // 'eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MTg2MTM3MTIsImV4cCI6MTcxODYzMzY3OSwibmJmIjoxNjk3MjYzNjMwLCJpc3MiOiJEb3lsZSBhbmQgU29ucyIsInN1YiI6IjYxYWRkYWFmLWY4MjktNDkzZS1iNTI1LTJjMGJkNjkzOTdjNyIsImF1ZCI6IjczNjcyMjVjLWIwMWMtNGE1My1hYzQyLTYwOWJkZmI1MzBiOCIsImp0aSI6IjU2Y2ZkZjAxLWRhMzMtNGUxNi04MzJiLTFlYTk3ZGY1MTQ2YSJ9.5iUgaCaFVPZ8d1QD0xMjoeJbmPVyUfKfoRQ6Njzm5MLp5F4UMh5REbPCrW70fAkr'
+ * jwt(fakerCore, { payload: { iss: 'Acme' }}) // 'eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJBY21lIn0.syUt0GBukNac8Cn1AGKFq2SWAXWy1YIfl0uOYiwg6TZ3omAW0c7FGWY6bC7ZOFSt'
+ * jwt(fakerCore, { refDate: '2020-01-01T00:00:00.000Z' }) // 'eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1Nzc4MDY4NDUsImV4cCI6MTU3Nzg0NjI4MCwibmJmIjoxNTgxNTQyMDYwLCJpc3MiOiJLcmVpZ2VyLCBBbHRlbndlcnRoIGFuZCBQYXVjZWsiLCJzdWIiOiI5NzVjMjMyOS02MDlhLTRjYTYtYjBkZi05ZmY4MGZiNDUwN2QiLCJhdWQiOiI0ODQxZWYwNi01OWYwLTQzMWEtYmFmZi0xMjkxZmRhZDdhNjgiLCJqdGkiOiJmNDBjZTJiYi00ZWYyLTQ1MjMtOGIxMy1kN2Q4NTA5N2M2ZTUifQ.cuClEZQ0CyPIMVS5uxrMwWXz0wcqFFdt0oNne3PMryyly0jghkxVurss2TapMC3C'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function jwt(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The header to use for the token. If present, it will replace any default values.
+     *
+     * @default
+     * {
+     *   alg: jwtAlgorithm(fakerCore),
+     *   typ: 'JWT'
+     * }
+     */
+    header?: Record<string, unknown>;
+    /**
+     * The payload to use for the token. If present, it will replace any default values.
+     *
+     * @default
+     * {
+     *   iat: dateRecent(fakerCore),
+     *   exp: dateSoon(fakerCore),
+     *   nbf: dateAnytime(fakerCore),
+     *   iss: companyName(fakerCore),
+     *   sub: stringUuid(fakerCore),
+     *   aud: stringUuid(fakerCore),
+     *   jti: stringUuid(fakerCore)
+     * }
+     */
+    payload?: Record<string, unknown>;
+    /**
+     * The date to use as reference point for the newly generated date.
+     *
+     * @default getDefaultRefDate(fakerCore)
+     */
+    refDate?: string | Date | number;
+  } = {}
+): string {
+  const { refDate = getDefaultRefDate(fakerCore) } = options;
+
+  const iatDefault = recent(fakerCore, { refDate });
+
+  const {
+    header = {
+      alg: jwtAlgorithm(fakerCore),
+      typ: 'JWT',
+    },
+    payload = {
+      iat: Math.round(iatDefault.valueOf() / 1000),
+      exp: Math.round(
+        soon(fakerCore, { refDate: iatDefault }).valueOf() / 1000
+      ),
+      nbf: Math.round(anytime(fakerCore, { refDate }).valueOf() / 1000),
+      iss: name(fakerCore),
+      sub: uuid(fakerCore),
+      aud: uuid(fakerCore),
+      jti: uuid(fakerCore),
+    },
+  } = options;
+
+  const encodedHeader = toBase64Url(JSON.stringify(header));
+  const encodedPayload = toBase64Url(JSON.stringify(payload));
+  const signature = alphanumeric(fakerCore, 64);
+
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}

--- a/src/modules/internet/mac.ts
+++ b/src/modules/internet/mac.ts
@@ -67,7 +67,6 @@ export function mac(
         separator?: string;
       }
 ): string;
-
 export function mac(
   fakerCore: FakerCore,
   options:

--- a/src/modules/internet/mac.ts
+++ b/src/modules/internet/mac.ts
@@ -1,0 +1,106 @@
+import type { FakerCore } from '../../core';
+import { hex } from '../number/hex';
+
+/**
+ * Generates a random mac address.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options An options object.
+ * @param options.separator The optional separator to use. Can be either `':'`, `'-'` or `''`. Defaults to `':'`.
+ *
+ * @example
+ * mac(fakerCore) // '32:8e:2e:09:c6:05'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function mac(
+  fakerCore: FakerCore,
+  options?: {
+    /**
+     * The optional separator to use. Can be either `':'`, `'-'` or `''`.
+     *
+     * @default ':'
+     */
+    separator?: string;
+  }
+): string;
+/**
+ * Generates a random mac address.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param separator The optional separator to use. Can be either `':'`, `'-'` or `''`. Defaults to `':'`.
+ *
+ * @example
+ * mac(fakerCore) // '32:8e:2e:09:c6:05'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function mac(fakerCore: FakerCore, separator?: string): string;
+/**
+ * Generates a random mac address.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional separator or an options object.
+ * @param options.separator The optional separator to use. Can be either `':'`, `'-'` or `''`. Defaults to `':'`.
+ *
+ * @example
+ * mac(fakerCore) // '32:8e:2e:09:c6:05'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function mac(
+  fakerCore: FakerCore,
+  options?:
+    | string
+    | {
+        /**
+         * The optional separator to use. Can be either `':'`, `'-'` or `''`.
+         *
+         * @default ':'
+         */
+        separator?: string;
+      }
+): string;
+
+export function mac(
+  fakerCore: FakerCore,
+  options:
+    | string
+    | {
+        /**
+         * The optional separator to use. Can be either `':'`, `'-'` or `''`.
+         *
+         * @default ':'
+         */
+        separator?: string;
+      } = {}
+): string {
+  if (typeof options === 'string') {
+    options = { separator: options };
+  }
+
+  let { separator = ':' } = options;
+
+  let i: number;
+  let mac = '';
+
+  const acceptableSeparators = [':', '-', ''];
+  if (!acceptableSeparators.includes(separator)) {
+    separator = ':';
+  }
+
+  for (i = 0; i < 12; i++) {
+    mac += hex(fakerCore, 15);
+    if (i !== 11 && i % 2 === 1) {
+      mac += separator;
+    }
+  }
+
+  return mac;
+}

--- a/src/modules/internet/module.ts
+++ b/src/modules/internet/module.ts
@@ -1,13 +1,29 @@
-import { FakerError } from '../../errors/faker-error';
-import { toBase64Url } from '../../internal/base64';
 import { ModuleBase } from '../../internal/module-base';
-import { charMapping } from './_char-mappings';
-import { makeValidDomainWordSlug } from './domain-word';
+import { displayName as internetDisplayName } from './display-name';
+import { domainName as internetDomainName } from './domain-name';
+import { domainSuffix as internetDomainSuffix } from './domain-suffix';
+import { domainWord as internetDomainWord } from './domain-word';
+import { email as internetEmail } from './email';
 import type { EmojiType } from './emoji';
+import { emoji as internetEmoji } from './emoji';
+import { exampleEmail as internetExampleEmail } from './example-email';
+import { httpMethod as internetHttpMethod } from './http-method';
 import type { HTTPStatusCodeType } from './http-status-code';
+import { httpStatusCode as internetHttpStatusCode } from './http-status-code';
+import { ip as internetIp } from './ip';
 import type { IPv4NetworkType } from './ipv4';
-import { ipv4Networks } from './ipv4';
+import { ipv4 as internetIpv4 } from './ipv4';
+import { ipv6 as internetIpv6 } from './ipv6';
+import { jwt as internetJwt } from './jwt';
+import { jwtAlgorithm as internetJwtAlgorithm } from './jwt-algorithm';
+import { mac as internetMac } from './mac';
+import { password as internetPassword } from './password';
+import { port as internetPort } from './port';
+import { protocol as internetProtocol } from './protocol';
 import type { HTTPProtocolType } from './url';
+import { url as internetUrl } from './url';
+import { userAgent as internetUserAgent } from './user-agent';
+import { username as internetUsername } from './username';
 
 /**
  * Module to generate internet related entries.
@@ -23,6 +39,11 @@ import type { HTTPProtocolType } from './url';
  * You also have access to a number of the more technical elements of web requests, such as [`httpMethod`](https://fakerjs.dev/api/internet.html#httpmethod), [`httpStatusCode`](https://fakerjs.dev/api/internet.html#httpstatuscode), [`ip`](https://fakerjs.dev/api/internet.html#ip), [`mac`](https://fakerjs.dev/api/internet.html#mac), [`userAgent`](https://fakerjs.dev/api/internet.html#useragent), and [`port`](https://fakerjs.dev/api/internet.html#port).
  */
 export class InternetModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree internet' to update the methods from their respective files.
+   */
+
   /**
    * Generates an email address using the given person's name as base.
    *
@@ -69,40 +90,7 @@ export class InternetModule extends ModuleBase {
       allowSpecialCharacters?: boolean;
     } = {}
   ): string {
-    const {
-      firstName,
-      lastName,
-      provider = this.faker.helpers.arrayElement(
-        this.faker.definitions.internet.free_email
-      ),
-      allowSpecialCharacters = false,
-    } = options;
-
-    let localPart: string = this.username({ firstName, lastName });
-    // Strip any special characters from the local part of the email address
-    // This could happen if invalid chars are passed in manually in the firstName/lastName
-    localPart = localPart.replaceAll(/[^A-Za-z0-9._+-]+/g, '');
-
-    // The local part of an email address is limited to 64 chars per RFC 3696
-    // We limit to 50 chars to be more realistic
-    localPart = localPart.substring(0, 50);
-    if (allowSpecialCharacters) {
-      const usernameChars: string[] = [...'._-'];
-      const specialChars: string[] = [...".!#$%&'*+-/=?^_`{|}~"];
-      localPart = localPart.replace(
-        this.faker.helpers.arrayElement(usernameChars),
-        this.faker.helpers.arrayElement(specialChars)
-      );
-    }
-
-    // local parts may not contain two or more consecutive . characters
-    localPart = localPart.replaceAll(/\.{2,}/g, '.');
-
-    // local parts may not start with or end with a . character
-    localPart = localPart.replace(/^\./, '');
-    localPart = localPart.replace(/\.$/, '');
-
-    return `${localPart}@${provider}`;
+    return internetEmail(this.faker.fakerCore, options);
   }
 
   /**
@@ -145,18 +133,7 @@ export class InternetModule extends ModuleBase {
       allowSpecialCharacters?: boolean;
     } = {}
   ): string {
-    const { firstName, lastName, allowSpecialCharacters = false } = options;
-
-    const provider = this.faker.helpers.arrayElement(
-      this.faker.definitions.internet.example_email
-    );
-
-    return this.email({
-      firstName,
-      lastName,
-      provider,
-      allowSpecialCharacters,
-    });
+    return internetExampleEmail(this.faker.fakerCore, options);
   }
 
   /**
@@ -199,52 +176,7 @@ export class InternetModule extends ModuleBase {
       lastName?: string;
     } = {}
   ): string {
-    const {
-      firstName = this.faker.person.firstName(),
-      lastName = this.faker.person.lastName(),
-      lastName: hasLastName,
-    } = options;
-
-    const separator = this.faker.helpers.arrayElement(['.', '_']);
-    const disambiguator = this.faker.number.int(99);
-    const strategies: Array<() => string> = [
-      () => `${firstName}${separator}${lastName}${disambiguator}`,
-      () => `${firstName}${separator}${lastName}`,
-    ];
-    if (!hasLastName) {
-      strategies.push(() => `${firstName}${disambiguator}`);
-    }
-
-    let result = this.faker.helpers.arrayElement(strategies)();
-
-    // There may still be non-ascii characters in the result.
-    // First remove simple accents etc
-    result = result
-      .normalize('NFKD') //for example è decomposes to as e +  ̀
-      .replaceAll(/[\u0300-\u036F]/g, ''); // removes combining marks
-
-    result = [...result]
-      .map((char) => {
-        // If we have a mapping for this character, (for Cyrillic, Greek etc) use it
-        if (charMapping[char]) {
-          return charMapping[char];
-        }
-
-        const charCode = char.codePointAt(0) ?? Number.NaN;
-
-        if (charCode < 0x80) {
-          // Keep ASCII characters
-          return char;
-        }
-
-        // Final fallback return the Unicode char code value for Chinese, Japanese, Korean etc, base-36 encoded
-        return charCode.toString(36);
-      })
-      .join('');
-    result = result.replaceAll("'", '');
-    result = result.replaceAll(' ', '');
-
-    return result;
+    return internetUsername(this.faker.fakerCore, options);
   }
 
   /**
@@ -285,23 +217,7 @@ export class InternetModule extends ModuleBase {
       lastName?: string;
     } = {}
   ): string {
-    const {
-      firstName = this.faker.person.firstName(),
-      lastName = this.faker.person.lastName(),
-    } = options;
-
-    const separator = this.faker.helpers.arrayElement(['.', '_']);
-    const disambiguator = this.faker.number.int(99);
-    const strategies: Array<() => string> = [
-      () => `${firstName}${disambiguator}`,
-      () => `${firstName}${separator}${lastName}`,
-      () => `${firstName}${separator}${lastName}${disambiguator}`,
-    ];
-
-    let result = this.faker.helpers.arrayElement(strategies)();
-    result = result.replaceAll("'", '');
-    result = result.replaceAll(' ', '');
-    return result;
+    return internetDisplayName(this.faker.fakerCore, options);
   }
 
   /**
@@ -313,8 +229,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.1.5
    */
   protocol(): 'http' | 'https' {
-    const protocols: ['http', 'https'] = ['http', 'https'];
-    return this.faker.helpers.arrayElement(protocols);
+    return internetProtocol(this.faker.fakerCore);
   }
 
   /**
@@ -334,14 +249,7 @@ export class InternetModule extends ModuleBase {
    * @since 5.4.0
    */
   httpMethod(): 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' {
-    const httpMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] = [
-      'GET',
-      'POST',
-      'PUT',
-      'DELETE',
-      'PATCH',
-    ];
-    return this.faker.helpers.arrayElement(httpMethods);
+    return internetHttpMethod(this.faker.fakerCore);
   }
 
   /**
@@ -361,20 +269,12 @@ export class InternetModule extends ModuleBase {
       /**
        * A list of the HTTP status code types that should be used.
        *
-       * @default Object.keys(faker.definitions.internet.http_status_code)
+       * @default Object.keys(fakerCore.locale.internet.http_status_code)
        */
       types?: ReadonlyArray<HTTPStatusCodeType>;
     } = {}
   ): number {
-    const {
-      types = Object.keys(
-        this.faker.definitions.internet.http_status_code
-      ) as HTTPStatusCodeType[],
-    } = options;
-    const httpStatusCodeType = this.faker.helpers.arrayElement(types);
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.internet.http_status_code[httpStatusCodeType]
-    );
+    return internetHttpStatusCode(this.faker.fakerCore, options);
   }
 
   /**
@@ -407,9 +307,7 @@ export class InternetModule extends ModuleBase {
       protocol?: HTTPProtocolType;
     } = {}
   ): string {
-    const { appendSlash = this.faker.datatype.boolean(), protocol = 'https' } =
-      options;
-    return `${protocol}://${this.domainName()}${appendSlash ? '/' : ''}`;
+    return internetUrl(this.faker.fakerCore, options);
   }
 
   /**
@@ -421,7 +319,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   domainName(): string {
-    return `${this.domainWord()}.${this.domainSuffix()}`;
+    return internetDomainName(this.faker.fakerCore);
   }
 
   /**
@@ -434,9 +332,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   domainSuffix(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.internet.domain_suffix
-    );
+    return internetDomainSuffix(this.faker.fakerCore);
   }
 
   /**
@@ -449,18 +345,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   domainWord(): string {
-    // Generate an ASCII "word" in the form `noun-adjective`
-    // For locales with non-ASCII characters, we fall back to lorem words, or a random string
-
-    const word1 = makeValidDomainWordSlug(
-      this.faker.fakerCore,
-      this.faker.word.adjective()
-    );
-    const word2 = makeValidDomainWordSlug(
-      this.faker.fakerCore,
-      this.faker.word.noun()
-    );
-    return `${word1}-${word2}`.toLowerCase();
+    return internetDomainWord(this.faker.fakerCore);
   }
 
   /**
@@ -473,7 +358,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   ip(): string {
-    return this.faker.datatype.boolean() ? this.ipv4() : this.ipv6();
+    return internetIp(this.faker.fakerCore);
   }
 
   /**
@@ -560,45 +445,7 @@ export class InternetModule extends ModuleBase {
   ipv4(
     options: { cidrBlock?: string; network?: IPv4NetworkType } = {}
   ): string {
-    const { network = 'any', cidrBlock = ipv4Networks[network] } = options;
-
-    if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2}$/.test(cidrBlock)) {
-      throw new FakerError(
-        `Invalid CIDR block provided: ${cidrBlock}. Must be in the format x.x.x.x/y.`
-      );
-    }
-
-    const [ipText, subnet] = cidrBlock.split('/', 2);
-    const subnetValue = Number.parseInt(subnet, 10);
-    if (subnetValue > 32) {
-      throw new FakerError(
-        `Invalid CIDR block provided: ${cidrBlock}. Prefix length must be between 0 and 32.`
-      );
-    }
-
-    const octets = ipText.split('.').map(Number);
-    if (octets.some((octet) => octet > 255)) {
-      throw new FakerError(
-        `Invalid CIDR block provided: ${cidrBlock}. Each octet must be between 0 and 255.`
-      );
-    }
-
-    if (subnetValue === 32) {
-      return ipText;
-    }
-
-    const subnetMask = 0xffffffff >>> subnetValue;
-    const [rawIp1, rawIp2, rawIp3, rawIp4] = octets;
-    const rawIp = (rawIp1 << 24) | (rawIp2 << 16) | (rawIp3 << 8) | rawIp4;
-    const networkIp = rawIp & ~subnetMask;
-    const hostOffset = this.faker.number.int(subnetMask);
-    const ip = networkIp | hostOffset;
-    return [
-      (ip >>> 24) & 0xff,
-      (ip >>> 16) & 0xff,
-      (ip >>> 8) & 0xff,
-      ip & 0xff,
-    ].join('.');
+    return internetIpv4(this.faker.fakerCore, options);
   }
 
   /**
@@ -610,13 +457,7 @@ export class InternetModule extends ModuleBase {
    * @since 4.0.0
    */
   ipv6(): string {
-    return Array.from({ length: 8 }, () =>
-      this.faker.string.hexadecimal({
-        length: 4,
-        casing: 'lower',
-        prefix: '',
-      })
-    ).join(':');
+    return internetIpv6(this.faker.fakerCore);
   }
 
   /**
@@ -628,7 +469,7 @@ export class InternetModule extends ModuleBase {
    * @since 5.4.0
    */
   port(): number {
-    return this.faker.number.int({ min: 1, max: 65535 });
+    return internetPort(this.faker.fakerCore);
   }
 
   /**
@@ -641,9 +482,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   userAgent(): string {
-    return this.faker.helpers.fake(
-      this.faker.definitions.internet.user_agent_pattern
-    );
+    return internetUserAgent(this.faker.fakerCore);
   }
 
   /**
@@ -711,28 +550,7 @@ export class InternetModule extends ModuleBase {
           separator?: string;
         } = {}
   ): string {
-    if (typeof options === 'string') {
-      options = { separator: options };
-    }
-
-    let { separator = ':' } = options;
-
-    let i: number;
-    let mac = '';
-
-    const acceptableSeparators = [':', '-', ''];
-    if (!acceptableSeparators.includes(separator)) {
-      separator = ':';
-    }
-
-    for (i = 0; i < 12; i++) {
-      mac += this.faker.number.hex(15);
-      if (i !== 11 && i % 2 === 1) {
-        mac += separator;
-      }
-    }
-
-    return mac;
+    return internetMac(this.faker.fakerCore, options);
   }
 
   /**
@@ -784,41 +602,7 @@ export class InternetModule extends ModuleBase {
       prefix?: string;
     } = {}
   ): string {
-    /*
-     * password-generator ( function )
-     * Copyright(c) 2011-2013 Bermi Ferrer <bermi@bermilabs.com>
-     * MIT Licensed
-     */
-    const vowel = /[aeiouAEIOU]$/;
-    const consonant = /[bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ]$/;
-
-    const {
-      length = 15,
-      memorable = false,
-      pattern = /\w/,
-      prefix = '',
-    } = options;
-
-    let currentPattern = pattern;
-    let result = prefix;
-    // TODO @Shinigami92 2026-07-09: This loop never terminates if the pattern can never match a generated char (e.g. `/°/`), blocking the event loop. To be resolved by the password rewrite in https://github.com/faker-js/faker/issues/768.
-    while (result.length < length) {
-      if (memorable) {
-        currentPattern = consonant.test(result) ? vowel : consonant;
-      }
-
-      const n = this.faker.number.int(94) + 33;
-      let char = String.fromCodePoint(n);
-      if (memorable) {
-        char = char.toLowerCase();
-      }
-
-      if (currentPattern.test(char)) {
-        result += char;
-      }
-    }
-
-    return result;
+    return internetPassword(this.faker.fakerCore, options);
   }
 
   /**
@@ -843,13 +627,7 @@ export class InternetModule extends ModuleBase {
       types?: ReadonlyArray<EmojiType>;
     } = {}
   ): string {
-    const {
-      types = Object.keys(this.faker.definitions.internet.emoji) as EmojiType[],
-    } = options;
-    const emojiType = this.faker.helpers.arrayElement(types);
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.internet.emoji[emojiType]
-    );
+    return internetEmoji(this.faker.fakerCore, options);
   }
 
   /**
@@ -864,9 +642,7 @@ export class InternetModule extends ModuleBase {
    * @since 9.1.0
    */
   jwtAlgorithm(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.internet.jwt_algorithm
-    );
+    return internetJwtAlgorithm(this.faker.fakerCore);
   }
 
   /**
@@ -925,32 +701,6 @@ export class InternetModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): string {
-    const { refDate = this.faker.defaultRefDate() } = options;
-
-    const iatDefault = this.faker.date.recent({ refDate });
-
-    const {
-      header = {
-        alg: this.jwtAlgorithm(),
-        typ: 'JWT',
-      },
-      payload = {
-        iat: Math.round(iatDefault.valueOf() / 1000),
-        exp: Math.round(
-          this.faker.date.soon({ refDate: iatDefault }).valueOf() / 1000
-        ),
-        nbf: Math.round(this.faker.date.anytime({ refDate }).valueOf() / 1000),
-        iss: this.faker.company.name(),
-        sub: this.faker.string.uuid(),
-        aud: this.faker.string.uuid(),
-        jti: this.faker.string.uuid(),
-      },
-    } = options;
-
-    const encodedHeader = toBase64Url(JSON.stringify(header));
-    const encodedPayload = toBase64Url(JSON.stringify(payload));
-    const signature = this.faker.string.alphanumeric(64);
-
-    return `${encodedHeader}.${encodedPayload}.${signature}`;
+    return internetJwt(this.faker.fakerCore, options);
   }
 }

--- a/src/modules/internet/module.ts
+++ b/src/modules/internet/module.ts
@@ -1,137 +1,13 @@
 import { FakerError } from '../../errors/faker-error';
-import type { Faker } from '../../faker';
 import { toBase64Url } from '../../internal/base64';
 import { ModuleBase } from '../../internal/module-base';
 import { charMapping } from './_char-mappings';
-
-export type EmojiType =
-  | 'smiley'
-  | 'body'
-  | 'person'
-  | 'nature'
-  | 'food'
-  | 'travel'
-  | 'activity'
-  | 'object'
-  | 'symbol'
-  | 'flag';
-
-export type HTTPStatusCodeType =
-  | 'informational'
-  | 'success'
-  | 'clientError'
-  | 'serverError'
-  | 'redirection';
-
-export type HTTPProtocolType = 'http' | 'https';
-
-export enum IPv4Network {
-  /**
-   * Equivalent to: `0.0.0.0/0`
-   */
-  Any = 'any',
-  /**
-   * Equivalent to: `127.0.0.0/8`
-   *
-   * @see [RFC1122](https://www.rfc-editor.org/rfc/rfc1122)
-   */
-  Loopback = 'loopback',
-  /**
-   * Equivalent to: `10.0.0.0/8`
-   *
-   * @see [RFC1918](https://www.rfc-editor.org/rfc/rfc1918)
-   */
-  PrivateA = 'private-a',
-  /**
-   * Equivalent to: `172.16.0.0/12`
-   *
-   * @see [RFC1918](https://www.rfc-editor.org/rfc/rfc1918)
-   */
-  PrivateB = 'private-b',
-  /**
-   * Equivalent to: `192.168.0.0/16`
-   *
-   * @see [RFC1918](https://www.rfc-editor.org/rfc/rfc1918)
-   */
-  PrivateC = 'private-c',
-  /**
-   * Equivalent to: `192.0.2.0/24`
-   *
-   * @see [RFC5737](https://www.rfc-editor.org/rfc/rfc5737)
-   */
-  TestNet1 = 'test-net-1',
-  /**
-   * Equivalent to: `198.51.100.0/24`
-   *
-   * @see [RFC5737](https://www.rfc-editor.org/rfc/rfc5737)
-   */
-  TestNet2 = 'test-net-2',
-  /**
-   * Equivalent to: `203.0.113.0/24`
-   *
-   * @see [RFC5737](https://www.rfc-editor.org/rfc/rfc5737)
-   */
-  TestNet3 = 'test-net-3',
-  /**
-   * Equivalent to: `169.254.0.0/16`
-   *
-   * @see [RFC3927](https://www.rfc-editor.org/rfc/rfc3927)
-   */
-  LinkLocal = 'link-local',
-  /**
-   * Equivalent to: `224.0.0.0/4`
-   *
-   * @see [RFC5771](https://www.rfc-editor.org/rfc/rfc5771)
-   */
-  Multicast = 'multicast',
-}
-
-export type IPv4NetworkType = `${IPv4Network}`;
-
-const ipv4Networks: Record<IPv4Network, string> = {
-  [IPv4Network.Any]: '0.0.0.0/0',
-  [IPv4Network.Loopback]: '127.0.0.0/8',
-  [IPv4Network.PrivateA]: '10.0.0.0/8',
-  [IPv4Network.PrivateB]: '172.16.0.0/12',
-  [IPv4Network.PrivateC]: '192.168.0.0/16',
-  [IPv4Network.TestNet1]: '192.0.2.0/24',
-  [IPv4Network.TestNet2]: '198.51.100.0/24',
-  [IPv4Network.TestNet3]: '203.0.113.0/24',
-  [IPv4Network.LinkLocal]: '169.254.0.0/16',
-  [IPv4Network.Multicast]: '224.0.0.0/4',
-};
-
-/**
- * Checks whether the given string is a valid slug for `domainWord`s.
- *
- * @param slug The slug to check.
- */
-function isValidDomainWordSlug(slug: string): boolean {
-  return /^[a-z][a-z-]*[a-z]$/i.exec(slug) !== null;
-}
-
-/**
- * Tries various ways to produce a valid domain word slug, falling back to a random string if needed.
- *
- * @param faker The faker instance to use.
- * @param word The initial word to slugify.
- */
-function makeValidDomainWordSlug(faker: Faker, word: string): string {
-  const slug1 = faker.helpers.slugify(word);
-  if (isValidDomainWordSlug(slug1)) {
-    return slug1;
-  }
-
-  const slug2 = faker.helpers.slugify(faker.lorem.word());
-  if (isValidDomainWordSlug(slug2)) {
-    return slug2;
-  }
-
-  return faker.string.alpha({
-    casing: 'lower',
-    length: faker.number.int({ min: 4, max: 8 }),
-  });
-}
+import { makeValidDomainWordSlug } from './domain-word';
+import type { EmojiType } from './emoji';
+import type { HTTPStatusCodeType } from './http-status-code';
+import type { IPv4NetworkType } from './ipv4';
+import { ipv4Networks } from './ipv4';
+import type { HTTPProtocolType } from './url';
 
 /**
  * Module to generate internet related entries.
@@ -577,10 +453,13 @@ export class InternetModule extends ModuleBase {
     // For locales with non-ASCII characters, we fall back to lorem words, or a random string
 
     const word1 = makeValidDomainWordSlug(
-      this.faker,
+      this.faker.fakerCore,
       this.faker.word.adjective()
     );
-    const word2 = makeValidDomainWordSlug(this.faker, this.faker.word.noun());
+    const word2 = makeValidDomainWordSlug(
+      this.faker.fakerCore,
+      this.faker.word.noun()
+    );
     return `${word1}-${word2}`.toLowerCase();
   }
 

--- a/src/modules/internet/password.ts
+++ b/src/modules/internet/password.ts
@@ -1,0 +1,92 @@
+import type { FakerCore } from '../../core';
+import { int } from '../number/int';
+
+/**
+ * Generates a random password-like string. Do not use this method for generating actual passwords for users.
+ * Since the source of the randomness is not cryptographically secure, neither is this generator.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options An options object.
+ * @param options.length The length of the password to generate. Defaults to `15`.
+ * @param options.memorable Whether the generated password should be memorable. Defaults to `false`.
+ * @param options.pattern The pattern that all chars should match.
+ * This option will be ignored, if `memorable` is `true`. Defaults to `/\w/`.
+ * @param options.prefix The prefix to use. Defaults to `''`.
+ *
+ * @example
+ * password(fakerCore) // '89G1wJuBLbGziIs'
+ * password(fakerCore, { length: 20 }) // 'aF55c_8O9kZaPOrysFB_'
+ * password(fakerCore, { length: 20, memorable: true }) // 'lawetimufozujosodedi'
+ * password(fakerCore, { length: 20, memorable: true, pattern: /[A-Z]/ }) // 'HMAQDFFYLDDUTBKVNFVS'
+ * password(fakerCore, { length: 20, memorable: true, pattern: /[A-Z]/, prefix: 'Hello ' }) // 'Hello IREOXTDWPERQSB'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function password(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The length of the password to generate.
+     *
+     * @default 15
+     */
+    length?: number;
+    /**
+     * Whether the generated password should be memorable.
+     *
+     * @default false
+     */
+    memorable?: boolean;
+    /**
+     * The pattern that all chars should match.
+     * This option will be ignored, if `memorable` is `true`.
+     *
+     * @default /\w/
+     */
+    pattern?: RegExp;
+    /**
+     * The prefix to use.
+     *
+     * @default ''
+     */
+    prefix?: string;
+  } = {}
+): string {
+  /*
+   * password-generator ( function )
+   * Copyright(c) 2011-2013 Bermi Ferrer <bermi@bermilabs.com>
+   * MIT Licensed
+   */
+  const vowel = /[aeiouAEIOU]$/;
+  const consonant = /[bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ]$/;
+
+  const {
+    length = 15,
+    memorable = false,
+    pattern = /\w/,
+    prefix = '',
+  } = options;
+
+  let currentPattern = pattern;
+  let result = prefix;
+  // TODO @Shinigami92 2026-07-09: This loop never terminates if the pattern can never match a generated char (e.g. `/°/`), blocking the event loop. To be resolved by the password rewrite in https://github.com/faker-js/faker/issues/768.
+  while (result.length < length) {
+    if (memorable) {
+      currentPattern = consonant.test(result) ? vowel : consonant;
+    }
+
+    const n = int(fakerCore, 94) + 33;
+    let char = String.fromCodePoint(n);
+    if (memorable) {
+      char = char.toLowerCase();
+    }
+
+    if (currentPattern.test(char)) {
+      result += char;
+    }
+  }
+
+  return result;
+}

--- a/src/modules/internet/port.ts
+++ b/src/modules/internet/port.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { int } from '../number/int';
+
+/**
+ * Generates a random port number.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * port(fakerCore) // 9414
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function port(fakerCore: FakerCore): number {
+  return int(fakerCore, { min: 1, max: 65535 });
+}

--- a/src/modules/internet/protocol.ts
+++ b/src/modules/internet/protocol.ts
@@ -1,0 +1,19 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random web protocol. Either `http` or `https`.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * protocol(fakerCore) // 'http'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function protocol(fakerCore: FakerCore): 'http' | 'https' {
+  const protocols: ['http', 'https'] = ['http', 'https'];
+  return arrayElement(fakerCore, protocols);
+}

--- a/src/modules/internet/url.ts
+++ b/src/modules/internet/url.ts
@@ -1,0 +1,41 @@
+import type { FakerCore } from '../../core';
+import { boolean } from '../datatype/boolean';
+import { domainName } from './domain-name';
+
+/**
+ * Generates a random http(s) url.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options Optional options object.
+ * @param options.appendSlash Whether to append a slash to the end of the url (path). Defaults to a random boolean value.
+ * @param options.protocol The protocol to use. Defaults to `'https'`.
+ *
+ * @example
+ * url(fakerCore) // 'https://remarkable-hackwork.info'
+ * url(fakerCore, { appendSlash: true }) // 'https://slow-timer.info/'
+ * url(fakerCore, { protocol: 'http', appendSlash: false }) // 'http://www.terrible-idea.com'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function url(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * Whether to append a slash to the end of the url (path).
+     *
+     * @default datatypeBoolean(fakerCore)
+     */
+    appendSlash?: boolean;
+    /**
+     * The protocol to use.
+     *
+     * @default 'https'
+     */
+    protocol?: HTTPProtocolType;
+  } = {}
+): string {
+  const { appendSlash = boolean(fakerCore), protocol = 'https' } = options;
+  return `${protocol}://${domainName(fakerCore)}${appendSlash ? '/' : ''}`;
+}

--- a/src/modules/internet/url.ts
+++ b/src/modules/internet/url.ts
@@ -2,6 +2,8 @@ import type { FakerCore } from '../../core';
 import { boolean } from '../datatype/boolean';
 import { domainName } from './domain-name';
 
+export type HTTPProtocolType = 'http' | 'https';
+
 /**
  * Generates a random http(s) url.
  *

--- a/src/modules/internet/user-agent.ts
+++ b/src/modules/internet/user-agent.ts
@@ -1,0 +1,21 @@
+import type { FakerCore } from '../../core';
+import { Faker } from '../../faker';
+
+/**
+ * Generates a random user agent string.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * userAgent(fakerCore)
+ * // 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_1 like Mac OS X) AppleWebKit/537.19.86 (KHTML, like Gecko) Version/18_3 Mobile/15E148 Safari/598.43'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function userAgent(fakerCore: FakerCore): string {
+  return new Faker(fakerCore).helpers.fake(
+    fakerCore.locale.internet.user_agent_pattern
+  );
+}

--- a/src/modules/internet/username.ts
+++ b/src/modules/internet/username.ts
@@ -1,0 +1,98 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+import { int } from '../number/int';
+import { firstName as personFirstName } from '../person/first-name';
+import { lastName as personLastName } from '../person/last-name';
+import { charMapping } from './_char-mappings';
+
+/**
+ * Generates a username using the given person's name as base.
+ * The resulting username may use neither, one or both of the names provided.
+ * This will always return a plain ASCII string.
+ * Some basic stripping of accents and transliteration of characters will be done.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options An options object.
+ * @param options.firstName The optional first name to use. If not specified, a random one will be chosen.
+ * @param options.lastName The optional last name to use. If not specified, a random one will be chosen.
+ *
+ * @see displayName(fakerCore): For generating an Unicode display name.
+ *
+ * @example
+ * username(fakerCore) // 'Nettie_Zboncak40'
+ * username(fakerCore, { firstName: 'Jeanne' }) // 'Jeanne98'
+ * username(fakerCore, { firstName: 'Jeanne' }) // 'Jeanne.Smith98'
+ * username(fakerCore, { firstName: 'Jeanne', lastName: 'Doe'}) // 'Jeanne_Doe98'
+ * username(fakerCore, { firstName: 'John', lastName: 'Doe' }) // 'John.Doe'
+ * username(fakerCore, { firstName: 'Hélene', lastName: 'Müller' }) // 'Helene_Muller11'
+ * username(fakerCore, { firstName: 'Фёдор', lastName: 'Достоевский' }) // 'Fedor.Dostoevskii50'
+ * username(fakerCore, { firstName: '大羽', lastName: '陳' }) // 'hlzp8d.tpv45' - note neither name is used
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function username(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * The optional first name to use.
+     *
+     * @default personFirstName(fakerCore)
+     */
+    firstName?: string;
+    /**
+     * The optional last name to use.
+     *
+     * @default personLastName(fakerCore)
+     */
+    lastName?: string;
+  } = {}
+): string {
+  const {
+    firstName = personFirstName(fakerCore),
+    lastName = personLastName(fakerCore),
+    lastName: hasLastName,
+  } = options;
+
+  const separator = arrayElement(fakerCore, ['.', '_']);
+  const disambiguator = int(fakerCore, 99);
+  const strategies: Array<() => string> = [
+    () => `${firstName}${separator}${lastName}${disambiguator}`,
+    () => `${firstName}${separator}${lastName}`,
+  ];
+  if (!hasLastName) {
+    strategies.push(() => `${firstName}${disambiguator}`);
+  }
+
+  let result = arrayElement(fakerCore, strategies)();
+
+  // There may still be non-ascii characters in the result.
+  // First remove simple accents etc
+  result = result
+    .normalize('NFKD') //for example è decomposes to as e +  ̀
+    .replaceAll(/[\u0300-\u036F]/g, ''); // removes combining marks
+
+  result = [...result]
+    .map((char) => {
+      // If we have a mapping for this character, (for Cyrillic, Greek etc) use it
+      if (charMapping[char]) {
+        return charMapping[char];
+      }
+
+      const charCode = char.codePointAt(0) ?? Number.NaN;
+
+      if (charCode < 0x80) {
+        // Keep ASCII characters
+        return char;
+      }
+
+      // Final fallback return the Unicode char code value for Chinese, Japanese, Korean etc, base-36 encoded
+      return charCode.toString(36);
+    })
+    .join('');
+  result = result.replaceAll("'", '');
+  result = result.replaceAll(' ', '');
+
+  return result;
+}


### PR DESCRIPTION
Continuation of #4072

- #4072

---

Transforms the internet module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts internet`
4. Cherry-pick `refactor: transform internet module`
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. Cherry-pick `chore: remove temp exports`