### PR TITLE
feat(music): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -15,6 +15,7 @@ export const ALLOWED_MODULES = new Set([
   'LocationModule',
   'LoremModule',
   'MedicalModule',
+  'MusicModule',
   'NumberModule',
   'PersonModule',
   'StringModule',

--- a/src/modules/music/album.ts
+++ b/src/modules/music/album.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random album name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * album(fakerCore) // '1989'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function album(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.music.album);
+}

--- a/src/modules/music/artist.ts
+++ b/src/modules/music/artist.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random artist name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * artist(fakerCore) // 'The Beatles'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function artist(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.music.artist);
+}

--- a/src/modules/music/genre.ts
+++ b/src/modules/music/genre.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random music genre.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * genre(fakerCore) // 'Reggae'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function genre(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.music.genre);
+}

--- a/src/modules/music/module.ts
+++ b/src/modules/music/module.ts
@@ -1,4 +1,8 @@
 import { ModuleBase } from '../../internal/module-base';
+import { album as musicAlbum } from './album';
+import { artist as musicArtist } from './artist';
+import { genre as musicGenre } from './genre';
+import { songName as musicSongName } from './song-name';
 
 /**
  * Module to generate music related entries.
@@ -18,6 +22,11 @@ import { ModuleBase } from '../../internal/module-base';
  * All data types may be localized.
  */
 export class MusicModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree music' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random album name.
    *
@@ -27,7 +36,7 @@ export class MusicModule extends ModuleBase {
    * @since 9.0.0
    */
   album(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.music.album);
+    return musicAlbum(this.faker.fakerCore);
   }
 
   /**
@@ -39,7 +48,7 @@ export class MusicModule extends ModuleBase {
    * @since 9.0.0
    */
   artist(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.music.artist);
+    return musicArtist(this.faker.fakerCore);
   }
 
   /**
@@ -51,7 +60,7 @@ export class MusicModule extends ModuleBase {
    * @since 5.2.0
    */
   genre(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.music.genre);
+    return musicGenre(this.faker.fakerCore);
   }
 
   /**
@@ -63,8 +72,6 @@ export class MusicModule extends ModuleBase {
    * @since 7.1.0
    */
   songName(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.music.song_name
-    );
+    return musicSongName(this.faker.fakerCore);
   }
 }

--- a/src/modules/music/song-name.ts
+++ b/src/modules/music/song-name.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random song name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * songName(fakerCore) // 'White Christmas'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function songName(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.music.song_name);
+}


### PR DESCRIPTION
Continuation of #4065

- #4065

---

Transforms the music module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts music`
4. ~~Cherry-pick `refactor: transform music module`~~
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~