### PR TITLE
feat(phone): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -18,5 +18,6 @@ export const ALLOWED_MODULES = new Set([
   'MusicModule',
   'NumberModule',
   'PersonModule',
+  'PhoneModule',
   'StringModule',
 ]);

--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -15,6 +15,7 @@ export const ALLOWED_MODULES = new Set([
   'LocationModule',
   'LoremModule',
   'MedicalModule',
+  'MusicModule',
   'NumberModule',
   'PersonModule',
   'StringModule',

--- a/src/modules/music/album.ts
+++ b/src/modules/music/album.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random album name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * album(fakerCore) // '1989'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function album(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.music.album);
+}

--- a/src/modules/music/artist.ts
+++ b/src/modules/music/artist.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random artist name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * artist(fakerCore) // 'The Beatles'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function artist(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.music.artist);
+}

--- a/src/modules/music/genre.ts
+++ b/src/modules/music/genre.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random music genre.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * genre(fakerCore) // 'Reggae'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function genre(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.music.genre);
+}

--- a/src/modules/music/module.ts
+++ b/src/modules/music/module.ts
@@ -1,4 +1,8 @@
 import { ModuleBase } from '../../internal/module-base';
+import { album as musicAlbum } from './album';
+import { artist as musicArtist } from './artist';
+import { genre as musicGenre } from './genre';
+import { songName as musicSongName } from './song-name';
 
 /**
  * Module to generate music related entries.
@@ -18,6 +22,11 @@ import { ModuleBase } from '../../internal/module-base';
  * All data types may be localized.
  */
 export class MusicModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree music' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random album name.
    *
@@ -27,7 +36,7 @@ export class MusicModule extends ModuleBase {
    * @since 9.0.0
    */
   album(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.music.album);
+    return musicAlbum(this.faker.fakerCore);
   }
 
   /**
@@ -39,7 +48,7 @@ export class MusicModule extends ModuleBase {
    * @since 9.0.0
    */
   artist(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.music.artist);
+    return musicArtist(this.faker.fakerCore);
   }
 
   /**
@@ -51,7 +60,7 @@ export class MusicModule extends ModuleBase {
    * @since 5.2.0
    */
   genre(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.music.genre);
+    return musicGenre(this.faker.fakerCore);
   }
 
   /**
@@ -63,8 +72,6 @@ export class MusicModule extends ModuleBase {
    * @since 7.1.0
    */
   songName(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.music.song_name
-    );
+    return musicSongName(this.faker.fakerCore);
   }
 }

--- a/src/modules/music/song-name.ts
+++ b/src/modules/music/song-name.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random song name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * songName(fakerCore) // 'White Christmas'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function songName(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.music.song_name);
+}

--- a/src/modules/phone/imei.ts
+++ b/src/modules/phone/imei.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { replaceCreditCardSymbols } from '../helpers/replace-credit-card-symbols';
+
+/**
+ * Generates IMEI number.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * imei(fakerCore) // '13-850175-913761-7'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function imei(fakerCore: FakerCore): string {
+  return replaceCreditCardSymbols(fakerCore, '##-######-######-L', '#');
+}

--- a/src/modules/phone/module.ts
+++ b/src/modules/phone/module.ts
@@ -1,5 +1,6 @@
 import { ModuleBase } from '../../internal/module-base';
-import { legacyReplaceSymbolWithNumber } from '../helpers/_legacy-replace-symbol-with-number';
+import { imei as phoneImei } from './imei';
+import { number as phoneNumber } from './number';
 
 /**
  * Module to generate phone-related data.
@@ -9,6 +10,11 @@ import { legacyReplaceSymbolWithNumber } from '../helpers/_legacy-replace-symbol
  * For a phone number, use [`number()`](https://fakerjs.dev/api/phone.html#number). Many locales provide country-specific formats.
  */
 export class PhoneModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree phone' to update the methods from their respective files.
+   */
+
   /**
    * Generates a random phone number.
    *
@@ -41,16 +47,7 @@ export class PhoneModule extends ModuleBase {
       style?: 'human' | 'national' | 'international' | 'mobile';
     } = {}
   ): string {
-    const { style = 'human' } = options;
-    const formats = this.faker.definitions.phone_number.format;
-
-    const definitions = formats[style];
-    if (!definitions) {
-      throw new Error(`No definitions for ${style} in this locale`);
-    }
-
-    const format = this.faker.helpers.arrayElement(definitions);
-    return legacyReplaceSymbolWithNumber(this.faker.fakerCore, format);
+    return phoneNumber(this.faker.fakerCore, options);
   }
 
   /**
@@ -62,9 +59,6 @@ export class PhoneModule extends ModuleBase {
    * @since 6.2.0
    */
   imei(): string {
-    return this.faker.helpers.replaceCreditCardSymbols(
-      '##-######-######-L',
-      '#'
-    );
+    return phoneImei(this.faker.fakerCore);
   }
 }

--- a/src/modules/phone/number.ts
+++ b/src/modules/phone/number.ts
@@ -1,0 +1,51 @@
+import type { FakerCore } from '../../core';
+import { legacyReplaceSymbolWithNumber } from '../helpers/_legacy-replace-symbol-with-number';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Generates a random phone number.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options Options object
+ * @param options.style Style of the phone number. Defaults to `'human'`.
+ *
+ * @see stringNumeric(fakerCore): For generating a random string of numbers.
+ * @see helpersFromRegExp(fakerCore): For generating a phone number matching a regular expression.
+ *
+ * @example
+ * number(fakerCore) // '961-770-7727'
+ * number(fakerCore, { style: 'human' }) // '555.770.7727 x1234'
+ * number(fakerCore, { style: 'national' }) // '(961) 770-7727'
+ * number(fakerCore, { style: 'international' }) // '+15551234567'
+ * fakerEN_GB.phone.number({ style: 'mobile' }) // '07123456789'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function number(
+  fakerCore: FakerCore,
+  options: {
+    /**
+     * Style of the generated phone number:
+     * - `'human'`: (default) A human-input phone number, e.g. `555-770-7727` or `555.770.7727 x1234`
+     * - `'national'`: A phone number in a standardized national format, e.g. `(555) 123-4567`.
+     * - `'international'`: A phone number in the E.123 international format, e.g. `+15551234567`
+     * - `'mobile'`: In selected locales, provides a number used for mobile phones, e.g. `07123456789` in en_GB.
+     *
+     * @default 'human'
+     */
+    style?: 'human' | 'national' | 'international' | 'mobile';
+  } = {}
+): string {
+  const { style = 'human' } = options;
+  const formats = fakerCore.locale.phone_number.format;
+
+  const definitions = formats[style];
+  if (!definitions) {
+    throw new Error(`No definitions for ${style} in this locale`);
+  }
+
+  const format = arrayElement(fakerCore, definitions);
+  return legacyReplaceSymbolWithNumber(fakerCore, format);
+}

--- a/src/modules/phone/number.ts
+++ b/src/modules/phone/number.ts
@@ -1,4 +1,5 @@
 import type { FakerCore } from '../../core';
+import { assertLocaleData } from '../../internal/locale-proxy';
 import { legacyReplaceSymbolWithNumber } from '../helpers/_legacy-replace-symbol-with-number';
 import { arrayElement } from '../helpers/array-element';
 
@@ -39,13 +40,8 @@ export function number(
   } = {}
 ): string {
   const { style = 'human' } = options;
-  const formats = fakerCore.locale.phone_number.format;
-
-  const definitions = formats[style];
-  if (!definitions) {
-    throw new Error(`No definitions for ${style} in this locale`);
-  }
-
-  const format = arrayElement(fakerCore, definitions);
+  const formats = fakerCore.locale.phone_number.format[style];
+  assertLocaleData(formats, 'phone_number.format', style);
+  const format = arrayElement(fakerCore, formats);
   return legacyReplaceSymbolWithNumber(fakerCore, format);
 }


### PR DESCRIPTION
Continuation of #4066

- #4066

---

Transforms the phone module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts phone`
4. Cherry-pick `refactor: transform phone module`
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~