### PR TITLE
fix(git): replace all spaces in branch names

### DIFF
--- a/src/modules/git/module.ts
+++ b/src/modules/git/module.ts
@@ -19,8 +19,8 @@ export class GitModule extends ModuleBase {
    * @since 5.0.0
    */
   branch(): string {
-    const noun = this.faker.hacker.noun().replace(' ', '-');
-    const verb = this.faker.hacker.verb().replace(' ', '-');
+    const noun = this.faker.hacker.noun().replaceAll(' ', '-');
+    const verb = this.faker.hacker.verb().replaceAll(' ', '-');
     return `${noun}-${verb}`;
   }
 

--- a/test/modules/git.spec.ts
+++ b/test/modules/git.spec.ts
@@ -1,6 +1,6 @@
 import { isEmail, isHexadecimal, isSlug } from 'validator';
 import { describe, expect, it } from 'vitest';
-import { faker } from '../../src';
+import { Faker, faker } from '../../src';
 import { seededTests } from '../support/seeded-runs';
 import { times } from '../support/times';
 
@@ -19,6 +19,24 @@ function isValidCommitAuthor(email: string): boolean {
 }
 
 describe('git', () => {
+  describe('branch()', () => {
+    it.each([
+      ['local area network', 'parse', 'local-area-network-parse'],
+      ['program', 'in stukjes snijden', 'program-in-stukjes-snijden'],
+      [
+        'local area network',
+        'in stukjes snijden',
+        'local-area-network-in-stukjes-snijden',
+      ],
+    ])('should replace all spaces in "%s" and "%s"', (noun, verb, expected) => {
+      const customFaker = new Faker({
+        locale: { hacker: { noun: [noun], verb: [verb] } },
+      });
+
+      expect(customFaker.git.branch()).toBe(expected);
+    });
+  });
+
   seededTests(faker, 'git', (t) => {
     t.itEach('branch', 'commitMessage');
 


### PR DESCRIPTION
`faker.git.branch()` replaces only the first space in each hacker noun and verb. With the Dutch locale and seed 30, it returns `programma-in-stukjes snijden`, which `git check-ref-format --branch` rejects. Replacing all spaces produces the valid name `programma-in-stukjes-snijden`.

Use `replaceAll` for both components and add three deterministic regression cases using custom locale data: multiple spaces in the noun, in the verb, and in both.

Validation:
- All three regression cases failed before the fix.
- Git module tests: 89 passed after the fix.
- Full `pnpm run preflight`: passed (54,213 tests passed; formatting, lint, build and TypeScript checks passed).

Prepared against `next`. The same logic is being moved in #4056; if that lands first, the fix will need to follow it into `src/modules/git/branch.ts`.

### Reproduction

The issue can be reproduced deterministically with the Dutch locale and seed `30`.

Create a small script:

```js
import { fakerNL } from '@faker-js/faker';

fakerNL.seed(30);

const branch = fakerNL.git.branch();

console.log(branch); //programma-in-stukjes snijden -> not a valid branch name since it contains spaces 
```

note: I didn't create an issue since the bug is pretty straight and small.

