### PR TITLE
feat(science): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -19,5 +19,6 @@ export const ALLOWED_MODULES = new Set([
   'NumberModule',
   'PersonModule',
   'PhoneModule',
+  'ScienceModule',
   'StringModule',
 ]);

--- a/src/definitions/science.ts
+++ b/src/definitions/science.ts
@@ -1,4 +1,5 @@
-import type { ChemicalElement, Unit } from '../modules/science';
+import type { ChemicalElement } from '../modules/science/chemical-element';
+import type { Unit } from '../modules/science/unit';
 import type { LocaleEntry } from './definitions';
 
 /**

--- a/src/modules/science/chemical-element.ts
+++ b/src/modules/science/chemical-element.ts
@@ -1,0 +1,20 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random periodic table element.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * chemicalElement(fakerCore) // { symbol: 'H', name: 'Hydrogen', atomicNumber: 1 }
+ * chemicalElement(fakerCore) // { symbol: 'Xe', name: 'Xenon', atomicNumber: 54 }
+ * chemicalElement(fakerCore) // { symbol: 'Ce', name: 'Cerium', atomicNumber: 58 }
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function chemicalElement(fakerCore: FakerCore): ChemicalElement {
+  return arrayElement(fakerCore, fakerCore.locale.science.chemical_element);
+}

--- a/src/modules/science/chemical-element.ts
+++ b/src/modules/science/chemical-element.ts
@@ -2,6 +2,24 @@ import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
 /**
+ * The possible definitions related to elements.
+ */
+export interface ChemicalElement {
+  /**
+   * The symbol for the element (e.g. `'He'`).
+   */
+  symbol: string;
+  /**
+   * The name for the element (e.g. `'Cerium'`).
+   */
+  name: string;
+  /**
+   * The atomic number for the element (e.g. `52`).
+   */
+  atomicNumber: number;
+}
+
+/**
  * Returns a random periodic table element.
  *
  * @param fakerCore The FakerCore to use.

--- a/src/modules/science/index.ts
+++ b/src/modules/science/index.ts
@@ -1,1 +1,3 @@
+export type { ChemicalElement } from './chemical-element';
 export * from './module';
+export type { Unit } from './unit';

--- a/src/modules/science/module.ts
+++ b/src/modules/science/module.ts
@@ -1,33 +1,6 @@
 import { ModuleBase } from '../../internal/module-base';
-
-/**
- * The possible definitions related to elements.
- */
-export interface ChemicalElement {
-  /**
-   * The symbol for the element (e.g. `'He'`).
-   */
-  symbol: string;
-  /**
-   * The name for the element (e.g. `'Cerium'`).
-   */
-  name: string;
-  /**
-   * The atomic number for the element (e.g. `52`).
-   */
-  atomicNumber: number;
-}
-
-export interface Unit {
-  /**
-   * The long version of the unit (e.g. `meter`).
-   */
-  name: string;
-  /**
-   * The short version/abbreviation of the unit (e.g. `Pa`).
-   */
-  symbol: string;
-}
+import type { ChemicalElement } from './chemical-element';
+import type { Unit } from './unit';
 
 /**
  * Module to generate science related entries.

--- a/src/modules/science/module.ts
+++ b/src/modules/science/module.ts
@@ -1,6 +1,8 @@
 import { ModuleBase } from '../../internal/module-base';
 import type { ChemicalElement } from './chemical-element';
+import { chemicalElement as scienceChemicalElement } from './chemical-element';
 import type { Unit } from './unit';
+import { unit as scienceUnit } from './unit';
 
 /**
  * Module to generate science related entries.
@@ -10,6 +12,11 @@ import type { Unit } from './unit';
  * Both methods in this module return objects rather than strings. For example, you can use `faker.science.chemicalElement().name` to pick out the specific property you need.
  */
 export class ScienceModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree science' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random periodic table element.
    *
@@ -21,9 +28,7 @@ export class ScienceModule extends ModuleBase {
    * @since 7.2.0
    */
   chemicalElement(): ChemicalElement {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.science.chemical_element
-    );
+    return scienceChemicalElement(this.faker.fakerCore);
   }
 
   /**
@@ -37,6 +42,6 @@ export class ScienceModule extends ModuleBase {
    * @since 7.2.0
    */
   unit(): Unit {
-    return this.faker.helpers.arrayElement(this.faker.definitions.science.unit);
+    return scienceUnit(this.faker.fakerCore);
   }
 }

--- a/src/modules/science/unit.ts
+++ b/src/modules/science/unit.ts
@@ -1,0 +1,20 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a random scientific unit.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * unit(fakerCore) // { name: 'meter', symbol: 'm' }
+ * unit(fakerCore) // { name: 'second', symbol: 's' }
+ * unit(fakerCore) // { name: 'mole', symbol: 'mol' }
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function unit(fakerCore: FakerCore): Unit {
+  return arrayElement(fakerCore, fakerCore.locale.science.unit);
+}

--- a/src/modules/science/unit.ts
+++ b/src/modules/science/unit.ts
@@ -1,6 +1,17 @@
 import type { FakerCore } from '../../core';
 import { arrayElement } from '../helpers/array-element';
 
+export interface Unit {
+  /**
+   * The long version of the unit (e.g. `meter`).
+   */
+  name: string;
+  /**
+   * The short version/abbreviation of the unit (e.g. `Pa`).
+   */
+  symbol: string;
+}
+
 /**
  * Returns a random scientific unit.
  *


### PR DESCRIPTION
Continuation of #4067

- #4067

---

Transforms the science module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts science`
4. Cherry-pick `refactor: transform science module`
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~