### PR TITLE
feat(word): transform to standalone modular functions

### DIFF
--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -22,4 +22,5 @@ export const ALLOWED_MODULES = new Set([
   'ScienceModule',
   'StringModule',
   'VehicleModule',
+  'WordModule',
 ]);

--- a/scripts/temp-module-filter.ts
+++ b/scripts/temp-module-filter.ts
@@ -21,4 +21,5 @@ export const ALLOWED_MODULES = new Set([
   'PhoneModule',
   'ScienceModule',
   'StringModule',
+  'VehicleModule',
 ]);

--- a/src/modules/vehicle/bicycle.ts
+++ b/src/modules/vehicle/bicycle.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a type of bicycle.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * bicycle(fakerCore) // 'Adventure Road Bicycle'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function bicycle(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.bicycle_type);
+}

--- a/src/modules/vehicle/color.ts
+++ b/src/modules/vehicle/color.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { human } from '../color/human';
+
+/**
+ * Returns a vehicle color.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * color(fakerCore) // 'red'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function color(fakerCore: FakerCore): string {
+  return human(fakerCore);
+}

--- a/src/modules/vehicle/fuel.ts
+++ b/src/modules/vehicle/fuel.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a fuel type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * fuel(fakerCore) // 'Electric'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function fuel(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.fuel);
+}

--- a/src/modules/vehicle/manufacturer.ts
+++ b/src/modules/vehicle/manufacturer.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a manufacturer name.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * manufacturer(fakerCore) // 'Ford'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function manufacturer(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.manufacturer);
+}

--- a/src/modules/vehicle/model.ts
+++ b/src/modules/vehicle/model.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a vehicle model.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * model(fakerCore) // 'Explorer'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function model(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.model);
+}

--- a/src/modules/vehicle/module.ts
+++ b/src/modules/vehicle/module.ts
@@ -1,5 +1,13 @@
 import { ModuleBase } from '../../internal/module-base';
-import { vinCheckDigit } from './vin';
+import { bicycle as vehicleBicycle } from './bicycle';
+import { color as vehicleColor } from './color';
+import { fuel as vehicleFuel } from './fuel';
+import { manufacturer as vehicleManufacturer } from './manufacturer';
+import { model as vehicleModel } from './model';
+import { type as vehicleType } from './type';
+import { vehicle as vehicleVehicle } from './vehicle';
+import { vin as vehicleVin } from './vin';
+import { vrm as vehicleVrm } from './vrm';
 
 /**
  * Module to generate vehicle related entries.
@@ -11,6 +19,11 @@ import { vinCheckDigit } from './vin';
  * If you prefer two wheels, you can generate a [`bicycle()`](https://fakerjs.dev/api/vehicle.html#bicycle) type instead.
  */
 export class VehicleModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree vehicle' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random vehicle.
    *
@@ -20,7 +33,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   vehicle(): string {
-    return `${this.manufacturer()} ${this.model()}`;
+    return vehicleVehicle(this.faker.fakerCore);
   }
 
   /**
@@ -32,9 +45,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   manufacturer(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.vehicle.manufacturer
-    );
+    return vehicleManufacturer(this.faker.fakerCore);
   }
 
   /**
@@ -46,9 +57,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   model(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.vehicle.model
-    );
+    return vehicleModel(this.faker.fakerCore);
   }
 
   /**
@@ -60,7 +69,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   type(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.vehicle.type);
+    return vehicleType(this.faker.fakerCore);
   }
 
   /**
@@ -72,7 +81,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   fuel(): string {
-    return this.faker.helpers.arrayElement(this.faker.definitions.vehicle.fuel);
+    return vehicleFuel(this.faker.fakerCore);
   }
 
   /**
@@ -84,22 +93,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   vin(): string {
-    const exclude = ['o', 'i', 'q', 'O', 'I', 'Q'];
-    const vin = `${this.faker.string.alphanumeric({
-      length: 10,
-      casing: 'upper',
-      exclude,
-    })}${this.faker.string.alpha({
-      length: 1,
-      casing: 'upper',
-      exclude,
-    })}${this.faker.string.alphanumeric({
-      length: 1,
-      casing: 'upper',
-      exclude,
-    })}${this.faker.string.numeric({ length: 5, allowLeadingZeros: true })}`;
-
-    return `${vin.slice(0, 8)}${vinCheckDigit(vin)}${vin.slice(9)}`;
+    return vehicleVin(this.faker.fakerCore);
   }
 
   /**
@@ -111,7 +105,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   color(): string {
-    return this.faker.color.human();
+    return vehicleColor(this.faker.fakerCore);
   }
 
   /**
@@ -123,16 +117,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.4.0
    */
   vrm(): string {
-    return `${this.faker.string.alpha({
-      length: 2,
-      casing: 'upper',
-    })}${this.faker.string.numeric({
-      length: 2,
-      allowLeadingZeros: true,
-    })}${this.faker.string.alpha({
-      length: 3,
-      casing: 'upper',
-    })}`;
+    return vehicleVrm(this.faker.fakerCore);
   }
 
   /**
@@ -144,8 +129,6 @@ export class VehicleModule extends ModuleBase {
    * @since 5.5.0
    */
   bicycle(): string {
-    return this.faker.helpers.arrayElement(
-      this.faker.definitions.vehicle.bicycle_type
-    );
+    return vehicleBicycle(this.faker.fakerCore);
   }
 }

--- a/src/modules/vehicle/module.ts
+++ b/src/modules/vehicle/module.ts
@@ -1,50 +1,5 @@
 import { ModuleBase } from '../../internal/module-base';
-
-// NHTSA 49 CFR § 565.15(c), Tables III and IV define the transliteration
-// values and position weights used here:
-// https://www.govinfo.gov/content/pkg/CFR-2024-title49-vol6/pdf/CFR-2024-title49-vol6-sec565-15.pdf
-const vinWeights = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2];
-
-const vinTransliteration: Record<string, number> = {
-  A: 1,
-  B: 2,
-  C: 3,
-  D: 4,
-  E: 5,
-  F: 6,
-  G: 7,
-  H: 8,
-  J: 1,
-  K: 2,
-  L: 3,
-  M: 4,
-  N: 5,
-  P: 7,
-  R: 9,
-  S: 2,
-  T: 3,
-  U: 4,
-  V: 5,
-  W: 6,
-  X: 7,
-  Y: 8,
-  Z: 9,
-};
-
-/**
- * Calculates a Vehicle Identification Number (VIN) check digit.
- *
- * @param vin The VIN to calculate the check digit for.
- */
-export function vinCheckDigit(vin: string): string {
-  let checksum = 0;
-  for (const [index, character] of [...vin].entries()) {
-    const value = vinTransliteration[character] ?? Number(character);
-    checksum += value * vinWeights[index];
-  }
-
-  return checksum % 11 === 10 ? 'X' : String(checksum % 11);
-}
+import { vinCheckDigit } from './vin';
 
 /**
  * Module to generate vehicle related entries.

--- a/src/modules/vehicle/type.ts
+++ b/src/modules/vehicle/type.ts
@@ -1,0 +1,18 @@
+import type { FakerCore } from '../../core';
+import { arrayElement } from '../helpers/array-element';
+
+/**
+ * Returns a vehicle type.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * type(fakerCore) // 'Coupe'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function type(fakerCore: FakerCore): string {
+  return arrayElement(fakerCore, fakerCore.locale.vehicle.type);
+}

--- a/src/modules/vehicle/vehicle.ts
+++ b/src/modules/vehicle/vehicle.ts
@@ -1,0 +1,19 @@
+import type { FakerCore } from '../../core';
+import { manufacturer } from './manufacturer';
+import { model } from './model';
+
+/**
+ * Returns a random vehicle.
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * vehicle(fakerCore) // 'BMW Explorer'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function vehicle(fakerCore: FakerCore): string {
+  return `${manufacturer(fakerCore)} ${model(fakerCore)}`;
+}

--- a/src/modules/vehicle/vin.ts
+++ b/src/modules/vehicle/vin.ts
@@ -1,0 +1,35 @@
+import type { FakerCore } from '../../core';
+import { alpha } from '../string/alpha';
+import { alphanumeric } from '../string/alphanumeric';
+import { numeric } from '../string/numeric';
+
+/**
+ * Returns a vehicle identification number (VIN).
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * vin(fakerCore) // 'YV1MH682762184654'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function vin(fakerCore: FakerCore): string {
+  const exclude = ['o', 'i', 'q', 'O', 'I', 'Q'];
+  const vin = `${alphanumeric(fakerCore, {
+    length: 10,
+    casing: 'upper',
+    exclude,
+  })}${alpha(fakerCore, {
+    length: 1,
+    casing: 'upper',
+    exclude,
+  })}${alphanumeric(fakerCore, {
+    length: 1,
+    casing: 'upper',
+    exclude,
+  })}${numeric(fakerCore, { length: 5, allowLeadingZeros: true })}`;
+
+  return `${vin.slice(0, 8)}${vinCheckDigit(vin)}${vin.slice(9)}`;
+}

--- a/src/modules/vehicle/vin.ts
+++ b/src/modules/vehicle/vin.ts
@@ -3,6 +3,54 @@ import { alpha } from '../string/alpha';
 import { alphanumeric } from '../string/alphanumeric';
 import { numeric } from '../string/numeric';
 
+// NHTSA 49 CFR § 565.15(c), Tables III and IV define the transliteration
+// values and position weights used here:
+// https://www.govinfo.gov/content/pkg/CFR-2024-title49-vol6/pdf/CFR-2024-title49-vol6-sec565-15.pdf
+const vinWeights = [8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2];
+
+const vinTransliteration: Record<string, number> = {
+  A: 1,
+  B: 2,
+  C: 3,
+  D: 4,
+  E: 5,
+  F: 6,
+  G: 7,
+  H: 8,
+  J: 1,
+  K: 2,
+  L: 3,
+  M: 4,
+  N: 5,
+  P: 7,
+  R: 9,
+  S: 2,
+  T: 3,
+  U: 4,
+  V: 5,
+  W: 6,
+  X: 7,
+  Y: 8,
+  Z: 9,
+};
+
+/**
+ * Calculates a Vehicle Identification Number (VIN) check digit.
+ *
+ * @internal
+ *
+ * @param vin The VIN to calculate the check digit for.
+ */
+export function vinCheckDigit(vin: string): string {
+  let checksum = 0;
+  for (const [index, character] of [...vin].entries()) {
+    const value = vinTransliteration[character] ?? Number(character);
+    checksum += value * vinWeights[index];
+  }
+
+  return checksum % 11 === 10 ? 'X' : String(checksum % 11);
+}
+
 /**
  * Returns a vehicle identification number (VIN).
  *

--- a/src/modules/vehicle/vrm.ts
+++ b/src/modules/vehicle/vrm.ts
@@ -1,0 +1,28 @@
+import type { FakerCore } from '../../core';
+import { alpha } from '../string/alpha';
+import { numeric } from '../string/numeric';
+
+/**
+ * Returns a vehicle registration number (Vehicle Registration Mark - VRM)
+ *
+ * @param fakerCore The FakerCore to use.
+ *
+ * @example
+ * vrm(fakerCore) // 'MF56UPA'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function vrm(fakerCore: FakerCore): string {
+  return `${alpha(fakerCore, {
+    length: 2,
+    casing: 'upper',
+  })}${numeric(fakerCore, {
+    length: 2,
+    allowLeadingZeros: true,
+  })}${alpha(fakerCore, {
+    length: 3,
+    casing: 'upper',
+  })}`;
+}

--- a/src/modules/word/adjective.ts
+++ b/src/modules/word/adjective.ts
@@ -1,0 +1,54 @@
+import type { FakerCore } from '../../core';
+import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
+import { arrayElement } from '../helpers/array-element';
+import { filterWordListByLength } from './_filter-word-list-by-length';
+
+/**
+ * Returns a random adjective.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The expected length of the word or the options to use.
+ * @param options.length The expected length of the word.
+ * @param options.strategy The strategy to apply when no words with a matching length are found.
+ *
+ * Defaults to `'fail'`.
+ *
+ * @example
+ * adjective(fakerCore) // 'pungent'
+ * adjective(fakerCore, 5) // 'slimy'
+ * adjective(fakerCore, { strategy: 'shortest' }) // 'icy'
+ * adjective(fakerCore, { length: { min: 5, max: 7 }, strategy: "fail" }) // 'distant'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function adjective(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The expected length of the word.
+         */
+        length?: NumberOrRange;
+        /**
+         * The strategy to apply when no words with a matching length are found.
+         *
+         * @default 'fail'
+         */
+        strategy?: LengthStrategyType;
+      } = {}
+): string {
+  if (typeof options === 'number') {
+    options = { length: options };
+  }
+
+  return arrayElement(
+    fakerCore,
+    filterWordListByLength({
+      ...options,
+      wordList: fakerCore.locale.word.adjective,
+    })
+  );
+}

--- a/src/modules/word/adverb.ts
+++ b/src/modules/word/adverb.ts
@@ -1,0 +1,54 @@
+import type { FakerCore } from '../../core';
+import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
+import { arrayElement } from '../helpers/array-element';
+import { filterWordListByLength } from './_filter-word-list-by-length';
+
+/**
+ * Returns a random adverb.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The expected length of the word or the options to use.
+ * @param options.length The expected length of the word.
+ * @param options.strategy The strategy to apply when no words with a matching length are found.
+ *
+ * Defaults to `'fail'`.
+ *
+ * @example
+ * adverb(fakerCore) // 'quarrelsomely'
+ * adverb(fakerCore, 5) // 'madly'
+ * adverb(fakerCore, { strategy: 'shortest' }) // 'too'
+ * adverb(fakerCore, { length: { min: 5, max: 7 }, strategy: "fail" }) // 'sweetly'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function adverb(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The expected length of the word.
+         */
+        length?: NumberOrRange;
+        /**
+         * The strategy to apply when no words with a matching length are found.
+         *
+         * @default 'fail'
+         */
+        strategy?: LengthStrategyType;
+      } = {}
+): string {
+  if (typeof options === 'number') {
+    options = { length: options };
+  }
+
+  return arrayElement(
+    fakerCore,
+    filterWordListByLength({
+      ...options,
+      wordList: fakerCore.locale.word.adverb,
+    })
+  );
+}

--- a/src/modules/word/conjunction.ts
+++ b/src/modules/word/conjunction.ts
@@ -1,0 +1,54 @@
+import type { FakerCore } from '../../core';
+import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
+import { arrayElement } from '../helpers/array-element';
+import { filterWordListByLength } from './_filter-word-list-by-length';
+
+/**
+ * Returns a random conjunction.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The expected length of the word or the options to use.
+ * @param options.length The expected length of the word.
+ * @param options.strategy The strategy to apply when no words with a matching length are found.
+ *
+ * Defaults to `'fail'`.
+ *
+ * @example
+ * conjunction(fakerCore) // 'in order that'
+ * conjunction(fakerCore, 5) // 'since'
+ * conjunction(fakerCore, { strategy: 'shortest' }) // 'or'
+ * conjunction(fakerCore, { length: { min: 5, max: 7 }, strategy: "fail" }) // 'hence'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function conjunction(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The expected length of the word.
+         */
+        length?: NumberOrRange;
+        /**
+         * The strategy to apply when no words with a matching length are found.
+         *
+         * @default 'fail'
+         */
+        strategy?: LengthStrategyType;
+      } = {}
+): string {
+  if (typeof options === 'number') {
+    options = { length: options };
+  }
+
+  return arrayElement(
+    fakerCore,
+    filterWordListByLength({
+      ...options,
+      wordList: fakerCore.locale.word.conjunction,
+    })
+  );
+}

--- a/src/modules/word/interjection.ts
+++ b/src/modules/word/interjection.ts
@@ -1,0 +1,54 @@
+import type { FakerCore } from '../../core';
+import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
+import { arrayElement } from '../helpers/array-element';
+import { filterWordListByLength } from './_filter-word-list-by-length';
+
+/**
+ * Returns a random interjection.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The expected length of the word or the options to use.
+ * @param options.length The expected length of the word.
+ * @param options.strategy The strategy to apply when no words with a matching length are found.
+ *
+ * Defaults to `'fail'`.
+ *
+ * @example
+ * interjection(fakerCore) // 'gah'
+ * interjection(fakerCore, 5) // 'fooey'
+ * interjection(fakerCore, { strategy: 'shortest' }) // 'hm'
+ * interjection(fakerCore, { length: { min: 5, max: 7 }, strategy: "fail" }) // 'boohoo'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function interjection(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The expected length of the word.
+         */
+        length?: NumberOrRange;
+        /**
+         * The strategy to apply when no words with a matching length are found.
+         *
+         * @default 'fail'
+         */
+        strategy?: LengthStrategyType;
+      } = {}
+): string {
+  if (typeof options === 'number') {
+    options = { length: options };
+  }
+
+  return arrayElement(
+    fakerCore,
+    filterWordListByLength({
+      ...options,
+      wordList: fakerCore.locale.word.interjection,
+    })
+  );
+}

--- a/src/modules/word/module.ts
+++ b/src/modules/word/module.ts
@@ -1,12 +1,24 @@
-import { FakerError } from '../../errors/faker-error';
 import { ModuleBase } from '../../internal/module-base';
 import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
-import { filterWordListByLength } from './_filter-word-list-by-length';
+import { adjective as wordAdjective } from './adjective';
+import { adverb as wordAdverb } from './adverb';
+import { conjunction as wordConjunction } from './conjunction';
+import { interjection as wordInterjection } from './interjection';
+import { noun as wordNoun } from './noun';
+import { preposition as wordPreposition } from './preposition';
+import { wordSample } from './sample';
+import { verb as wordVerb } from './verb';
+import { words as wordWords } from './words';
 
 /**
  * Module to return various types of words.
  */
 export class WordModule extends ModuleBase {
+  /*
+   * The class body is automatically generated.
+   * Run 'pnpm run generate:module-tree word' to update the methods from their respective files.
+   */
+
   /**
    * Returns a random adjective.
    *
@@ -40,16 +52,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    if (typeof options === 'number') {
-      options = { length: options };
-    }
-
-    return this.faker.helpers.arrayElement(
-      filterWordListByLength({
-        ...options,
-        wordList: this.faker.definitions.word.adjective,
-      })
-    );
+    return wordAdjective(this.faker.fakerCore, options);
   }
 
   /**
@@ -85,16 +88,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    if (typeof options === 'number') {
-      options = { length: options };
-    }
-
-    return this.faker.helpers.arrayElement(
-      filterWordListByLength({
-        ...options,
-        wordList: this.faker.definitions.word.adverb,
-      })
-    );
+    return wordAdverb(this.faker.fakerCore, options);
   }
 
   /**
@@ -130,16 +124,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    if (typeof options === 'number') {
-      options = { length: options };
-    }
-
-    return this.faker.helpers.arrayElement(
-      filterWordListByLength({
-        ...options,
-        wordList: this.faker.definitions.word.conjunction,
-      })
-    );
+    return wordConjunction(this.faker.fakerCore, options);
   }
 
   /**
@@ -175,16 +160,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    if (typeof options === 'number') {
-      options = { length: options };
-    }
-
-    return this.faker.helpers.arrayElement(
-      filterWordListByLength({
-        ...options,
-        wordList: this.faker.definitions.word.interjection,
-      })
-    );
+    return wordInterjection(this.faker.fakerCore, options);
   }
 
   /**
@@ -220,16 +196,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    if (typeof options === 'number') {
-      options = { length: options };
-    }
-
-    return this.faker.helpers.arrayElement(
-      filterWordListByLength({
-        ...options,
-        wordList: this.faker.definitions.word.noun,
-      })
-    );
+    return wordNoun(this.faker.fakerCore, options);
   }
 
   /**
@@ -265,16 +232,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    if (typeof options === 'number') {
-      options = { length: options };
-    }
-
-    return this.faker.helpers.arrayElement(
-      filterWordListByLength({
-        ...options,
-        wordList: this.faker.definitions.word.preposition,
-      })
-    );
+    return wordPreposition(this.faker.fakerCore, options);
   }
 
   /**
@@ -310,16 +268,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    if (typeof options === 'number') {
-      options = { length: options };
-    }
-
-    return this.faker.helpers.arrayElement(
-      filterWordListByLength({
-        ...options,
-        wordList: this.faker.definitions.word.verb,
-      })
-    );
+    return wordVerb(this.faker.fakerCore, options);
   }
 
   /**
@@ -353,28 +302,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    const wordMethods = this.faker.helpers.shuffle([
-      this.adjective,
-      this.adverb,
-      this.conjunction,
-      this.interjection,
-      this.noun,
-      this.preposition,
-      this.verb,
-    ]);
-
-    for (const randomWordMethod of wordMethods) {
-      try {
-        return randomWordMethod(options);
-      } catch {
-        // catch missing locale data potentially required by randomWordMethod
-        continue;
-      }
-    }
-
-    throw new FakerError(
-      'No matching word data available for the current locale'
-    );
+    return wordSample(this.faker.fakerCore, options);
   }
 
   /**
@@ -403,14 +331,6 @@ export class WordModule extends ModuleBase {
           count?: NumberOrRange;
         } = {}
   ): string {
-    if (typeof options === 'number') {
-      options = { count: options };
-    }
-
-    const { count = { min: 1, max: 3 } } = options;
-
-    return this.faker.helpers
-      .multiple(() => this.sample(), { count })
-      .join(' ');
+    return wordWords(this.faker.fakerCore, options);
   }
 }

--- a/src/modules/word/noun.ts
+++ b/src/modules/word/noun.ts
@@ -1,0 +1,54 @@
+import type { FakerCore } from '../../core';
+import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
+import { arrayElement } from '../helpers/array-element';
+import { filterWordListByLength } from './_filter-word-list-by-length';
+
+/**
+ * Returns a random noun.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The expected length of the word or the options to use.
+ * @param options.length The expected length of the word.
+ * @param options.strategy The strategy to apply when no words with a matching length are found.
+ *
+ * Defaults to `'fail'`.
+ *
+ * @example
+ * noun(fakerCore) // 'external'
+ * noun(fakerCore, 5) // 'front'
+ * noun(fakerCore, { strategy: 'shortest' }) // 'ad'
+ * noun(fakerCore, { length: { min: 5, max: 7 }, strategy: "fail" }) // 'average'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function noun(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The expected length of the word.
+         */
+        length?: NumberOrRange;
+        /**
+         * The strategy to apply when no words with a matching length are found.
+         *
+         * @default 'fail'
+         */
+        strategy?: LengthStrategyType;
+      } = {}
+): string {
+  if (typeof options === 'number') {
+    options = { length: options };
+  }
+
+  return arrayElement(
+    fakerCore,
+    filterWordListByLength({
+      ...options,
+      wordList: fakerCore.locale.word.noun,
+    })
+  );
+}

--- a/src/modules/word/preposition.ts
+++ b/src/modules/word/preposition.ts
@@ -1,0 +1,54 @@
+import type { FakerCore } from '../../core';
+import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
+import { arrayElement } from '../helpers/array-element';
+import { filterWordListByLength } from './_filter-word-list-by-length';
+
+/**
+ * Returns a random preposition.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The expected length of the word or the options to use.
+ * @param options.length The expected length of the word.
+ * @param options.strategy The strategy to apply when no words with a matching length are found.
+ *
+ * Defaults to `'fail'`.
+ *
+ * @example
+ * preposition(fakerCore) // 'without'
+ * preposition(fakerCore, 5) // 'abaft'
+ * preposition(fakerCore, { strategy: 'shortest' }) // 'a'
+ * preposition(fakerCore, { length: { min: 5, max: 7 }, strategy: "fail" }) // 'given'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function preposition(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The expected length of the word.
+         */
+        length?: NumberOrRange;
+        /**
+         * The strategy to apply when no words with a matching length are found.
+         *
+         * @default 'fail'
+         */
+        strategy?: LengthStrategyType;
+      } = {}
+): string {
+  if (typeof options === 'number') {
+    options = { length: options };
+  }
+
+  return arrayElement(
+    fakerCore,
+    filterWordListByLength({
+      ...options,
+      wordList: fakerCore.locale.word.preposition,
+    })
+  );
+}

--- a/src/modules/word/sample.ts
+++ b/src/modules/word/sample.ts
@@ -2,6 +2,13 @@ import type { FakerCore } from '../../core';
 import { FakerError } from '../../errors/faker-error';
 import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
 import { shuffle } from '../helpers/shuffle';
+import { adjective } from './adjective';
+import { adverb } from './adverb';
+import { conjunction } from './conjunction';
+import { interjection } from './interjection';
+import { noun } from './noun';
+import { preposition } from './preposition';
+import { verb } from './verb';
 
 /**
  * Returns a random word, that can be an adjective, adverb, conjunction, interjection, noun, preposition, or verb.
@@ -39,18 +46,18 @@ export function wordSample(
       } = {}
 ): string {
   const wordMethods = shuffle(fakerCore, [
-    this.adjective,
-    this.adverb,
-    this.conjunction,
-    this.interjection,
-    this.noun,
-    this.preposition,
-    this.verb,
-  ]);
+    adjective,
+    adverb,
+    conjunction,
+    interjection,
+    noun,
+    preposition,
+    verb,
+  ] satisfies Array<typeof wordSample>);
 
   for (const randomWordMethod of wordMethods) {
     try {
-      return randomWordMethod(options);
+      return randomWordMethod(fakerCore, options);
     } catch {
       // catch missing locale data potentially required by randomWordMethod
       continue;

--- a/src/modules/word/sample.ts
+++ b/src/modules/word/sample.ts
@@ -1,0 +1,63 @@
+import type { FakerCore } from '../../core';
+import { FakerError } from '../../errors/faker-error';
+import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
+import { shuffle } from '../helpers/shuffle';
+
+/**
+ * Returns a random word, that can be an adjective, adverb, conjunction, interjection, noun, preposition, or verb.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The expected length of the word or the options to use.
+ * @param options.length The expected length of the word.
+ * @param options.strategy The strategy to apply when no words with a matching length are found.
+ *
+ * Defaults to `'fail'`.
+ *
+ * @example
+ * wordSample(fakerCore) // 'incidentally'
+ * wordSample(fakerCore, 5) // 'fruit'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function wordSample(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The expected length of the word.
+         */
+        length?: NumberOrRange;
+        /**
+         * The strategy to apply when no words with a matching length are found.
+         *
+         * @default 'fail'
+         */
+        strategy?: LengthStrategyType;
+      } = {}
+): string {
+  const wordMethods = shuffle(fakerCore, [
+    this.adjective,
+    this.adverb,
+    this.conjunction,
+    this.interjection,
+    this.noun,
+    this.preposition,
+    this.verb,
+  ]);
+
+  for (const randomWordMethod of wordMethods) {
+    try {
+      return randomWordMethod(options);
+    } catch {
+      // catch missing locale data potentially required by randomWordMethod
+      continue;
+    }
+  }
+
+  throw new FakerError(
+    'No matching word data available for the current locale'
+  );
+}

--- a/src/modules/word/verb.ts
+++ b/src/modules/word/verb.ts
@@ -1,0 +1,54 @@
+import type { FakerCore } from '../../core';
+import type { LengthStrategyType, NumberOrRange } from '../../utils/types';
+import { arrayElement } from '../helpers/array-element';
+import { filterWordListByLength } from './_filter-word-list-by-length';
+
+/**
+ * Returns a random verb.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The expected length of the word or the options to use.
+ * @param options.length The expected length of the word.
+ * @param options.strategy The strategy to apply when no words with a matching length are found.
+ *
+ * Defaults to `'fail'`.
+ *
+ * @example
+ * verb(fakerCore) // 'act'
+ * verb(fakerCore, 5) // 'tinge'
+ * verb(fakerCore, { strategy: 'shortest' }) // 'do'
+ * verb(fakerCore, { length: { min: 5, max: 7 }, strategy: "fail" }) // 'vault'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function verb(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The expected length of the word.
+         */
+        length?: NumberOrRange;
+        /**
+         * The strategy to apply when no words with a matching length are found.
+         *
+         * @default 'fail'
+         */
+        strategy?: LengthStrategyType;
+      } = {}
+): string {
+  if (typeof options === 'number') {
+    options = { length: options };
+  }
+
+  return arrayElement(
+    fakerCore,
+    filterWordListByLength({
+      ...options,
+      wordList: fakerCore.locale.word.verb,
+    })
+  );
+}

--- a/src/modules/word/words.ts
+++ b/src/modules/word/words.ts
@@ -1,0 +1,43 @@
+import type { FakerCore } from '../../core';
+import type { NumberOrRange } from '../../utils/types';
+import { multiple } from '../helpers/multiple';
+import { wordSample } from './sample';
+
+/**
+ * Returns a random string containing some words separated by spaces.
+ *
+ * @param fakerCore The FakerCore to use.
+ * @param options The optional options object or the number of words to return.
+ * @param options.count The number of words to return. Defaults to a random value between `1` and `3`.
+ *
+ * @example
+ * words(fakerCore) // 'almost'
+ * words(fakerCore, 5) // 'before hourly patiently dribble equal'
+ * words(fakerCore, { count: 5 }) // 'whoever edible um kissingly faraway'
+ * words(fakerCore, { count: { min: 5, max: 10 } }) // 'vice buoyant through apropos poised total wary boohoo'
+ *
+ * @since 11.0.0
+ *
+ * @experimental
+ */
+export function words(
+  fakerCore: FakerCore,
+  options:
+    | number
+    | {
+        /**
+         * The number of words to return.
+         *
+         * @default { min: 1, max: 3 }
+         */
+        count?: NumberOrRange;
+      } = {}
+): string {
+  if (typeof options === 'number') {
+    options = { count: options };
+  }
+
+  const { count = { min: 1, max: 3 } } = options;
+
+  return multiple(fakerCore, () => wordSample(fakerCore), { count }).join(' ');
+}

--- a/test/modules/vehicle.spec.ts
+++ b/test/modules/vehicle.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { faker } from '../../src';
-import { vinCheckDigit } from '../../src/modules/vehicle/module';
+import { vinCheckDigit } from '../../src/modules/vehicle/vin';
 import { seededTests } from '../support/seeded-runs';
 import { times } from '../support/times';
 


### PR DESCRIPTION
Continuation of #4071

- #4071

---

Transforms the word module to standalone modular functions.

---

This PR can be recreated using the following steps:

1. Checkout next/previous SMF PR
2. Run `pnpm tsx scripts/temp-transform-once.ts word`
4. Cherry-pick `refactor: transform word module`
5. Cherry-pick `chore: allow module`
6. Run `pnpm run generate:module-tree`
7. ~~Cherry-pick `chore: remove temp exports`~~