### PR TITLE
docs(helpers): fix typescript error in uniqueArray example

### DIFF
--- a/scripts/module-tree/generate-module-tree.ts
+++ b/scripts/module-tree/generate-module-tree.ts
@@ -213,7 +213,7 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
               .replaceAll(/ +\*\n +\*\n/g, ' *\n')
               // Examples
               .replaceAll(
-                new RegExp(`${methodName}\\(fakerCore(?:, ?)?`, 'g'),
+                new RegExp(`${methodName}\\(fakerCore(?:, ?|(?=\\)))`, 'g'),
                 `faker.${moduleName}.${methodName}(`
               )
               // Since
@@ -225,19 +225,21 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
               .replaceAll(' *\n * @experimental\n', '')
               // Default Ref Date
               .replaceAll(
-                /(?<= +\* .*?)\bgetDefaultRefDate\(fakerCore(?:, ?)?/g,
+                /(?<= +\* .*?)\bgetDefaultRefDate\(fakerCore(?:, ?|(?=\)))/g,
                 'faker.defaultRefDate('
               )
               // Method References
               .replaceAll(
-                /\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?)?/g,
+                /\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?|(?=\)))/g,
                 restoreFakerTreeInvocations
               )
               .replaceAll(
-                /\b([a-zA-Z]+)\(fakerCore(?:, ?)?/g,
+                /\b([a-zA-Z]+)\(fakerCore(?:, ?|(?=\)))/g,
                 (_, method: string) =>
                   `faker.${moduleName}.${toCamelCase(method)}(`
-              );
+              )
+              // Locale Access
+              .replaceAll(/\bfakerCore\.locale\b/g, 'faker.definitions');
 
             parts.push(description);
           }
@@ -251,11 +253,11 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
             .replace(/\((\n +)?fakerCore: FakerCore,?/, '(')
             // Adapt nested options defaults
             .replaceAll(
-              /(?<= +\* .*?)\bgetDefaultRefDate\(fakerCore(?:, ?)?/g,
+              /(?<= +\* .*?)\bgetDefaultRefDate\(fakerCore(?:, ?|(?=\)))/g,
               'faker.defaultRefDate('
             )
             .replaceAll(
-              /(?<= +\* .*?)\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?)?/g,
+              /(?<= +\* .*?)\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?|(?=\)))/g,
               restoreFakerTreeInvocations
             )
             // moduleSample() => sample()

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -245,7 +245,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @example
    * faker.helpers.uniqueArray(faker.word.sample, 3) // ['mob', 'junior', 'ripe']
-   * faker.helpers.uniqueArray(faker.definitions.person.first_name.generic, 6) // ['Silas', 'Montana', 'Lorenzo', 'Alayna', 'Aditya', 'Antone']
+   * faker.helpers.uniqueArray(faker.definitions.color.human, 6) // ['lavender', 'green', 'indigo', 'orange', 'tan', 'teal']
    * faker.helpers.uniqueArray(["Hello", "World", "Goodbye"], 2) // ['World', 'Goodbye']
    *
    * @since 6.0.0

--- a/src/modules/helpers/unique-array.ts
+++ b/src/modules/helpers/unique-array.ts
@@ -19,7 +19,7 @@ import { shuffle } from './shuffle';
  *
  * @example
  * uniqueArray(fakerCore, faker.word.sample, 3) // ['mob', 'junior', 'ripe']
- * uniqueArray(fakerCore, faker.definitions.person.first_name.generic, 6) // ['Silas', 'Montana', 'Lorenzo', 'Alayna', 'Aditya', 'Antone']
+ * uniqueArray(fakerCore, fakerCore.locale.color.human, 6) // ['lavender', 'green', 'indigo', 'orange', 'tan', 'teal']
  * uniqueArray(fakerCore, ["Hello", "World", "Goodbye"], 2) // ['World', 'Goodbye']
  *
  * @since 11.0.0


### PR DESCRIPTION
Fixes #4009

- #4009

---

- Fixed typescript error in uniqueArray example.
- Example changed to use `fakerCore` for locale access.
- Fixed `generate:module-tree` script regarding locale access.

Preview: [API-Docs](https://deploy-preview-4082.fakerjs.dev/api/helpers.html#uniquearray)