### PR TITLE
feat(vehicle): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -21,4 +21,5 @@ export const ALLOWED_MODULES = new Set([
   'PhoneModule',
   'ScienceModule',
   'StringModule',
+  'VehicleModule',
 ]);

--- a/src/modules/vehicle/bicycle.ts
+++ b/src/modules/vehicle/bicycle.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a type of bicycle.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * bicycle(fakerCore) // 'Adventure Road Bicycle'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function bicycle(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.bicycle_type);
+}

--- a/src/modules/vehicle/color.ts
+++ b/src/modules/vehicle/color.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { human } from '../color/human';
+
+/**
+ * Returns a vehicle color.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * color(fakerCore) // 'red'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function color(fakerCore: FakerCore): string {
+  return human(fakerCore);
+}

--- a/src/modules/vehicle/fuel.ts
+++ b/src/modules/vehicle/fuel.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a fuel type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * fuel(fakerCore) // 'Electric'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function fuel(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.fuel);
+}

--- a/src/modules/vehicle/manufacturer.ts
+++ b/src/modules/vehicle/manufacturer.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a manufacturer name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * manufacturer(fakerCore) // 'Ford'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function manufacturer(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.manufacturer);
+}

--- a/src/modules/vehicle/model.ts
+++ b/src/modules/vehicle/model.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a vehicle model.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * model(fakerCore) // 'Explorer'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function model(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.model);
+}

--- a/src/modules/vehicle/module.ts
+++ b/src/modules/vehicle/module.ts
@@ -1,5 +1,13 @@
 import { ModuleBase } from '../../internal/module-base';
-import { vinCheckDigit } from './vin';
+import { bicycle as vehicleBicycle } from './bicycle';
+import { color as vehicleColor } from './color';
+import { fuel as vehicleFuel } from './fuel';
+import { manufacturer as vehicleManufacturer } from './manufacturer';
+import { model as vehicleModel } from './model';
+import { type as vehicleType } from './type';
+import { vehicle as vehicleVehicle } from './vehicle';
+import { vin as vehicleVin } from './vin';
+import { vrm as vehicleVrm } from './vrm';
 
 /**
  * Module to generate vehicle related entries.
@@ -11,6 +19,11 @@ import { vinCheckDigit } from './vin';
  * If you prefer two wheels, you can generate a [`bicycle()`](https://fakerjs.dev/api/vehicle.html#bicycle) type instead.
  */
 export class VehicleModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree vehicle' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random vehicle.
    *
@@ -20,7 +33,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   vehicle(): string {
-    return `${this.manufacturer()} ${this.model()}`;
+    return vehicleVehicle(this.faker.fakerCore);
   }
 
   /**
@@ -32,9 +45,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   manufacturer(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.vehicle.manufacturer
-    );
+    return vehicleManufacturer(this.faker.fakerCore);
   }
 
   /**
@@ -46,9 +57,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   model(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.vehicle.model
-    );
+    return vehicleModel(this.faker.fakerCore);
   }
 
   /**
@@ -60,7 +69,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   type(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.vehicle.type);
+    return vehicleType(this.faker.fakerCore);
   }
 
   /**
@@ -72,7 +81,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   fuel(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.vehicle.fuel);
+    return vehicleFuel(this.faker.fakerCore);
   }
 
   /**
@@ -84,22 +93,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   vin(): string {
-    const exclude = ['o', 'i', 'q', 'O', 'I', 'Q'];
-    const vin = `${this.faker.string.alphanumeric({
-      length: 10,
-      casing: 'upper',
-      exclude,
-    })}${this.faker.string.alpha({
-      length: 1,
-      casing: 'upper',
-      exclude,
-    })}${this.faker.string.alphanumeric({
-      length: 1,
-      casing: 'upper',
-      exclude,
-    })}${this.faker.string.numeric({ length: 5, allowLeadingZeros: true })}`;
-
-    return `${vin.slice(0, 8)}${vinCheckDigit(vin)}${vin.slice(9)}`;
+    return vehicleVin(this.faker.fakerCore);
   }
 
   /**
@@ -111,7 +105,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   color(): string {
-    return this.faker.color.human();
+    return vehicleColor(this.faker.fakerCore);
   }
 
   /**
@@ -123,16 +117,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.4.0
    */
   vrm(): string {
-    return `${this.faker.string.alpha({
-      length: 2,
-      casing: 'upper',
-    })}${this.faker.string.numeric({
-      length: 2,
-      allowLeadingZeros: true,
-    })}${this.faker.string.alpha({
-      length: 3,
-      casing: 'upper',
-    })}`;
+    return vehicleVrm(this.faker.fakerCore);
   }
 
   /**
@@ -144,8 +129,6 @@ export class VehicleModule extends ModuleBase {
    * @since 5.5.0
    */
   bicycle(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.vehicle.bicycle_type
-    );
+    return vehicleBicycle(this.faker.fakerCore);
   }
 }

--- a/src/modules/vehicle/module.ts
+++ b/src/modules/vehicle/module.ts
@@ -1,50 +1,5 @@
 import { ModuleBase } from '../../internal/module-base';
-
-// NHTSA 49 CFR § 565.15(c), Tables III and IV define the transliteration
-// values and position weights used here:
-// https://www.govinfo.gov/content/pkg/CFR-2024-title49-vol6/pdf/CFR-2024-title49-vol6-sec565-15.pdf
-const vinWeights = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2];
-
-const vinTransliteration: Record<string, number> = {
-  A: 1,
-  B: 2,
-  C: 3,
-  D: 4,
-  E: 5,
-  F: 6,
-  G: 7,
-  H: 8,
-  J: 1,
-  K: 2,
-  L: 3,
-  M: 4,
-  N: 5,
-  P: 7,
-  R: 9,
-  S: 2,
-  T: 3,
-  U: 4,
-  V: 5,
-  W: 6,
-  X: 7,
-  Y: 8,
-  Z: 9,
-};
-
-/**
- * Calculates a Vehicle Identification Number (VIN) check digit.
- *
- * @param vin The VIN to calculate the check digit for.
- */
-export function vinCheckDigit(vin: string): string {
-  let checksum = 0;
-  for (const [index, character] of [...vin].entries()) {
-    const value = vinTransliteration[character] ?? Number(character);
-    checksum += value * vinWeights[index];
-  }
-
-  return checksum % 11 === 10 ? 'X' : String(checksum % 11);
-}
+import { vinCheckDigit } from './vin';
 
 /**
  * Module to generate vehicle related entries.

--- a/src/modules/vehicle/type.ts
+++ b/src/modules/vehicle/type.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a vehicle type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * type(fakerCore) // 'Coupe'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function type(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.type);
+}

--- a/src/modules/vehicle/vehicle.ts
+++ b/src/modules/vehicle/vehicle.ts
@@ -1,0 +1,19 @@
+import type { FakerCore } from '../../core';
+import { manufacturer } from './manufacturer';
+import { model } from './model';
+
+/**
+ * Returns a random vehicle.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * vehicle(fakerCore) // 'BMW Explorer'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function vehicle(fakerCore: FakerCore): string {
+  return `${manufacturer(fakerCore)} ${model(fakerCore)}`;
+}

--- a/src/modules/vehicle/vin.ts
+++ b/src/modules/vehicle/vin.ts
@@ -1,0 +1,35 @@
+import type { FakerCore } from '../../core';
+import { alpha } from '../string/alpha';
+import { alphanumeric } from '../string/alphanumeric';
+import { numeric } from '../string/numeric';
+
+/**
+ * Returns a vehicle identification number (VIN).
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * vin(fakerCore) // 'YV1MH682762184654'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function vin(fakerCore: FakerCore): string {
+  const exclude = ['o', 'i', 'q', 'O', 'I', 'Q'];
+  const vin = `${alphanumeric(fakerCore, {
+    length: 10,
+    casing: 'upper',
+    exclude,
+  })}${alpha(fakerCore, {
+    length: 1,
+    casing: 'upper',
+    exclude,
+  })}${alphanumeric(fakerCore, {
+    length: 1,
+    casing: 'upper',
+    exclude,
+  })}${numeric(fakerCore, { length: 5, allowLeadingZeros: true })}`;
+
+  return `${vin.slice(0, 8)}${vinCheckDigit(vin)}${vin.slice(9)}`;
+}

--- a/src/modules/vehicle/vin.ts
+++ b/src/modules/vehicle/vin.ts
@@ -3,6 +3,54 @@ import { alpha } from '../string/alpha';
 import { alphanumeric } from '../string/alphanumeric';
 import { numeric } from '../string/numeric';
 
+// NHTSA 49 CFR § 565.15(c), Tables III and IV define the transliteration
+// values and position weights used here:
+// https://www.govinfo.gov/content/pkg/CFR-2024-title49-vol6/pdf/CFR-2024-title49-vol6-sec565-15.pdf
+const vinWeights = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2];
+
+const vinTransliteration: Record<string, number> = {
+  A: 1,
+  B: 2,
+  C: 3,
+  D: 4,
+  E: 5,
+  F: 6,
+  G: 7,
+  H: 8,
+  J: 1,
+  K: 2,
+  L: 3,
+  M: 4,
+  N: 5,
+  P: 7,
+  R: 9,
+  S: 2,
+  T: 3,
+  U: 4,
+  V: 5,
+  W: 6,
+  X: 7,
+  Y: 8,
+  Z: 9,
+};
+
+/**
+ * Calculates a Vehicle Identification Number (VIN) check digit.
+ *
+ * @internal
+ *
+ * @param vin The VIN to calculate the check digit for.
+ */
+export function vinCheckDigit(vin: string): string {
+  let checksum = 0;
+  for (const [index, character] of [...vin].entries()) {
+    const value = vinTransliteration[character] ?? Number(character);
+    checksum += value * vinWeights[index];
+  }
+
+  return checksum % 11 === 10 ? 'X' : String(checksum % 11);
+}
+
 /**
  * Returns a vehicle identification number (VIN).
  *

--- a/src/modules/vehicle/vrm.ts
+++ b/src/modules/vehicle/vrm.ts
@@ -1,0 +1,28 @@
+import type { FakerCore } from '../../core';
+import { alpha } from '../string/alpha';
+import { numeric } from '../string/numeric';
+
+/**
+ * Returns a vehicle registration number (Vehicle Registration Mark - VRM)
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * vrm(fakerCore) // 'MF56UPA'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function vrm(fakerCore: FakerCore): string {
+  return `${alpha(fakerCore, {
+    length: 2,
+    casing: 'upper',
+  })}${numeric(fakerCore, {
+    length: 2,
+    allowLeadingZeros: true,
+  })}${alpha(fakerCore, {
+    length: 3,
+    casing: 'upper',
+  })}`;
+}

--- a/test/modules/vehicle.spec.ts
+++ b/test/modules/vehicle.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { faker } from '../../src';
-import { vinCheckDigit } from '../../src/modules/vehicle/module';
+import { vinCheckDigit } from '../../src/modules/vehicle/vin';
 import { seededTests } from '../support/seeded-runs';
 import { times } from '../support/times';
 


### PR DESCRIPTION
Continuation of #4069

- #4069

---

Transforms the vehicle module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts vehicle`
4. Cherry-pick `refactor: transform vehicle module`
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~