### PR TITLE
docs(helpers): refer to elements instead of strings in uniqueArray

### DIFF
--- a/scripts/module-tree/generate-module-tree.ts
+++ b/scripts/module-tree/generate-module-tree.ts
@@ -213,7 +213,7 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
               .replaceAll(/ +\*\n +\*\n/g, ' *\n')
               // Examples
               .replaceAll(
-                new RegExp(`${methodName}\\(fakerCore(?:, ?)?`, 'g'),
+                new RegExp(`${methodName}\\(fakerCore(?:, ?|(?=\\)))`, 'g'),
                 `faker.${moduleName}.${methodName}(`
               )
               // Since
@@ -225,19 +225,21 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
               .replaceAll(' *\n * @experimental\n', '')
               // Default Ref Date
               .replaceAll(
-                /(?<= +\* .*?)\bgetDefaultRefDate\(fakerCore(?:, ?)?/g,
+                /(?<= +\* .*?)\bgetDefaultRefDate\(fakerCore(?:, ?|(?=\)))/g,
                 'faker.defaultRefDate('
               )
               // Method References
               .replaceAll(
-                /\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?)?/g,
+                /\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?|(?=\)))/g,
                 restoreFakerTreeInvocations
               )
               .replaceAll(
-                /\b([a-zA-Z]+)\(fakerCore(?:, ?)?/g,
+                /\b([a-zA-Z]+)\(fakerCore(?:, ?|(?=\)))/g,
                 (_, method: string) =>
                   `faker.${moduleName}.${toCamelCase(method)}(`
-              );
+              )
+              // Locale Access
+              .replaceAll(/\bfakerCore\.locale\b/g, 'faker.definitions');
 
             parts.push(description);
           }
@@ -251,11 +253,11 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
             .replace(/\((\n +)?fakerCore: FakerCore,?/, '(')
             // Adapt nested options defaults
             .replaceAll(
-              /(?<= +\* .*?)\bgetDefaultRefDate\(fakerCore(?:, ?)?/g,
+              /(?<= +\* .*?)\bgetDefaultRefDate\(fakerCore(?:, ?|(?=\)))/g,
               'faker.defaultRefDate('
             )
             .replaceAll(
-              /(?<= +\* .*?)\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?)?/g,
+              /(?<= +\* .*?)\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?|(?=\)))/g,
               restoreFakerTreeInvocations
             )
             // moduleSample() => sample()

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -245,7 +245,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @example
    * faker.helpers.uniqueArray(faker.word.sample, 3) // ['mob', 'junior', 'ripe']
-   * faker.helpers.uniqueArray(faker.definitions.person.first_name.generic, 6) // ['Silas', 'Montana', 'Lorenzo', 'Alayna', 'Aditya', 'Antone']
+   * faker.helpers.uniqueArray(faker.definitions.color.human, 6) // ['lavender', 'green', 'indigo', 'orange', 'tan', 'teal']
    * faker.helpers.uniqueArray(["Hello", "World", "Goodbye"], 2) // ['World', 'Goodbye']
    *
    * @since 6.0.0

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -229,8 +229,8 @@ export class SimpleHelpersModule extends SimpleModuleBase {
   }
 
   /**
-   * Takes an array of strings or function that returns a string
-   * and outputs a unique array of strings based on that source.
+   * Takes an array of elements or function that returns an element
+   * and outputs a unique array of elements based on that source.
    * This method does not store the unique state between invocations.
    *
    * If there are not enough unique values to satisfy the length, if
@@ -240,7 +240,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    *
    * @template T The type of the elements.
    *
-   * @param source The strings to choose from or a function that generates a string.
+   * @param source The elements to choose from or a function that generates an element.
    * @param length The number of elements to generate.
    *
    * @example

--- a/src/modules/helpers/unique-array.ts
+++ b/src/modules/helpers/unique-array.ts
@@ -19,7 +19,7 @@ import { shuffle } from './shuffle';
  *
  * @example
  * uniqueArray(fakerCore, faker.word.sample, 3) // ['mob', 'junior', 'ripe']
- * uniqueArray(fakerCore, faker.definitions.person.first_name.generic, 6) // ['Silas', 'Montana', 'Lorenzo', 'Alayna', 'Aditya', 'Antone']
+ * uniqueArray(fakerCore, fakerCore.locale.color.human, 6) // ['lavender', 'green', 'indigo', 'orange', 'tan', 'teal']
  * uniqueArray(fakerCore, ["Hello", "World", "Goodbye"], 2) // ['World', 'Goodbye']
  *
  * @since 11.0.0

--- a/src/modules/helpers/unique-array.ts
+++ b/src/modules/helpers/unique-array.ts
@@ -2,8 +2,8 @@ import type { FakerCore } from '../../core';
 import { shuffle } from './shuffle';
 
 /**
- * Takes an array of strings or function that returns a string
- * and outputs a unique array of strings based on that source.
+ * Takes an array of elements or function that returns an element
+ * and outputs a unique array of elements based on that source.
  * This method does not store the unique state between invocations.
  *
  * If there are not enough unique values to satisfy the length, if
@@ -14,7 +14,7 @@ import { shuffle } from './shuffle';
  * @template T The type of the elements.
  *
  * @param fakerCore The FakerCore to use.
- * @param source The strings to choose from or a function that generates a string.
+ * @param source The elements to choose from or a function that generates an element.
  * @param length The number of elements to generate.
  *
  * @example


### PR DESCRIPTION
Found during #4082

- #4082

---

Change the description from referring to `strings` to `elements` as the method takes a generic `T` as argument.