### PR TITLE
refactor!: only use FakerCore in modules

### DIFF
--- a/scripts/module-tree/generate-module-tree.ts
+++ b/scripts/module-tree/generate-module-tree.ts
@@ -194,7 +194,7 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
               .map((param) => param.getName());
 
             child.setBodyText(
-              `return ${toCamelCase(moduleName, methodName)}(this.faker.fakerCore, ${params.join(', ')});`
+              `return ${toCamelCase(moduleName, methodName)}(this.fakerCore, ${params.join(', ')});`
             );
           }
 

--- a/scripts/module-tree/generate-module-tree.ts
+++ b/scripts/module-tree/generate-module-tree.ts
@@ -26,10 +26,15 @@ function patchModuleImports(moduleName: string, importHelper: ImportHelper) {
     }
     case 'helpers': {
       importHelper.addImports('./_eval', 'fakeEval');
+      importHelper.addTypeImports('../../core', 'FakerCore');
       break;
     }
     case 'image': {
       importHelper.addTypeImports('../person', 'SexType');
+      importHelper.removeImports('../../faker', 'Faker');
+      break;
+    }
+    case 'location': {
       importHelper.removeImports('../../faker', 'Faker');
       break;
     }

--- a/scripts/module-tree/generate-module-tree.ts
+++ b/scripts/module-tree/generate-module-tree.ts
@@ -80,11 +80,7 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
       .map((c) => c.getText());
 
     const importHelper = new ImportHelper();
-    importHelper.addImports(
-      '../../internal/module-base',
-      'SimpleModuleBase',
-      'ModuleBase'
-    );
+    importHelper.addImports('../../internal/module-base', 'ModuleBase');
     importHelper.addTypeImports('../../faker', 'Faker');
     importHelper.addTypeImports(
       '../../utils/types',

--- a/src/faker.ts
+++ b/src/faker.ts
@@ -57,31 +57,31 @@ import { SimpleFaker } from './simple-faker';
  * customFaker.music.genre(); // throws Error as this data is not available in `es`
  */
 export class Faker extends SimpleFaker {
-  readonly airline: AirlineModule = new AirlineModule(this);
-  readonly animal: AnimalModule = new AnimalModule(this);
-  readonly book: BookModule = new BookModule(this);
-  readonly color: ColorModule = new ColorModule(this);
-  readonly commerce: CommerceModule = new CommerceModule(this);
-  readonly company: CompanyModule = new CompanyModule(this);
-  readonly database: DatabaseModule = new DatabaseModule(this);
-  readonly date: DateModule = new DateModule(this);
-  readonly finance = new FinanceModule(this);
-  readonly food = new FoodModule(this);
-  readonly git: GitModule = new GitModule(this);
-  readonly hacker: HackerModule = new HackerModule(this);
-  readonly helpers: HelpersModule = new HelpersModule(this);
-  readonly image: ImageModule = new ImageModule(this);
-  readonly internet: InternetModule = new InternetModule(this);
-  readonly location: LocationModule = new LocationModule(this);
-  readonly lorem: LoremModule = new LoremModule(this);
-  readonly medical: MedicalModule = new MedicalModule(this);
-  readonly music: MusicModule = new MusicModule(this);
-  readonly person: PersonModule = new PersonModule(this);
-  readonly phone: PhoneModule = new PhoneModule(this);
-  readonly science: ScienceModule = new ScienceModule(this);
-  readonly system: SystemModule = new SystemModule(this);
-  readonly vehicle: VehicleModule = new VehicleModule(this);
-  readonly word: WordModule = new WordModule(this);
+  readonly airline: AirlineModule;
+  readonly animal: AnimalModule;
+  readonly book: BookModule;
+  readonly color: ColorModule;
+  readonly commerce: CommerceModule;
+  readonly company: CompanyModule;
+  readonly database: DatabaseModule;
+  readonly date: DateModule;
+  readonly finance: FinanceModule;
+  readonly food: FoodModule;
+  readonly git: GitModule;
+  readonly hacker: HackerModule;
+  readonly helpers: HelpersModule;
+  readonly image: ImageModule;
+  readonly internet: InternetModule;
+  readonly location: LocationModule;
+  readonly lorem: LoremModule;
+  readonly medical: MedicalModule;
+  readonly music: MusicModule;
+  readonly person: PersonModule;
+  readonly phone: PhoneModule;
+  readonly science: ScienceModule;
+  readonly system: SystemModule;
+  readonly vehicle: VehicleModule;
+  readonly word: WordModule;
 
   get rawDefinitions(): LocaleDefinition {
     return this.fakerCore.locale.raw;
@@ -139,6 +139,32 @@ export class Faker extends SimpleFaker {
         'The locale option must contain at least one locale definition.'
       );
     }
+
+    this.airline = new AirlineModule(this.fakerCore);
+    this.animal = new AnimalModule(this.fakerCore);
+    this.book = new BookModule(this.fakerCore);
+    this.color = new ColorModule(this.fakerCore);
+    this.commerce = new CommerceModule(this.fakerCore);
+    this.company = new CompanyModule(this.fakerCore);
+    this.database = new DatabaseModule(this.fakerCore);
+    this.date = new DateModule(this.fakerCore);
+    this.finance = new FinanceModule(this.fakerCore);
+    this.food = new FoodModule(this.fakerCore);
+    this.git = new GitModule(this.fakerCore);
+    this.hacker = new HackerModule(this.fakerCore);
+    this.helpers = new HelpersModule(this.fakerCore, this);
+    this.image = new ImageModule(this.fakerCore);
+    this.internet = new InternetModule(this.fakerCore);
+    this.location = new LocationModule(this.fakerCore);
+    this.lorem = new LoremModule(this.fakerCore);
+    this.medical = new MedicalModule(this.fakerCore);
+    this.music = new MusicModule(this.fakerCore);
+    this.person = new PersonModule(this.fakerCore);
+    this.phone = new PhoneModule(this.fakerCore);
+    this.science = new ScienceModule(this.fakerCore);
+    this.system = new SystemModule(this.fakerCore);
+    this.vehicle = new VehicleModule(this.fakerCore);
+    this.word = new WordModule(this.fakerCore);
   }
 
   /**

--- a/src/internal/module-base.ts
+++ b/src/internal/module-base.ts
@@ -1,21 +1,11 @@
-import type { Faker } from '../faker';
-import type { SimpleFaker } from '../simple-faker';
+import type { FakerCore } from '../core';
 import { bindThisToMemberFunctions } from './bind-this-to-member-functions';
 
 /**
- * Base class for all modules that use a `SimpleFaker` instance.
+ * Base class for all modules.
  */
-export abstract class SimpleModuleBase {
-  constructor(protected readonly faker: SimpleFaker) {
+export abstract class ModuleBase {
+  constructor(protected readonly fakerCore: FakerCore) {
     bindThisToMemberFunctions(this);
-  }
-}
-
-/**
- * Base class for all modules that use a `Faker` instance.
- */
-export abstract class ModuleBase extends SimpleModuleBase {
-  constructor(protected readonly faker: Faker) {
-    super(faker);
   }
 }

--- a/src/modules/airline/module.ts
+++ b/src/modules/airline/module.ts
@@ -44,7 +44,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airport(): Airport {
-    return airlineAirport(this.faker.fakerCore);
+    return airlineAirport(this.fakerCore);
   }
 
   /**
@@ -56,7 +56,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airline(): Airline {
-    return airlineAirline(this.faker.fakerCore);
+    return airlineAirline(this.fakerCore);
   }
 
   /**
@@ -68,7 +68,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   airplane(): Airplane {
-    return airlineAirplane(this.faker.fakerCore);
+    return airlineAirplane(this.fakerCore);
   }
 
   /**
@@ -104,7 +104,7 @@ export class AirlineModule extends ModuleBase {
       allowVisuallySimilarCharacters?: boolean;
     } = {}
   ): string {
-    return airlineRecordLocator(this.faker.fakerCore, options);
+    return airlineRecordLocator(this.fakerCore, options);
   }
 
   /**
@@ -130,7 +130,7 @@ export class AirlineModule extends ModuleBase {
       aircraftType?: AircraftType;
     } = {}
   ): string {
-    return airlineSeat(this.faker.fakerCore, options);
+    return airlineSeat(this.fakerCore, options);
   }
 
   /**
@@ -142,7 +142,7 @@ export class AirlineModule extends ModuleBase {
    * @since 8.0.0
    */
   aircraftType(): AircraftType {
-    return airlineAircraftType(this.faker.fakerCore);
+    return airlineAircraftType(this.fakerCore);
   }
 
   /**
@@ -186,6 +186,6 @@ export class AirlineModule extends ModuleBase {
       addLeadingZeros?: boolean;
     } = {}
   ): string {
-    return airlineFlightNumber(this.faker.fakerCore, options);
+    return airlineFlightNumber(this.fakerCore, options);
   }
 }

--- a/src/modules/animal/module.ts
+++ b/src/modules/animal/module.ts
@@ -42,7 +42,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   dog(): string {
-    return animalDog(this.faker.fakerCore);
+    return animalDog(this.fakerCore);
   }
 
   /**
@@ -54,7 +54,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   cat(): string {
-    return animalCat(this.faker.fakerCore);
+    return animalCat(this.fakerCore);
   }
 
   /**
@@ -66,7 +66,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   snake(): string {
-    return animalSnake(this.faker.fakerCore);
+    return animalSnake(this.fakerCore);
   }
 
   /**
@@ -78,7 +78,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   bear(): string {
-    return animalBear(this.faker.fakerCore);
+    return animalBear(this.fakerCore);
   }
 
   /**
@@ -90,7 +90,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   lion(): string {
-    return animalLion(this.faker.fakerCore);
+    return animalLion(this.fakerCore);
   }
 
   /**
@@ -102,7 +102,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   cetacean(): string {
-    return animalCetacean(this.faker.fakerCore);
+    return animalCetacean(this.fakerCore);
   }
 
   /**
@@ -114,7 +114,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   horse(): string {
-    return animalHorse(this.faker.fakerCore);
+    return animalHorse(this.fakerCore);
   }
 
   /**
@@ -126,7 +126,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   bird(): string {
-    return animalBird(this.faker.fakerCore);
+    return animalBird(this.fakerCore);
   }
 
   /**
@@ -138,7 +138,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   cow(): string {
-    return animalCow(this.faker.fakerCore);
+    return animalCow(this.fakerCore);
   }
 
   /**
@@ -150,7 +150,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   fish(): string {
-    return animalFish(this.faker.fakerCore);
+    return animalFish(this.fakerCore);
   }
 
   /**
@@ -162,7 +162,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   crocodilia(): string {
-    return animalCrocodilia(this.faker.fakerCore);
+    return animalCrocodilia(this.fakerCore);
   }
 
   /**
@@ -174,7 +174,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   insect(): string {
-    return animalInsect(this.faker.fakerCore);
+    return animalInsect(this.fakerCore);
   }
 
   /**
@@ -186,7 +186,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   rabbit(): string {
-    return animalRabbit(this.faker.fakerCore);
+    return animalRabbit(this.fakerCore);
   }
 
   /**
@@ -198,7 +198,7 @@ export class AnimalModule extends ModuleBase {
    * @since 7.4.0
    */
   rodent(): string {
-    return animalRodent(this.faker.fakerCore);
+    return animalRodent(this.fakerCore);
   }
 
   /**
@@ -210,7 +210,7 @@ export class AnimalModule extends ModuleBase {
    * @since 5.5.0
    */
   type(): string {
-    return animalType(this.faker.fakerCore);
+    return animalType(this.fakerCore);
   }
 
   /**
@@ -222,6 +222,6 @@ export class AnimalModule extends ModuleBase {
    * @since 9.2.0
    */
   petName(): string {
-    return animalPetName(this.faker.fakerCore);
+    return animalPetName(this.fakerCore);
   }
 }

--- a/src/modules/book/module.ts
+++ b/src/modules/book/module.ts
@@ -37,7 +37,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   author(): string {
-    return bookAuthor(this.faker.fakerCore);
+    return bookAuthor(this.fakerCore);
   }
 
   /**
@@ -49,7 +49,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   format(): string {
-    return bookFormat(this.faker.fakerCore);
+    return bookFormat(this.fakerCore);
   }
 
   /**
@@ -61,7 +61,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   genre(): string {
-    return bookGenre(this.faker.fakerCore);
+    return bookGenre(this.fakerCore);
   }
 
   /**
@@ -73,7 +73,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   publisher(): string {
-    return bookPublisher(this.faker.fakerCore);
+    return bookPublisher(this.fakerCore);
   }
 
   /**
@@ -85,7 +85,7 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   series(): string {
-    return bookSeries(this.faker.fakerCore);
+    return bookSeries(this.fakerCore);
   }
 
   /**
@@ -97,6 +97,6 @@ export class BookModule extends ModuleBase {
    * @since 9.1.0
    */
   title(): string {
-    return bookTitle(this.faker.fakerCore);
+    return bookTitle(this.fakerCore);
   }
 }

--- a/src/modules/color/module.ts
+++ b/src/modules/color/module.ts
@@ -43,7 +43,7 @@ export class ColorModule extends ModuleBase {
    * @since 7.0.0
    */
   human(): string {
-    return colorHuman(this.faker.fakerCore);
+    return colorHuman(this.fakerCore);
   }
 
   /**
@@ -56,7 +56,7 @@ export class ColorModule extends ModuleBase {
    * @since 7.0.0
    */
   space(): string {
-    return colorSpace(this.faker.fakerCore);
+    return colorSpace(this.fakerCore);
   }
 
   /**
@@ -68,7 +68,7 @@ export class ColorModule extends ModuleBase {
    * @since 7.0.0
    */
   cssSupportedFunction(): CssFunctionType {
-    return colorCssSupportedFunction(this.faker.fakerCore);
+    return colorCssSupportedFunction(this.fakerCore);
   }
 
   /**
@@ -80,7 +80,7 @@ export class ColorModule extends ModuleBase {
    * @since 7.0.0
    */
   cssSupportedSpace(): CssSpaceType {
-    return colorCssSupportedSpace(this.faker.fakerCore);
+    return colorCssSupportedSpace(this.fakerCore);
   }
 
   /**
@@ -228,7 +228,7 @@ export class ColorModule extends ModuleBase {
       includeAlpha?: boolean;
     } = {}
   ): string | number[] {
-    return colorRgb(this.faker.fakerCore, options);
+    return colorRgb(this.fakerCore, options);
   }
 
   /**
@@ -304,7 +304,7 @@ export class ColorModule extends ModuleBase {
     format?: ColorFormat;
   }): string | number[];
   cmyk(options: { format?: ColorFormat } = {}): string | number[] {
-    return colorCmyk(this.faker.fakerCore, options);
+    return colorCmyk(this.fakerCore, options);
   }
 
   /**
@@ -412,7 +412,7 @@ export class ColorModule extends ModuleBase {
       includeAlpha?: boolean;
     } = {}
   ): string | number[] {
-    return colorHsl(this.faker.fakerCore, options);
+    return colorHsl(this.fakerCore, options);
   }
 
   /**
@@ -511,7 +511,7 @@ export class ColorModule extends ModuleBase {
       format?: ColorFormat;
     } = {}
   ): string | number[] {
-    return colorHwb(this.faker.fakerCore, options);
+    return colorHwb(this.fakerCore, options);
   }
 
   /**
@@ -587,7 +587,7 @@ export class ColorModule extends ModuleBase {
     format?: ColorFormat;
   }): string | number[];
   lab(options: { format?: ColorFormat } = {}): string | number[] {
-    return colorLab(this.faker.fakerCore, options);
+    return colorLab(this.fakerCore, options);
   }
 
   /**
@@ -675,7 +675,7 @@ export class ColorModule extends ModuleBase {
     format?: ColorFormat;
   }): string | number[];
   lch(options: { format?: ColorFormat } = {}): string | number[] {
-    return colorLch(this.faker.fakerCore, options);
+    return colorLch(this.fakerCore, options);
   }
 
   /**
@@ -777,6 +777,6 @@ export class ColorModule extends ModuleBase {
       space?: CssSpaceType;
     } = {}
   ): string | number[] {
-    return colorColorByCSSColorSpace(this.faker.fakerCore, options);
+    return colorColorByCSSColorSpace(this.fakerCore, options);
   }
 }

--- a/src/modules/commerce/module.ts
+++ b/src/modules/commerce/module.ts
@@ -37,7 +37,7 @@ export class CommerceModule extends ModuleBase {
    * @since 3.0.0
    */
   department(): string {
-    return commerceDepartment(this.faker.fakerCore);
+    return commerceDepartment(this.fakerCore);
   }
 
   /**
@@ -49,7 +49,7 @@ export class CommerceModule extends ModuleBase {
    * @since 3.0.0
    */
   productName(): string {
-    return commerceProductName(this.faker.fakerCore);
+    return commerceProductName(this.fakerCore);
   }
 
   /**
@@ -105,7 +105,7 @@ export class CommerceModule extends ModuleBase {
       symbol?: string;
     } = {}
   ): string {
-    return commercePrice(this.faker.fakerCore, options);
+    return commercePrice(this.fakerCore, options);
   }
 
   /**
@@ -117,7 +117,7 @@ export class CommerceModule extends ModuleBase {
    * @since 3.0.0
    */
   productAdjective(): string {
-    return commerceProductAdjective(this.faker.fakerCore);
+    return commerceProductAdjective(this.fakerCore);
   }
 
   /**
@@ -129,7 +129,7 @@ export class CommerceModule extends ModuleBase {
    * @since 3.0.0
    */
   productMaterial(): string {
-    return commerceProductMaterial(this.faker.fakerCore);
+    return commerceProductMaterial(this.fakerCore);
   }
 
   /**
@@ -141,7 +141,7 @@ export class CommerceModule extends ModuleBase {
    * @since 3.0.0
    */
   product(): string {
-    return commerceProduct(this.faker.fakerCore);
+    return commerceProduct(this.fakerCore);
   }
 
   /**
@@ -153,7 +153,7 @@ export class CommerceModule extends ModuleBase {
    * @since 5.0.0
    */
   productDescription(): string {
-    return commerceProductDescription(this.faker.fakerCore);
+    return commerceProductDescription(this.fakerCore);
   }
 
   /**
@@ -196,7 +196,7 @@ export class CommerceModule extends ModuleBase {
           separator?: string;
         } = {}
   ): string {
-    return commerceIsbn(this.faker.fakerCore, options);
+    return commerceIsbn(this.fakerCore, options);
   }
 
   /**
@@ -226,6 +226,6 @@ export class CommerceModule extends ModuleBase {
       prefix?: string;
     } = {}
   ): string {
-    return commerceUpc(this.faker.fakerCore, options);
+    return commerceUpc(this.fakerCore, options);
   }
 }

--- a/src/modules/company/module.ts
+++ b/src/modules/company/module.ts
@@ -38,7 +38,7 @@ export class CompanyModule extends ModuleBase {
    * @since 7.4.0
    */
   name(): string {
-    return companyName(this.faker.fakerCore);
+    return companyName(this.fakerCore);
   }
 
   /**
@@ -50,7 +50,7 @@ export class CompanyModule extends ModuleBase {
    * @since 2.0.1
    */
   catchPhrase(): string {
-    return companyCatchPhrase(this.faker.fakerCore);
+    return companyCatchPhrase(this.fakerCore);
   }
 
   /**
@@ -62,7 +62,7 @@ export class CompanyModule extends ModuleBase {
    * @since 8.0.0
    */
   buzzPhrase(): string {
-    return companyBuzzPhrase(this.faker.fakerCore);
+    return companyBuzzPhrase(this.fakerCore);
   }
 
   /**
@@ -74,7 +74,7 @@ export class CompanyModule extends ModuleBase {
    * @since 2.0.1
    */
   catchPhraseAdjective(): string {
-    return companyCatchPhraseAdjective(this.faker.fakerCore);
+    return companyCatchPhraseAdjective(this.fakerCore);
   }
 
   /**
@@ -86,7 +86,7 @@ export class CompanyModule extends ModuleBase {
    * @since 2.0.1
    */
   catchPhraseDescriptor(): string {
-    return companyCatchPhraseDescriptor(this.faker.fakerCore);
+    return companyCatchPhraseDescriptor(this.fakerCore);
   }
 
   /**
@@ -98,7 +98,7 @@ export class CompanyModule extends ModuleBase {
    * @since 2.0.1
    */
   catchPhraseNoun(): string {
-    return companyCatchPhraseNoun(this.faker.fakerCore);
+    return companyCatchPhraseNoun(this.fakerCore);
   }
 
   /**
@@ -110,7 +110,7 @@ export class CompanyModule extends ModuleBase {
    * @since 8.0.0
    */
   buzzAdjective(): string {
-    return companyBuzzAdjective(this.faker.fakerCore);
+    return companyBuzzAdjective(this.fakerCore);
   }
 
   /**
@@ -122,7 +122,7 @@ export class CompanyModule extends ModuleBase {
    * @since 8.0.0
    */
   buzzVerb(): string {
-    return companyBuzzVerb(this.faker.fakerCore);
+    return companyBuzzVerb(this.fakerCore);
   }
 
   /**
@@ -134,6 +134,6 @@ export class CompanyModule extends ModuleBase {
    * @since 8.0.0
    */
   buzzNoun(): string {
-    return companyBuzzNoun(this.faker.fakerCore);
+    return companyBuzzNoun(this.fakerCore);
   }
 }

--- a/src/modules/database/module.ts
+++ b/src/modules/database/module.ts
@@ -29,7 +29,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   column(): string {
-    return databaseColumn(this.faker.fakerCore);
+    return databaseColumn(this.fakerCore);
   }
 
   /**
@@ -41,7 +41,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   type(): string {
-    return databaseType(this.faker.fakerCore);
+    return databaseType(this.fakerCore);
   }
 
   /**
@@ -53,7 +53,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   collation(): string {
-    return databaseCollation(this.faker.fakerCore);
+    return databaseCollation(this.fakerCore);
   }
 
   /**
@@ -65,7 +65,7 @@ export class DatabaseModule extends ModuleBase {
    * @since 4.0.0
    */
   engine(): string {
-    return databaseEngine(this.faker.fakerCore);
+    return databaseEngine(this.fakerCore);
   }
 
   /**
@@ -77,6 +77,6 @@ export class DatabaseModule extends ModuleBase {
    * @since 6.2.0
    */
   mongodbObjectId(): string {
-    return databaseMongodbObjectId(this.faker.fakerCore);
+    return databaseMongodbObjectId(this.fakerCore);
   }
 }

--- a/src/modules/datatype/module.ts
+++ b/src/modules/datatype/module.ts
@@ -44,6 +44,6 @@ export class DatatypeModule extends ModuleBase {
           probability?: number;
         } = {}
   ): boolean {
-    return datatypeBoolean(this.faker.fakerCore, options);
+    return datatypeBoolean(this.fakerCore, options);
   }
 }

--- a/src/modules/datatype/module.ts
+++ b/src/modules/datatype/module.ts
@@ -1,4 +1,4 @@
-import { SimpleModuleBase } from '../../internal/module-base';
+import { ModuleBase } from '../../internal/module-base';
 import { boolean as datatypeBoolean } from './boolean';
 
 /**
@@ -8,7 +8,7 @@ import { boolean as datatypeBoolean } from './boolean';
  *
  * For a simple random true or false value, use [`boolean()`](https://fakerjs.dev/api/datatype.html#boolean).
  */
-export class DatatypeModule extends SimpleModuleBase {
+export class DatatypeModule extends ModuleBase {
   /*
    * The class body is automatically generated.
    * Run 'pnpm run generate:module-tree datatype' to update the methods from their respective files.

--- a/src/modules/date/module.ts
+++ b/src/modules/date/module.ts
@@ -1,4 +1,3 @@
-import type { Faker } from '../../faker';
 import { ModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
 import { anytime as dateAnytime } from './anytime';
@@ -489,10 +488,6 @@ export class DateModule extends SimpleDateModule {
    * The class body is automatically generated.
    * Run 'pnpm run generate:module-tree date' to update the methods from their respective files.
    */
-
-  constructor(protected readonly faker: Faker) {
-    super(faker);
-  }
 
   /**
    * Returns a random name of a month.

--- a/src/modules/date/module.ts
+++ b/src/modules/date/module.ts
@@ -1,5 +1,5 @@
 import type { Faker } from '../../faker';
-import { SimpleModuleBase } from '../../internal/module-base';
+import { ModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
 import { anytime as dateAnytime } from './anytime';
 import { between as dateBetween } from './between';
@@ -16,7 +16,7 @@ import { weekday as dateWeekday } from './weekday';
 /**
  * Module to generate dates (without methods requiring localized data).
  */
-export class SimpleDateModule extends SimpleModuleBase {
+export class SimpleDateModule extends ModuleBase {
   /*
    * The class body is automatically generated.
    * Run 'pnpm run generate:module-tree date' to update the methods from their respective files.

--- a/src/modules/date/module.ts
+++ b/src/modules/date/module.ts
@@ -47,7 +47,7 @@ export class SimpleDateModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    return dateAnytime(this.faker.fakerCore, options);
+    return dateAnytime(this.fakerCore, options);
   }
 
   /**
@@ -86,7 +86,7 @@ export class SimpleDateModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    return datePast(this.faker.fakerCore, options);
+    return datePast(this.fakerCore, options);
   }
 
   /**
@@ -125,7 +125,7 @@ export class SimpleDateModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    return dateFuture(this.faker.fakerCore, options);
+    return dateFuture(this.fakerCore, options);
   }
 
   /**
@@ -153,7 +153,7 @@ export class SimpleDateModule extends ModuleBase {
      */
     to: string | Date | number;
   }): Date {
-    return dateBetween(this.faker.fakerCore, options);
+    return dateBetween(this.fakerCore, options);
   }
 
   /**
@@ -201,7 +201,7 @@ export class SimpleDateModule extends ModuleBase {
      */
     count?: NumberOrRange;
   }): Date[] {
-    return dateBetweens(this.faker.fakerCore, options);
+    return dateBetweens(this.fakerCore, options);
   }
 
   /**
@@ -255,7 +255,7 @@ export class SimpleDateModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    return dateRecent(this.faker.fakerCore, options);
+    return dateRecent(this.fakerCore, options);
   }
 
   /**
@@ -309,7 +309,7 @@ export class SimpleDateModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    return dateSoon(this.faker.fakerCore, options);
+    return dateSoon(this.fakerCore, options);
   }
 
   /**
@@ -454,7 +454,7 @@ export class SimpleDateModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): Date {
-    return dateBirthdate(this.faker.fakerCore, options);
+    return dateBirthdate(this.fakerCore, options);
   }
 }
 
@@ -529,7 +529,7 @@ export class DateModule extends SimpleDateModule {
       context?: boolean;
     } = {}
   ): string {
-    return dateMonth(this.faker.fakerCore, options);
+    return dateMonth(this.fakerCore, options);
   }
 
   /**
@@ -567,7 +567,7 @@ export class DateModule extends SimpleDateModule {
       context?: boolean;
     } = {}
   ): string {
-    return dateWeekday(this.faker.fakerCore, options);
+    return dateWeekday(this.fakerCore, options);
   }
 
   /**
@@ -584,6 +584,6 @@ export class DateModule extends SimpleDateModule {
    * @since 9.0.0
    */
   timeZone(): string {
-    return dateTimeZone(this.faker.fakerCore);
+    return dateTimeZone(this.fakerCore);
   }
 }

--- a/src/modules/finance/module.ts
+++ b/src/modules/finance/module.ts
@@ -134,7 +134,7 @@ export class FinanceModule extends ModuleBase {
           length?: number;
         } = {}
   ): string {
-    return financeAccountNumber(this.faker.fakerCore, options);
+    return financeAccountNumber(this.fakerCore, options);
   }
 
   /**
@@ -146,7 +146,7 @@ export class FinanceModule extends ModuleBase {
    * @since 2.0.1
    */
   accountName(): string {
-    return financeAccountName(this.faker.fakerCore);
+    return financeAccountName(this.fakerCore);
   }
 
   /**
@@ -158,7 +158,7 @@ export class FinanceModule extends ModuleBase {
    * @since 5.0.0
    */
   routingNumber(): string {
-    return financeRoutingNumber(this.faker.fakerCore);
+    return financeRoutingNumber(this.fakerCore);
   }
 
   /**
@@ -216,7 +216,7 @@ export class FinanceModule extends ModuleBase {
       autoFormat?: boolean;
     } = {}
   ): string {
-    return financeAmount(this.faker.fakerCore, options);
+    return financeAmount(this.fakerCore, options);
   }
 
   /**
@@ -228,7 +228,7 @@ export class FinanceModule extends ModuleBase {
    * @since 2.0.1
    */
   transactionType(): string {
-    return financeTransactionType(this.faker.fakerCore);
+    return financeTransactionType(this.fakerCore);
   }
 
   /**
@@ -245,7 +245,7 @@ export class FinanceModule extends ModuleBase {
    * @since 8.0.0
    */
   currency(): Currency {
-    return financeCurrency(this.faker.fakerCore);
+    return financeCurrency(this.fakerCore);
   }
 
   /**
@@ -258,7 +258,7 @@ export class FinanceModule extends ModuleBase {
    * @since 2.0.1
    */
   currencyCode(): string {
-    return financeCurrencyCode(this.faker.fakerCore);
+    return financeCurrencyCode(this.fakerCore);
   }
 
   /**
@@ -270,7 +270,7 @@ export class FinanceModule extends ModuleBase {
    * @since 2.0.1
    */
   currencyName(): string {
-    return financeCurrencyName(this.faker.fakerCore);
+    return financeCurrencyName(this.fakerCore);
   }
 
   /**
@@ -282,7 +282,7 @@ export class FinanceModule extends ModuleBase {
    * @since 2.0.1
    */
   currencySymbol(): string {
-    return financeCurrencySymbol(this.faker.fakerCore);
+    return financeCurrencySymbol(this.fakerCore);
   }
 
   /**
@@ -295,7 +295,7 @@ export class FinanceModule extends ModuleBase {
    * @since 9.6.0
    */
   currencyNumericCode(): string {
-    return financeCurrencyNumericCode(this.faker.fakerCore);
+    return financeCurrencyNumericCode(this.fakerCore);
   }
 
   /**
@@ -328,7 +328,7 @@ export class FinanceModule extends ModuleBase {
       network?: BitcoinNetworkType;
     } = {}
   ): string {
-    return financeBitcoinAddress(this.faker.fakerCore, options);
+    return financeBitcoinAddress(this.fakerCore, options);
   }
 
   /**
@@ -340,7 +340,7 @@ export class FinanceModule extends ModuleBase {
    * @since 5.0.0
    */
   litecoinAddress(): string {
-    return financeLitecoinAddress(this.faker.fakerCore);
+    return financeLitecoinAddress(this.fakerCore);
   }
 
   /**
@@ -429,7 +429,7 @@ export class FinanceModule extends ModuleBase {
           issuer?: string;
         } = {}
   ): string {
-    return financeCreditCardNumber(this.faker.fakerCore, options);
+    return financeCreditCardNumber(this.fakerCore, options);
   }
 
   /**
@@ -441,7 +441,7 @@ export class FinanceModule extends ModuleBase {
    * @since 5.0.0
    */
   creditCardCVV(): string {
-    return financeCreditCardCVV(this.faker.fakerCore);
+    return financeCreditCardCVV(this.fakerCore);
   }
 
   /**
@@ -453,7 +453,7 @@ export class FinanceModule extends ModuleBase {
    * @since 6.3.0
    */
   creditCardIssuer(): string {
-    return financeCreditCardIssuer(this.faker.fakerCore);
+    return financeCreditCardIssuer(this.fakerCore);
   }
 
   /**
@@ -554,7 +554,7 @@ export class FinanceModule extends ModuleBase {
           length?: number;
         } = {}
   ): string {
-    return financePin(this.faker.fakerCore, options);
+    return financePin(this.fakerCore, options);
   }
 
   /**
@@ -568,7 +568,7 @@ export class FinanceModule extends ModuleBase {
    * @since 5.0.0
    */
   ethereumAddress(): string {
-    return financeEthereumAddress(this.faker.fakerCore);
+    return financeEthereumAddress(this.fakerCore);
   }
 
   /**
@@ -604,7 +604,7 @@ export class FinanceModule extends ModuleBase {
       countryCode?: string;
     } = {}
   ): string {
-    return financeIban(this.faker.fakerCore, options);
+    return financeIban(this.fakerCore, options);
   }
 
   /**
@@ -630,7 +630,7 @@ export class FinanceModule extends ModuleBase {
       includeBranchCode?: boolean;
     } = {}
   ): string {
-    return financeBic(this.faker.fakerCore, options);
+    return financeBic(this.fakerCore, options);
   }
 
   /**
@@ -643,6 +643,6 @@ export class FinanceModule extends ModuleBase {
    * @since 5.1.0
    */
   transactionDescription(): string {
-    return financeTransactionDescription(this.faker.fakerCore);
+    return financeTransactionDescription(this.fakerCore);
   }
 }

--- a/src/modules/food/module.ts
+++ b/src/modules/food/module.ts
@@ -33,7 +33,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   adjective(): string {
-    return foodAdjective(this.faker.fakerCore);
+    return foodAdjective(this.fakerCore);
   }
 
   /**
@@ -45,7 +45,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   description(): string {
-    return foodDescription(this.faker.fakerCore);
+    return foodDescription(this.fakerCore);
   }
 
   /**
@@ -57,7 +57,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   dish(): string {
-    return foodDish(this.faker.fakerCore);
+    return foodDish(this.fakerCore);
   }
 
   /**
@@ -69,7 +69,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   ethnicCategory(): string {
-    return foodEthnicCategory(this.faker.fakerCore);
+    return foodEthnicCategory(this.fakerCore);
   }
 
   /**
@@ -81,7 +81,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   fruit(): string {
-    return foodFruit(this.faker.fakerCore);
+    return foodFruit(this.fakerCore);
   }
 
   /**
@@ -93,7 +93,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   ingredient(): string {
-    return foodIngredient(this.faker.fakerCore);
+    return foodIngredient(this.fakerCore);
   }
 
   /**
@@ -105,7 +105,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   meat(): string {
-    return foodMeat(this.faker.fakerCore);
+    return foodMeat(this.fakerCore);
   }
 
   /**
@@ -117,7 +117,7 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   spice(): string {
-    return foodSpice(this.faker.fakerCore);
+    return foodSpice(this.fakerCore);
   }
 
   /**
@@ -129,6 +129,6 @@ export class FoodModule extends ModuleBase {
    * @since 9.0.0
    */
   vegetable(): string {
-    return foodVegetable(this.faker.fakerCore);
+    return foodVegetable(this.fakerCore);
   }
 }

--- a/src/modules/git/module.ts
+++ b/src/modules/git/module.ts
@@ -27,7 +27,7 @@ export class GitModule extends ModuleBase {
    * @since 5.0.0
    */
   branch(): string {
-    return gitBranch(this.faker.fakerCore);
+    return gitBranch(this.fakerCore);
   }
 
   /**
@@ -75,7 +75,7 @@ export class GitModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): string {
-    return gitCommitEntry(this.faker.fakerCore, options);
+    return gitCommitEntry(this.fakerCore, options);
   }
 
   /**
@@ -87,7 +87,7 @@ export class GitModule extends ModuleBase {
    * @since 5.0.0
    */
   commitMessage(): string {
-    return gitCommitMessage(this.faker.fakerCore);
+    return gitCommitMessage(this.fakerCore);
   }
 
   /**
@@ -112,7 +112,7 @@ export class GitModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): string {
-    return gitCommitDate(this.faker.fakerCore, options);
+    return gitCommitDate(this.fakerCore, options);
   }
 
   /**
@@ -146,6 +146,6 @@ export class GitModule extends ModuleBase {
       length?: number;
     } = {}
   ): string {
-    return gitCommitSha(this.faker.fakerCore, options);
+    return gitCommitSha(this.fakerCore, options);
   }
 }

--- a/src/modules/hacker/module.ts
+++ b/src/modules/hacker/module.ts
@@ -36,7 +36,7 @@ export class HackerModule extends ModuleBase {
    * @since 2.0.1
    */
   abbreviation(): string {
-    return hackerAbbreviation(this.faker.fakerCore);
+    return hackerAbbreviation(this.fakerCore);
   }
 
   /**
@@ -48,7 +48,7 @@ export class HackerModule extends ModuleBase {
    * @since 2.0.1
    */
   adjective(): string {
-    return hackerAdjective(this.faker.fakerCore);
+    return hackerAdjective(this.fakerCore);
   }
 
   /**
@@ -60,7 +60,7 @@ export class HackerModule extends ModuleBase {
    * @since 2.0.1
    */
   noun(): string {
-    return hackerNoun(this.faker.fakerCore);
+    return hackerNoun(this.fakerCore);
   }
 
   /**
@@ -72,7 +72,7 @@ export class HackerModule extends ModuleBase {
    * @since 2.0.1
    */
   verb(): string {
-    return hackerVerb(this.faker.fakerCore);
+    return hackerVerb(this.fakerCore);
   }
 
   /**
@@ -84,7 +84,7 @@ export class HackerModule extends ModuleBase {
    * @since 2.0.1
    */
   ingverb(): string {
-    return hackerIngverb(this.faker.fakerCore);
+    return hackerIngverb(this.fakerCore);
   }
 
   /**
@@ -97,6 +97,6 @@ export class HackerModule extends ModuleBase {
    * @since 2.0.1
    */
   phrase(): string {
-    return hackerPhrase(this.faker.fakerCore);
+    return hackerPhrase(this.fakerCore);
   }
 }

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -43,7 +43,7 @@ export class SimpleHelpersModule extends ModuleBase {
    * @since 2.0.1
    */
   slugify(string: string = ''): string {
-    return helpersSlugify(this.faker.fakerCore, string);
+    return helpersSlugify(this.fakerCore, string);
   }
 
   /**
@@ -65,7 +65,7 @@ export class SimpleHelpersModule extends ModuleBase {
    * @since 3.0.0
    */
   replaceSymbols(string: string = ''): string {
-    return helpersReplaceSymbols(this.faker.fakerCore, string);
+    return helpersReplaceSymbols(this.fakerCore, string);
   }
 
   /**
@@ -87,11 +87,7 @@ export class SimpleHelpersModule extends ModuleBase {
     string: string = '6453-####-####-####-###L',
     symbol: string = '#'
   ): string {
-    return helpersReplaceCreditCardSymbols(
-      this.faker.fakerCore,
-      string,
-      symbol
-    );
+    return helpersReplaceCreditCardSymbols(this.fakerCore, string, symbol);
   }
 
   /**
@@ -143,7 +139,7 @@ export class SimpleHelpersModule extends ModuleBase {
    * @since 8.0.0
    */
   fromRegExp(pattern: string | RegExp): string {
-    return helpersFromRegExp(this.faker.fakerCore, pattern);
+    return helpersFromRegExp(this.fakerCore, pattern);
   }
 
   /**
@@ -225,7 +221,7 @@ export class SimpleHelpersModule extends ModuleBase {
     }
   ): T[];
   shuffle<const T>(list: T[], options: { inplace?: boolean } = {}): T[] {
-    return helpersShuffle(this.faker.fakerCore, list, options);
+    return helpersShuffle(this.fakerCore, list, options);
   }
 
   /**
@@ -254,7 +250,7 @@ export class SimpleHelpersModule extends ModuleBase {
     source: ReadonlyArray<T> | (() => T),
     length: number
   ): T[] {
-    return helpersUniqueArray(this.faker.fakerCore, source, length);
+    return helpersUniqueArray(this.fakerCore, source, length);
   }
 
   /**
@@ -277,7 +273,7 @@ export class SimpleHelpersModule extends ModuleBase {
     text: string | undefined,
     data: Record<string, string | Parameters<string['replace']>[1]>
   ): string {
-    return helpersMustache(this.faker.fakerCore, text, data);
+    return helpersMustache(this.fakerCore, text, data);
   }
 
   /**
@@ -307,7 +303,7 @@ export class SimpleHelpersModule extends ModuleBase {
       probability?: number;
     } = {}
   ): TResult | undefined {
-    return helpersMaybe(this.faker.fakerCore, callback, options);
+    return helpersMaybe(this.fakerCore, callback, options);
   }
 
   /**
@@ -325,7 +321,7 @@ export class SimpleHelpersModule extends ModuleBase {
    * @since 6.3.0
    */
   objectKey<const T extends Record<string, unknown>>(object: T): keyof T {
-    return helpersObjectKey(this.faker.fakerCore, object);
+    return helpersObjectKey(this.fakerCore, object);
   }
 
   /**
@@ -343,7 +339,7 @@ export class SimpleHelpersModule extends ModuleBase {
    * @since 6.3.0
    */
   objectValue<const T extends Record<string, unknown>>(object: T): T[keyof T] {
-    return helpersObjectValue(this.faker.fakerCore, object);
+    return helpersObjectValue(this.fakerCore, object);
   }
 
   /**
@@ -363,7 +359,7 @@ export class SimpleHelpersModule extends ModuleBase {
   objectEntry<const T extends Record<string, unknown>>(
     object: T
   ): [keyof T, T[keyof T]] {
-    return helpersObjectEntry(this.faker.fakerCore, object);
+    return helpersObjectEntry(this.fakerCore, object);
   }
 
   /**
@@ -381,7 +377,7 @@ export class SimpleHelpersModule extends ModuleBase {
    * @since 6.3.0
    */
   arrayElement<const T>(array: ReadonlyArray<T>): T {
-    return helpersArrayElement(this.faker.fakerCore, array);
+    return helpersArrayElement(this.fakerCore, array);
   }
 
   /**
@@ -418,7 +414,7 @@ export class SimpleHelpersModule extends ModuleBase {
       value: T;
     }>
   ): T {
-    return helpersWeightedArrayElement(this.faker.fakerCore, array);
+    return helpersWeightedArrayElement(this.fakerCore, array);
   }
 
   /**
@@ -439,7 +435,7 @@ export class SimpleHelpersModule extends ModuleBase {
    * @since 6.3.0
    */
   arrayElements<const T>(array: ReadonlyArray<T>, count?: NumberOrRange): T[] {
-    return helpersArrayElements(this.faker.fakerCore, array, count);
+    return helpersArrayElements(this.fakerCore, array, count);
   }
 
   /**
@@ -466,7 +462,7 @@ export class SimpleHelpersModule extends ModuleBase {
   enumValue<T extends Record<string | number, string | number>>(
     enumObject: T
   ): T[keyof T] {
-    return helpersEnumValue(this.faker.fakerCore, enumObject);
+    return helpersEnumValue(this.fakerCore, enumObject);
   }
 
   /**
@@ -483,7 +479,7 @@ export class SimpleHelpersModule extends ModuleBase {
    * @since 8.0.0
    */
   rangeToNumber(numberOrRange: NumberOrRange): number {
-    return helpersRangeToNumber(this.faker.fakerCore, numberOrRange);
+    return helpersRangeToNumber(this.fakerCore, numberOrRange);
   }
 
   /**
@@ -514,7 +510,7 @@ export class SimpleHelpersModule extends ModuleBase {
       count?: NumberOrRange;
     } = {}
   ): TResult[] {
-    return helpersMultiple(this.faker.fakerCore, method, options);
+    return helpersMultiple(this.fakerCore, method, options);
   }
 }
 

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -1,5 +1,5 @@
 import type { Faker } from '../../faker';
-import { SimpleModuleBase } from '../../internal/module-base';
+import { ModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
 import { fakeEval } from './_eval';
 import { arrayElement as helpersArrayElement } from './array-element';
@@ -23,7 +23,7 @@ import { weightedArrayElement as helpersWeightedArrayElement } from './weighted-
 /**
  * Module with various helper methods providing basic (seed-dependent) operations useful for implementing faker methods (without methods requiring localized data).
  */
-export class SimpleHelpersModule extends SimpleModuleBase {
+export class SimpleHelpersModule extends ModuleBase {
   /*
    * The class body is automatically generated.
    * Run 'pnpm run generate:module-tree helpers' to update the methods from their respective files.

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -1,3 +1,4 @@
+import type { FakerCore } from '../../core';
 import type { Faker } from '../../faker';
 import { ModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
@@ -531,8 +532,11 @@ export class HelpersModule extends SimpleHelpersModule {
    * Run 'pnpm run generate:module-tree helpers' to update the methods from their respective files.
    */
 
-  constructor(protected readonly faker: Faker) {
-    super(faker);
+  constructor(
+    protected readonly fakerCore: FakerCore,
+    private readonly faker: Faker
+  ) {
+    super(fakerCore);
   }
 
   /**

--- a/src/modules/image/module.ts
+++ b/src/modules/image/module.ts
@@ -42,7 +42,7 @@ export class ImageModule extends ModuleBase {
    * @since 2.0.1
    */
   avatar(): string {
-    return imageAvatar(this.faker.fakerCore);
+    return imageAvatar(this.fakerCore);
   }
 
   /**
@@ -57,7 +57,7 @@ export class ImageModule extends ModuleBase {
    * @since 8.0.0
    */
   avatarGitHub(): string {
-    return imageAvatarGitHub(this.faker.fakerCore);
+    return imageAvatarGitHub(this.fakerCore);
   }
 
   /**
@@ -93,7 +93,7 @@ export class ImageModule extends ModuleBase {
       size?: 512 | 256 | 128 | 64 | 32;
     } = {}
   ): string {
-    return imagePersonPortrait(this.faker.fakerCore, options);
+    return imagePersonPortrait(this.fakerCore, options);
   }
 
   /**
@@ -126,7 +126,7 @@ export class ImageModule extends ModuleBase {
       height?: number;
     } = {}
   ): string {
-    return imageUrl(this.faker.fakerCore, options);
+    return imageUrl(this.fakerCore, options);
   }
 
   /**
@@ -169,7 +169,7 @@ export class ImageModule extends ModuleBase {
       category?: string;
     } = {}
   ): string {
-    return imageUrlLoremFlickr(this.faker.fakerCore, options);
+    return imageUrlLoremFlickr(this.fakerCore, options);
   }
 
   /**
@@ -221,7 +221,7 @@ export class ImageModule extends ModuleBase {
       blur?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
     } = {}
   ): string {
-    return imageUrlPicsumPhotos(this.faker.fakerCore, options);
+    return imageUrlPicsumPhotos(this.fakerCore, options);
   }
 
   /**
@@ -268,6 +268,6 @@ export class ImageModule extends ModuleBase {
       type?: 'svg-uri' | 'svg-base64';
     } = {}
   ): string {
-    return imageDataUri(this.faker.fakerCore, options);
+    return imageDataUri(this.fakerCore, options);
   }
 }

--- a/src/modules/internet/module.ts
+++ b/src/modules/internet/module.ts
@@ -90,7 +90,7 @@ export class InternetModule extends ModuleBase {
       allowSpecialCharacters?: boolean;
     } = {}
   ): string {
-    return internetEmail(this.faker.fakerCore, options);
+    return internetEmail(this.fakerCore, options);
   }
 
   /**
@@ -133,7 +133,7 @@ export class InternetModule extends ModuleBase {
       allowSpecialCharacters?: boolean;
     } = {}
   ): string {
-    return internetExampleEmail(this.faker.fakerCore, options);
+    return internetExampleEmail(this.fakerCore, options);
   }
 
   /**
@@ -176,7 +176,7 @@ export class InternetModule extends ModuleBase {
       lastName?: string;
     } = {}
   ): string {
-    return internetUsername(this.faker.fakerCore, options);
+    return internetUsername(this.fakerCore, options);
   }
 
   /**
@@ -217,7 +217,7 @@ export class InternetModule extends ModuleBase {
       lastName?: string;
     } = {}
   ): string {
-    return internetDisplayName(this.faker.fakerCore, options);
+    return internetDisplayName(this.fakerCore, options);
   }
 
   /**
@@ -229,7 +229,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.1.5
    */
   protocol(): 'http' | 'https' {
-    return internetProtocol(this.faker.fakerCore);
+    return internetProtocol(this.fakerCore);
   }
 
   /**
@@ -249,7 +249,7 @@ export class InternetModule extends ModuleBase {
    * @since 5.4.0
    */
   httpMethod(): 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' {
-    return internetHttpMethod(this.faker.fakerCore);
+    return internetHttpMethod(this.fakerCore);
   }
 
   /**
@@ -274,7 +274,7 @@ export class InternetModule extends ModuleBase {
       types?: ReadonlyArray<HTTPStatusCodeType>;
     } = {}
   ): number {
-    return internetHttpStatusCode(this.faker.fakerCore, options);
+    return internetHttpStatusCode(this.fakerCore, options);
   }
 
   /**
@@ -307,7 +307,7 @@ export class InternetModule extends ModuleBase {
       protocol?: HTTPProtocolType;
     } = {}
   ): string {
-    return internetUrl(this.faker.fakerCore, options);
+    return internetUrl(this.fakerCore, options);
   }
 
   /**
@@ -319,7 +319,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   domainName(): string {
-    return internetDomainName(this.faker.fakerCore);
+    return internetDomainName(this.fakerCore);
   }
 
   /**
@@ -332,7 +332,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   domainSuffix(): string {
-    return internetDomainSuffix(this.faker.fakerCore);
+    return internetDomainSuffix(this.fakerCore);
   }
 
   /**
@@ -345,7 +345,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   domainWord(): string {
-    return internetDomainWord(this.faker.fakerCore);
+    return internetDomainWord(this.fakerCore);
   }
 
   /**
@@ -358,7 +358,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   ip(): string {
-    return internetIp(this.faker.fakerCore);
+    return internetIp(this.fakerCore);
   }
 
   /**
@@ -445,7 +445,7 @@ export class InternetModule extends ModuleBase {
   ipv4(
     options: { cidrBlock?: string; network?: IPv4NetworkType } = {}
   ): string {
-    return internetIpv4(this.faker.fakerCore, options);
+    return internetIpv4(this.fakerCore, options);
   }
 
   /**
@@ -457,7 +457,7 @@ export class InternetModule extends ModuleBase {
    * @since 4.0.0
    */
   ipv6(): string {
-    return internetIpv6(this.faker.fakerCore);
+    return internetIpv6(this.fakerCore);
   }
 
   /**
@@ -469,7 +469,7 @@ export class InternetModule extends ModuleBase {
    * @since 5.4.0
    */
   port(): number {
-    return internetPort(this.faker.fakerCore);
+    return internetPort(this.fakerCore);
   }
 
   /**
@@ -482,7 +482,7 @@ export class InternetModule extends ModuleBase {
    * @since 2.0.1
    */
   userAgent(): string {
-    return internetUserAgent(this.faker.fakerCore);
+    return internetUserAgent(this.fakerCore);
   }
 
   /**
@@ -550,7 +550,7 @@ export class InternetModule extends ModuleBase {
           separator?: string;
         } = {}
   ): string {
-    return internetMac(this.faker.fakerCore, options);
+    return internetMac(this.fakerCore, options);
   }
 
   /**
@@ -602,7 +602,7 @@ export class InternetModule extends ModuleBase {
       prefix?: string;
     } = {}
   ): string {
-    return internetPassword(this.faker.fakerCore, options);
+    return internetPassword(this.fakerCore, options);
   }
 
   /**
@@ -627,7 +627,7 @@ export class InternetModule extends ModuleBase {
       types?: ReadonlyArray<EmojiType>;
     } = {}
   ): string {
-    return internetEmoji(this.faker.fakerCore, options);
+    return internetEmoji(this.fakerCore, options);
   }
 
   /**
@@ -642,7 +642,7 @@ export class InternetModule extends ModuleBase {
    * @since 9.1.0
    */
   jwtAlgorithm(): string {
-    return internetJwtAlgorithm(this.faker.fakerCore);
+    return internetJwtAlgorithm(this.fakerCore);
   }
 
   /**
@@ -701,6 +701,6 @@ export class InternetModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): string {
-    return internetJwt(this.faker.fakerCore, options);
+    return internetJwt(this.fakerCore, options);
   }
 }

--- a/src/modules/location/module.ts
+++ b/src/modules/location/module.ts
@@ -1,5 +1,5 @@
 import type { Faker } from '../../faker';
-import { SimpleModuleBase } from '../../internal/module-base';
+import { ModuleBase } from '../../internal/module-base';
 import { buildingNumber as locationBuildingNumber } from './building-number';
 import { cardinalDirection as locationCardinalDirection } from './cardinal-direction';
 import { city as locationCity } from './city';
@@ -25,7 +25,7 @@ import { zipCode as locationZipCode } from './zip-code';
 /**
  * Module with location functions that don't require localized data
  */
-export class SimpleLocationModule extends SimpleModuleBase {
+export class SimpleLocationModule extends ModuleBase {
   /*
    * The class body is automatically generated.
    * Run 'pnpm run generate:module-tree location' to update the methods from their respective files.

--- a/src/modules/location/module.ts
+++ b/src/modules/location/module.ts
@@ -69,7 +69,7 @@ export class SimpleLocationModule extends ModuleBase {
       precision?: number;
     } = {}
   ): number {
-    return locationLatitude(this.faker.fakerCore, options);
+    return locationLatitude(this.fakerCore, options);
   }
 
   /**
@@ -110,7 +110,7 @@ export class SimpleLocationModule extends ModuleBase {
       precision?: number;
     } = {}
   ): number {
-    return locationLongitude(this.faker.fakerCore, options);
+    return locationLongitude(this.fakerCore, options);
   }
 
   /**
@@ -149,7 +149,7 @@ export class SimpleLocationModule extends ModuleBase {
       isMetric?: boolean;
     } = {}
   ): [latitude: number, longitude: number] {
-    return locationNearbyGPSCoordinate(this.faker.fakerCore, options);
+    return locationNearbyGPSCoordinate(this.fakerCore, options);
   }
 }
 
@@ -213,7 +213,7 @@ export class LocationModule extends SimpleLocationModule {
           format?: string;
         } = {}
   ): string {
-    return locationZipCode(this.faker.fakerCore, options);
+    return locationZipCode(this.fakerCore, options);
   }
 
   /**
@@ -226,7 +226,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 8.0.0
    */
   city(): string {
-    return locationCity(this.faker.fakerCore);
+    return locationCity(this.fakerCore);
   }
 
   /**
@@ -238,7 +238,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 8.0.0
    */
   buildingNumber(): string {
-    return locationBuildingNumber(this.faker.fakerCore);
+    return locationBuildingNumber(this.fakerCore);
   }
 
   /**
@@ -250,7 +250,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 8.0.0
    */
   street(): string {
-    return locationStreet(this.faker.fakerCore);
+    return locationStreet(this.fakerCore);
   }
 
   /**
@@ -279,7 +279,7 @@ export class LocationModule extends SimpleLocationModule {
           useFullAddress?: boolean;
         } = {}
   ): string {
-    return locationStreetAddress(this.faker.fakerCore, options);
+    return locationStreetAddress(this.fakerCore, options);
   }
 
   /**
@@ -309,7 +309,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 10.5.0
    */
   postalAddress(): string {
-    return locationPostalAddress(this.faker.fakerCore);
+    return locationPostalAddress(this.fakerCore);
   }
 
   /**
@@ -322,7 +322,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 8.0.0
    */
   secondaryAddress(): string {
-    return locationSecondaryAddress(this.faker.fakerCore);
+    return locationSecondaryAddress(this.fakerCore);
   }
 
   /**
@@ -335,7 +335,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 8.0.0
    */
   county(): string {
-    return locationCounty(this.faker.fakerCore);
+    return locationCounty(this.fakerCore);
   }
 
   /**
@@ -347,7 +347,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 8.0.0
    */
   country(): string {
-    return locationCountry(this.faker.fakerCore);
+    return locationCountry(this.fakerCore);
   }
 
   /**
@@ -359,7 +359,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 9.1.0
    */
   continent(): string {
-    return locationContinent(this.faker.fakerCore);
+    return locationContinent(this.fakerCore);
   }
 
   /**
@@ -399,7 +399,7 @@ export class LocationModule extends SimpleLocationModule {
           variant?: 'alpha-2' | 'alpha-3' | 'numeric';
         } = {}
   ): string {
-    return locationCountryCode(this.faker.fakerCore, options);
+    return locationCountryCode(this.fakerCore, options);
   }
 
   /**
@@ -431,7 +431,7 @@ export class LocationModule extends SimpleLocationModule {
       abbreviated?: boolean;
     } = {}
   ): string {
-    return locationState(this.faker.fakerCore, options);
+    return locationState(this.fakerCore, options);
   }
 
   /**
@@ -458,7 +458,7 @@ export class LocationModule extends SimpleLocationModule {
       abbreviated?: boolean;
     } = {}
   ): string {
-    return locationDirection(this.faker.fakerCore, options);
+    return locationDirection(this.fakerCore, options);
   }
 
   /**
@@ -485,7 +485,7 @@ export class LocationModule extends SimpleLocationModule {
       abbreviated?: boolean;
     } = {}
   ): string {
-    return locationCardinalDirection(this.faker.fakerCore, options);
+    return locationCardinalDirection(this.fakerCore, options);
   }
 
   /**
@@ -512,7 +512,7 @@ export class LocationModule extends SimpleLocationModule {
       abbreviated?: boolean;
     } = {}
   ): string {
-    return locationOrdinalDirection(this.faker.fakerCore, options);
+    return locationOrdinalDirection(this.fakerCore, options);
   }
 
   /**
@@ -529,7 +529,7 @@ export class LocationModule extends SimpleLocationModule {
    * @since 8.0.0
    */
   timeZone(): string {
-    return locationTimeZone(this.faker.fakerCore);
+    return locationTimeZone(this.fakerCore);
   }
 
   /**
@@ -548,6 +548,6 @@ export class LocationModule extends SimpleLocationModule {
    * @since 9.4.0
    */
   language(): Language {
-    return locationLanguage(this.faker.fakerCore);
+    return locationLanguage(this.fakerCore);
   }
 }

--- a/src/modules/location/module.ts
+++ b/src/modules/location/module.ts
@@ -1,4 +1,3 @@
-import type { Faker } from '../../faker';
 import { ModuleBase } from '../../internal/module-base';
 import { buildingNumber as locationBuildingNumber } from './building-number';
 import { cardinalDirection as locationCardinalDirection } from './cardinal-direction';
@@ -169,10 +168,6 @@ export class LocationModule extends SimpleLocationModule {
    * The class body is automatically generated.
    * Run 'pnpm run generate:module-tree location' to update the methods from their respective files.
    */
-
-  constructor(protected readonly faker: Faker) {
-    super(faker);
-  }
 
   /**
    * Generates random zip code from specified format. If format is not specified,

--- a/src/modules/lorem/module.ts
+++ b/src/modules/lorem/module.ts
@@ -60,7 +60,7 @@ export class LoremModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return loremWord(this.faker.fakerCore, options);
+    return loremWord(this.fakerCore, options);
   }
 
   /**
@@ -78,7 +78,7 @@ export class LoremModule extends ModuleBase {
    * @since 2.0.1
    */
   words(wordCount: NumberOrRange = 3): string {
-    return loremWords(this.faker.fakerCore, wordCount);
+    return loremWords(this.fakerCore, wordCount);
   }
 
   /**
@@ -96,7 +96,7 @@ export class LoremModule extends ModuleBase {
    * @since 2.0.1
    */
   sentence(wordCount: NumberOrRange = { min: 3, max: 10 }): string {
-    return loremSentence(this.faker.fakerCore, wordCount);
+    return loremSentence(this.fakerCore, wordCount);
   }
 
   /**
@@ -114,7 +114,7 @@ export class LoremModule extends ModuleBase {
    * @since 4.0.0
    */
   slug(wordCount: NumberOrRange = 3): string {
-    return loremSlug(this.faker.fakerCore, wordCount);
+    return loremSlug(this.fakerCore, wordCount);
   }
 
   /**
@@ -139,7 +139,7 @@ export class LoremModule extends ModuleBase {
     sentenceCount: NumberOrRange = { min: 2, max: 6 },
     separator: string = ' '
   ): string {
-    return loremSentences(this.faker.fakerCore, sentenceCount, separator);
+    return loremSentences(this.fakerCore, sentenceCount, separator);
   }
 
   /**
@@ -157,7 +157,7 @@ export class LoremModule extends ModuleBase {
    * @since 2.0.1
    */
   paragraph(sentenceCount: NumberOrRange = 3): string {
-    return loremParagraph(this.faker.fakerCore, sentenceCount);
+    return loremParagraph(this.fakerCore, sentenceCount);
   }
 
   /**
@@ -196,7 +196,7 @@ export class LoremModule extends ModuleBase {
     paragraphCount: NumberOrRange = 3,
     separator: string = '\n'
   ): string {
-    return loremParagraphs(this.faker.fakerCore, paragraphCount, separator);
+    return loremParagraphs(this.fakerCore, paragraphCount, separator);
   }
 
   /**
@@ -214,7 +214,7 @@ export class LoremModule extends ModuleBase {
    * @since 3.1.0
    */
   text(): string {
-    return loremText(this.faker.fakerCore);
+    return loremText(this.fakerCore);
   }
 
   /**
@@ -245,6 +245,6 @@ export class LoremModule extends ModuleBase {
    * @since 3.1.0
    */
   lines(lineCount: NumberOrRange = { min: 1, max: 5 }): string {
-    return loremLines(this.faker.fakerCore, lineCount);
+    return loremLines(this.fakerCore, lineCount);
   }
 }

--- a/src/modules/medical/module.ts
+++ b/src/modules/medical/module.ts
@@ -34,7 +34,7 @@ export class MedicalModule extends ModuleBase {
    * @since 11.0.0
    */
   specialty(): string {
-    return medicalSpecialty(this.faker.fakerCore);
+    return medicalSpecialty(this.fakerCore);
   }
 
   /**
@@ -46,7 +46,7 @@ export class MedicalModule extends ModuleBase {
    * @since 11.0.0
    */
   department(): string {
-    return medicalDepartment(this.faker.fakerCore);
+    return medicalDepartment(this.fakerCore);
   }
 
   /**
@@ -58,7 +58,7 @@ export class MedicalModule extends ModuleBase {
    * @since 11.0.0
    */
   condition(): string {
-    return medicalCondition(this.faker.fakerCore);
+    return medicalCondition(this.fakerCore);
   }
 
   /**
@@ -70,7 +70,7 @@ export class MedicalModule extends ModuleBase {
    * @since 11.0.0
    */
   symptom(): string {
-    return medicalSymptom(this.faker.fakerCore);
+    return medicalSymptom(this.fakerCore);
   }
 
   /**
@@ -82,7 +82,7 @@ export class MedicalModule extends ModuleBase {
    * @since 11.0.0
    */
   procedure(): string {
-    return medicalProcedure(this.faker.fakerCore);
+    return medicalProcedure(this.fakerCore);
   }
 
   /**
@@ -98,7 +98,7 @@ export class MedicalModule extends ModuleBase {
    * @since 11.0.0
    */
   allergen(): string {
-    return medicalAllergen(this.faker.fakerCore);
+    return medicalAllergen(this.fakerCore);
   }
 
   /**
@@ -110,7 +110,7 @@ export class MedicalModule extends ModuleBase {
    * @since 11.0.0
    */
   bloodType(): string {
-    return medicalBloodType(this.faker.fakerCore);
+    return medicalBloodType(this.fakerCore);
   }
 
   /**
@@ -126,6 +126,6 @@ export class MedicalModule extends ModuleBase {
    * @since 11.0.0
    */
   drugName(): string {
-    return medicalDrugName(this.faker.fakerCore);
+    return medicalDrugName(this.fakerCore);
   }
 }

--- a/src/modules/music/module.ts
+++ b/src/modules/music/module.ts
@@ -36,7 +36,7 @@ export class MusicModule extends ModuleBase {
    * @since 9.0.0
    */
   album(): string {
-    return musicAlbum(this.faker.fakerCore);
+    return musicAlbum(this.fakerCore);
   }
 
   /**
@@ -48,7 +48,7 @@ export class MusicModule extends ModuleBase {
    * @since 9.0.0
    */
   artist(): string {
-    return musicArtist(this.faker.fakerCore);
+    return musicArtist(this.fakerCore);
   }
 
   /**
@@ -60,7 +60,7 @@ export class MusicModule extends ModuleBase {
    * @since 5.2.0
    */
   genre(): string {
-    return musicGenre(this.faker.fakerCore);
+    return musicGenre(this.fakerCore);
   }
 
   /**
@@ -72,6 +72,6 @@ export class MusicModule extends ModuleBase {
    * @since 7.1.0
    */
   songName(): string {
-    return musicSongName(this.faker.fakerCore);
+    return musicSongName(this.fakerCore);
   }
 }

--- a/src/modules/number/module.ts
+++ b/src/modules/number/module.ts
@@ -84,7 +84,7 @@ export class NumberModule extends ModuleBase {
           distributor?: Distributor;
         } = {}
   ): number {
-    return numberInt(this.faker.fakerCore, options);
+    return numberInt(this.fakerCore, options);
   }
 
   /**
@@ -147,7 +147,7 @@ export class NumberModule extends ModuleBase {
           distributor?: Distributor;
         } = {}
   ): number {
-    return numberFloat(this.faker.fakerCore, options);
+    return numberFloat(this.fakerCore, options);
   }
 
   /**
@@ -188,7 +188,7 @@ export class NumberModule extends ModuleBase {
           max?: number;
         } = {}
   ): string {
-    return numberBinary(this.faker.fakerCore, options);
+    return numberBinary(this.fakerCore, options);
   }
 
   /**
@@ -229,7 +229,7 @@ export class NumberModule extends ModuleBase {
           max?: number;
         } = {}
   ): string {
-    return numberOctal(this.faker.fakerCore, options);
+    return numberOctal(this.fakerCore, options);
   }
 
   /**
@@ -268,7 +268,7 @@ export class NumberModule extends ModuleBase {
           max?: number;
         } = {}
   ): string {
-    return numberHex(this.faker.fakerCore, options);
+    return numberHex(this.fakerCore, options);
   }
 
   /**
@@ -321,7 +321,7 @@ export class NumberModule extends ModuleBase {
           multipleOf?: bigint | number | string | boolean;
         } = {}
   ): bigint {
-    return numberBigInt(this.faker.fakerCore, options);
+    return numberBigInt(this.fakerCore, options);
   }
 
   /**
@@ -364,6 +364,6 @@ export class NumberModule extends ModuleBase {
           max?: number;
         } = {}
   ): string {
-    return numberRomanNumeral(this.faker.fakerCore, options);
+    return numberRomanNumeral(this.fakerCore, options);
   }
 }

--- a/src/modules/number/module.ts
+++ b/src/modules/number/module.ts
@@ -1,5 +1,5 @@
 import type { Distributor } from '../../distributors/distributor';
-import { SimpleModuleBase } from '../../internal/module-base';
+import { ModuleBase } from '../../internal/module-base';
 import { bigInt as numberBigInt } from './big-int';
 import { binary as numberBinary } from './binary';
 import { float as numberFloat } from './float';
@@ -22,7 +22,7 @@ import { romanNumeral as numberRomanNumeral } from './roman-numeral';
  * - For numeric strings of a given length, use [`faker.string.numeric()`](https://fakerjs.dev/api/string.html#numeric).
  * - For credit card numbers, use [`faker.finance.creditCardNumber()`](https://fakerjs.dev/api/finance.html#creditcardnumber).
  */
-export class NumberModule extends SimpleModuleBase {
+export class NumberModule extends ModuleBase {
   /*
    * The class body is automatically generated.
    * Run 'pnpm run generate:module-tree number' to update the methods from their respective files.

--- a/src/modules/person/module.ts
+++ b/src/modules/person/module.ts
@@ -55,7 +55,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   firstName(sex?: SexType): string {
-    return personFirstName(this.faker.fakerCore, sex);
+    return personFirstName(this.fakerCore, sex);
   }
 
   /**
@@ -72,7 +72,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   lastName(sex?: SexType): string {
-    return personLastName(this.faker.fakerCore, sex);
+    return personLastName(this.fakerCore, sex);
   }
 
   /**
@@ -89,7 +89,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   middleName(sex?: SexType): string {
-    return personMiddleName(this.faker.fakerCore, sex);
+    return personMiddleName(this.fakerCore, sex);
   }
 
   /**
@@ -131,7 +131,7 @@ export class PersonModule extends ModuleBase {
       sex?: SexType;
     } = {}
   ): string {
-    return personFullName(this.faker.fakerCore, options);
+    return personFullName(this.fakerCore, options);
   }
 
   /**
@@ -145,7 +145,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   gender(): string {
-    return personGender(this.faker.fakerCore);
+    return personGender(this.fakerCore);
   }
 
   /**
@@ -163,7 +163,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   sex(): string {
-    return personSex(this.faker.fakerCore);
+    return personSex(this.fakerCore);
   }
 
   /**
@@ -194,7 +194,7 @@ export class PersonModule extends ModuleBase {
       includeGeneric?: boolean;
     } = {}
   ): SexType {
-    return personSexType(this.faker.fakerCore, options);
+    return personSexType(this.fakerCore, options);
   }
 
   /**
@@ -206,7 +206,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   bio(): string {
-    return personBio(this.faker.fakerCore);
+    return personBio(this.fakerCore);
   }
 
   /**
@@ -222,7 +222,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   prefix(sex?: SexType): string {
-    return personPrefix(this.faker.fakerCore, sex);
+    return personPrefix(this.fakerCore, sex);
   }
 
   /**
@@ -234,7 +234,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   suffix(): string {
-    return personSuffix(this.faker.fakerCore);
+    return personSuffix(this.fakerCore);
   }
 
   /**
@@ -246,7 +246,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   jobTitle(): string {
-    return personJobTitle(this.faker.fakerCore);
+    return personJobTitle(this.fakerCore);
   }
 
   /**
@@ -258,7 +258,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   jobDescriptor(): string {
-    return personJobDescriptor(this.faker.fakerCore);
+    return personJobDescriptor(this.fakerCore);
   }
 
   /**
@@ -270,7 +270,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   jobArea(): string {
-    return personJobArea(this.faker.fakerCore);
+    return personJobArea(this.fakerCore);
   }
 
   /**
@@ -282,7 +282,7 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   jobType(): string {
-    return personJobType(this.faker.fakerCore);
+    return personJobType(this.fakerCore);
   }
 
   /**
@@ -294,6 +294,6 @@ export class PersonModule extends ModuleBase {
    * @since 8.0.0
    */
   zodiacSign(): string {
-    return personZodiacSign(this.faker.fakerCore);
+    return personZodiacSign(this.fakerCore);
   }
 }

--- a/src/modules/phone/module.ts
+++ b/src/modules/phone/module.ts
@@ -47,7 +47,7 @@ export class PhoneModule extends ModuleBase {
       style?: 'human' | 'national' | 'international' | 'mobile';
     } = {}
   ): string {
-    return phoneNumber(this.faker.fakerCore, options);
+    return phoneNumber(this.fakerCore, options);
   }
 
   /**
@@ -59,6 +59,6 @@ export class PhoneModule extends ModuleBase {
    * @since 6.2.0
    */
   imei(): string {
-    return phoneImei(this.faker.fakerCore);
+    return phoneImei(this.fakerCore);
   }
 }

--- a/src/modules/science/module.ts
+++ b/src/modules/science/module.ts
@@ -28,7 +28,7 @@ export class ScienceModule extends ModuleBase {
    * @since 7.2.0
    */
   chemicalElement(): ChemicalElement {
-    return scienceChemicalElement(this.faker.fakerCore);
+    return scienceChemicalElement(this.fakerCore);
   }
 
   /**
@@ -42,6 +42,6 @@ export class ScienceModule extends ModuleBase {
    * @since 7.2.0
    */
   unit(): Unit {
-    return scienceUnit(this.faker.fakerCore);
+    return scienceUnit(this.fakerCore);
   }
 }

--- a/src/modules/string/module.ts
+++ b/src/modules/string/module.ts
@@ -1,4 +1,4 @@
-import { SimpleModuleBase } from '../../internal/module-base';
+import { ModuleBase } from '../../internal/module-base';
 import type { LiteralUnion } from '../../internal/types';
 import type { Casing, NumberOrRange } from '../../utils/types';
 import type { AlphaChar, AlphaNumericChar, NumericChar } from './_types';
@@ -31,7 +31,7 @@ import { uuid as stringUuid } from './uuid';
  * - Emoji can be found at [`faker.internet.emoji()`](https://fakerjs.dev/api/internet.html#emoji).
  * - The [`faker.helpers`](https://fakerjs.dev/api/helpers.html) module includes a number of string related methods.
  */
-export class StringModule extends SimpleModuleBase {
+export class StringModule extends ModuleBase {
   /*
    * The class body is automatically generated.
    * Run 'pnpm run generate:module-tree string' to update the methods from their respective files.

--- a/src/modules/string/module.ts
+++ b/src/modules/string/module.ts
@@ -58,7 +58,7 @@ export class StringModule extends ModuleBase {
     characters: string | ReadonlyArray<string>,
     length: NumberOrRange = 1
   ): string {
-    return stringFromCharacters(this.faker.fakerCore, characters, length);
+    return stringFromCharacters(this.fakerCore, characters, length);
   }
 
   /**
@@ -103,7 +103,7 @@ export class StringModule extends ModuleBase {
           exclude?: ReadonlyArray<LiteralUnion<AlphaChar>> | string;
         } = {}
   ): string {
-    return stringAlpha(this.faker.fakerCore, options);
+    return stringAlpha(this.fakerCore, options);
   }
 
   /**
@@ -148,7 +148,7 @@ export class StringModule extends ModuleBase {
           exclude?: ReadonlyArray<LiteralUnion<AlphaNumericChar>> | string;
         } = {}
   ): string {
-    return stringAlphanumeric(this.faker.fakerCore, options);
+    return stringAlphanumeric(this.fakerCore, options);
   }
 
   /**
@@ -185,7 +185,7 @@ export class StringModule extends ModuleBase {
       prefix?: string;
     } = {}
   ): string {
-    return stringBinary(this.faker.fakerCore, options);
+    return stringBinary(this.fakerCore, options);
   }
 
   /**
@@ -222,7 +222,7 @@ export class StringModule extends ModuleBase {
       prefix?: string;
     } = {}
   ): string {
-    return stringOctal(this.faker.fakerCore, options);
+    return stringOctal(this.fakerCore, options);
   }
 
   /**
@@ -268,7 +268,7 @@ export class StringModule extends ModuleBase {
       prefix?: string;
     } = {}
   ): string {
-    return stringHexadecimal(this.faker.fakerCore, options);
+    return stringHexadecimal(this.fakerCore, options);
   }
 
   /**
@@ -317,7 +317,7 @@ export class StringModule extends ModuleBase {
           exclude?: ReadonlyArray<LiteralUnion<NumericChar>> | string;
         } = {}
   ): string {
-    return stringNumeric(this.faker.fakerCore, options);
+    return stringNumeric(this.fakerCore, options);
   }
 
   /**
@@ -335,7 +335,7 @@ export class StringModule extends ModuleBase {
    * @since 8.0.0
    */
   sample(length: NumberOrRange = 10): string {
-    return stringSample(this.faker.fakerCore, length);
+    return stringSample(this.fakerCore, length);
   }
 
   /**
@@ -427,7 +427,7 @@ export class StringModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): string {
-    return stringUuid(this.faker.fakerCore, options);
+    return stringUuid(this.fakerCore, options);
   }
 
   /**
@@ -458,7 +458,7 @@ export class StringModule extends ModuleBase {
       refDate?: string | Date | number;
     } = {}
   ): string {
-    return stringUlid(this.faker.fakerCore, options);
+    return stringUlid(this.fakerCore, options);
   }
 
   /**
@@ -476,7 +476,7 @@ export class StringModule extends ModuleBase {
    * @since 8.0.0
    */
   nanoid(length: NumberOrRange = 21): string {
-    return stringNanoid(this.faker.fakerCore, length);
+    return stringNanoid(this.fakerCore, length);
   }
 
   /**
@@ -498,6 +498,6 @@ export class StringModule extends ModuleBase {
    * @since 8.0.0
    */
   symbol(length: NumberOrRange = 1): string {
-    return stringSymbol(this.faker.fakerCore, length);
+    return stringSymbol(this.fakerCore, length);
   }
 }

--- a/src/modules/system/module.ts
+++ b/src/modules/system/module.ts
@@ -49,7 +49,7 @@ export class SystemModule extends ModuleBase {
       extensionCount?: NumberOrRange;
     } = {}
   ): string {
-    return systemFileName(this.faker.fakerCore, options);
+    return systemFileName(this.fakerCore, options);
   }
 
   /**
@@ -64,7 +64,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   commonFileName(extension?: string): string {
-    return systemCommonFileName(this.faker.fakerCore, extension);
+    return systemCommonFileName(this.fakerCore, extension);
   }
 
   /**
@@ -76,7 +76,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   mimeType(): string {
-    return systemMimeType(this.faker.fakerCore);
+    return systemMimeType(this.fakerCore);
   }
 
   /**
@@ -88,7 +88,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   commonFileType(): string {
-    return systemCommonFileType(this.faker.fakerCore);
+    return systemCommonFileType(this.fakerCore);
   }
 
   /**
@@ -100,7 +100,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   commonFileExt(): string {
-    return systemCommonFileExt(this.faker.fakerCore);
+    return systemCommonFileExt(this.fakerCore);
   }
 
   /**
@@ -112,7 +112,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   fileType(): string {
-    return systemFileType(this.faker.fakerCore);
+    return systemFileType(this.fakerCore);
   }
 
   /**
@@ -127,7 +127,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   fileExt(mimeType?: string): string {
-    return systemFileExt(this.faker.fakerCore, mimeType);
+    return systemFileExt(this.fakerCore, mimeType);
   }
 
   /**
@@ -139,7 +139,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   directoryPath(): string {
-    return systemDirectoryPath(this.faker.fakerCore);
+    return systemDirectoryPath(this.fakerCore);
   }
 
   /**
@@ -151,7 +151,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   filePath(): string {
-    return systemFilePath(this.faker.fakerCore);
+    return systemFilePath(this.fakerCore);
   }
 
   /**
@@ -163,7 +163,7 @@ export class SystemModule extends ModuleBase {
    * @since 3.1.0
    */
   semver(): string {
-    return systemSemver(this.faker.fakerCore);
+    return systemSemver(this.fakerCore);
   }
 
   /**
@@ -197,7 +197,7 @@ export class SystemModule extends ModuleBase {
       interfaceSchema?: CommonInterfaceSchema;
     } = {}
   ): string {
-    return systemNetworkInterface(this.faker.fakerCore, options);
+    return systemNetworkInterface(this.fakerCore, options);
   }
 
   /**
@@ -232,6 +232,6 @@ export class SystemModule extends ModuleBase {
       includeNonStandard?: boolean;
     } = {}
   ): string {
-    return systemCron(this.faker.fakerCore, options);
+    return systemCron(this.fakerCore, options);
   }
 }

--- a/src/modules/vehicle/module.ts
+++ b/src/modules/vehicle/module.ts
@@ -33,7 +33,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   vehicle(): string {
-    return vehicleVehicle(this.faker.fakerCore);
+    return vehicleVehicle(this.fakerCore);
   }
 
   /**
@@ -45,7 +45,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   manufacturer(): string {
-    return vehicleManufacturer(this.faker.fakerCore);
+    return vehicleManufacturer(this.fakerCore);
   }
 
   /**
@@ -57,7 +57,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   model(): string {
-    return vehicleModel(this.faker.fakerCore);
+    return vehicleModel(this.fakerCore);
   }
 
   /**
@@ -69,7 +69,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   type(): string {
-    return vehicleType(this.faker.fakerCore);
+    return vehicleType(this.fakerCore);
   }
 
   /**
@@ -81,7 +81,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   fuel(): string {
-    return vehicleFuel(this.faker.fakerCore);
+    return vehicleFuel(this.fakerCore);
   }
 
   /**
@@ -93,7 +93,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   vin(): string {
-    return vehicleVin(this.faker.fakerCore);
+    return vehicleVin(this.fakerCore);
   }
 
   /**
@@ -105,7 +105,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.0.0
    */
   color(): string {
-    return vehicleColor(this.faker.fakerCore);
+    return vehicleColor(this.fakerCore);
   }
 
   /**
@@ -117,7 +117,7 @@ export class VehicleModule extends ModuleBase {
    * @since 5.4.0
    */
   vrm(): string {
-    return vehicleVrm(this.faker.fakerCore);
+    return vehicleVrm(this.fakerCore);
   }
 
   /**
@@ -129,6 +129,6 @@ export class VehicleModule extends ModuleBase {
    * @since 5.5.0
    */
   bicycle(): string {
-    return vehicleBicycle(this.faker.fakerCore);
+    return vehicleBicycle(this.fakerCore);
   }
 }

--- a/src/modules/word/module.ts
+++ b/src/modules/word/module.ts
@@ -52,7 +52,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return wordAdjective(this.faker.fakerCore, options);
+    return wordAdjective(this.fakerCore, options);
   }
 
   /**
@@ -88,7 +88,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return wordAdverb(this.faker.fakerCore, options);
+    return wordAdverb(this.fakerCore, options);
   }
 
   /**
@@ -124,7 +124,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return wordConjunction(this.faker.fakerCore, options);
+    return wordConjunction(this.fakerCore, options);
   }
 
   /**
@@ -160,7 +160,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return wordInterjection(this.faker.fakerCore, options);
+    return wordInterjection(this.fakerCore, options);
   }
 
   /**
@@ -196,7 +196,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return wordNoun(this.faker.fakerCore, options);
+    return wordNoun(this.fakerCore, options);
   }
 
   /**
@@ -232,7 +232,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return wordPreposition(this.faker.fakerCore, options);
+    return wordPreposition(this.fakerCore, options);
   }
 
   /**
@@ -268,7 +268,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return wordVerb(this.faker.fakerCore, options);
+    return wordVerb(this.fakerCore, options);
   }
 
   /**
@@ -302,7 +302,7 @@ export class WordModule extends ModuleBase {
           strategy?: LengthStrategyType;
         } = {}
   ): string {
-    return wordSample(this.faker.fakerCore, options);
+    return wordSample(this.fakerCore, options);
   }
 
   /**
@@ -331,6 +331,6 @@ export class WordModule extends ModuleBase {
           count?: NumberOrRange;
         } = {}
   ): string {
-    return wordWords(this.faker.fakerCore, options);
+    return wordWords(this.fakerCore, options);
   }
 }

--- a/src/simple-faker.ts
+++ b/src/simple-faker.ts
@@ -84,12 +84,12 @@ export class SimpleFaker {
     utilsSetDefaultRefDate(this.fakerCore, dateOrSource);
   }
 
-  readonly datatype: DatatypeModule = new DatatypeModule(this);
-  readonly date: SimpleDateModule = new SimpleDateModule(this);
-  readonly helpers: SimpleHelpersModule = new SimpleHelpersModule(this);
-  readonly location: SimpleLocationModule = new SimpleLocationModule(this);
-  readonly number: NumberModule = new NumberModule(this);
-  readonly string: StringModule = new StringModule(this);
+  readonly datatype: DatatypeModule;
+  readonly date: SimpleDateModule;
+  readonly helpers: SimpleHelpersModule;
+  readonly location: SimpleLocationModule;
+  readonly number: NumberModule;
+  readonly string: StringModule;
 
   /**
    * Creates a new instance of SimpleFaker.
@@ -120,6 +120,13 @@ export class SimpleFaker {
    */
   constructor(options?: FakerOptions) {
     this.fakerCore = createFakerCore(options);
+
+    this.datatype = new DatatypeModule(this.fakerCore);
+    this.date = new SimpleDateModule(this.fakerCore);
+    this.helpers = new SimpleHelpersModule(this.fakerCore);
+    this.location = new SimpleLocationModule(this.fakerCore);
+    this.number = new NumberModule(this.fakerCore);
+    this.string = new StringModule(this.fakerCore);
   }
 
   /**


### PR DESCRIPTION
Continuation of #3748

- #3748

---

- Replace all references to `Faker` and `SimpleFaker` inside modules with `FakerCore`.
  - The `HelpersModule` is the only module, that retains a reference to `Faker` as it needs it for the module tree.
- The modules are now initialized inside the `Faker` constructor, as they require a reference to the `FakerCore` instance, that is passed as constructor parameter.
- This is breaking for JS users, that previously could access the `Faker` instances via `faker.airline.faker`.