### PR TITLE
feat(helpers)!: forward fakerCore parameter in uniqueArray

### DIFF
--- a/docs/guide/upgrading_v11/4084.md
+++ b/docs/guide/upgrading_v11/4084.md
@@ -1,0 +1,19 @@
+## Change in signature of uniqueArray
+
+`faker.helpers.uniqueArray` no passes the `fakerCore` to the embedded function.
+
+So functions that previously had only optional parameters are now incompatible as the first parameter is the `FakerCore`.
+
+This change allows users to pass other small modular functions directly to the `uniqueArray` method.
+
+```diff
+// Needs to be migrated
+-faker.helpers.uniqueArray(anyNoRequiredArgMethod, 3);
+
+// Works like before
+faker.helpers.uniqueArray(() => anyNoRequiredArgMethod(), 3);
+
+// New usages
++uniqueArray(fakerCore, () => anyNoRequiredArgMethod(), 3)
++uniqueArray(fakerCore, loremWord, 3)
+```

--- a/docs/guide/upgrading_v11/4084.md
+++ b/docs/guide/upgrading_v11/4084.md
@@ -1,6 +1,6 @@
 ## Change in signature of uniqueArray
 
-`faker.helpers.uniqueArray` no passes the `fakerCore` to the embedded function.
+`faker.helpers.uniqueArray` now passes the `fakerCore` to the embedded function.
 
 So functions that previously had only optional parameters are now incompatible as the first parameter is the `FakerCore`.
 

--- a/scripts/module-tree/generate-module-tree.ts
+++ b/scripts/module-tree/generate-module-tree.ts
@@ -31,6 +31,7 @@ function patchModuleImports(moduleName: string, importHelper: ImportHelper) {
     }
     case 'helpers': {
       importHelper.addImports('./_eval', 'fakeEval');
+      importHelper.addTypeImports('../../core', 'FakerCore');
       break;
     }
     case 'image': {
@@ -67,7 +68,7 @@ const directories = project
 const moduleNames = new Set(directories.map((dir) => dir.getBaseName()));
 
 export async function generateModuleTree(onlyModule?: string): Promise<void> {
-  //#region Module
+  //#region Modules
   for (const directory of directories) {
     const moduleName = directory.getBaseName();
 
@@ -187,13 +188,14 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
         const restoreFakerTreeInvocations = (
           _: string,
           module: string,
-          method: string
+          method: string,
+          suffix: string = ''
         ): string =>
           methodNames.has(`${module}${method}`)
-            ? `faker.${moduleName}.${module}${method}(`
+            ? `faker.${moduleName}.${module}${method}${suffix}`
             : moduleNames.has(module)
-              ? `faker.${module}.${toCamelCase(method)}(`
-              : `faker.${module}${method}(`;
+              ? `faker.${module}.${toCamelCase(method)}${suffix}`
+              : `faker.${module}${method}${suffix}`;
 
         for (const [index, child] of functions.entries()) {
           //#region Module Functions
@@ -211,6 +213,7 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
             );
           }
 
+          //#region JSDocs
           if (jsDocs) {
             const description = jsDocs
               .getFullText()
@@ -236,7 +239,7 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
               )
               // Method References
               .replaceAll(
-                /\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?|(?=\)))/g,
+                /\b([a-z]+)([A-Z][a-zA-Z]+)(\()fakerCore(?:, ?|(?=\)))/g,
                 restoreFakerTreeInvocations
               )
               .replaceAll(
@@ -244,11 +247,17 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
                 (_, method: string) =>
                   `faker.${moduleName}.${toCamelCase(method)}(`
               )
+              .replaceAll(
+                /\b([a-z]+)([A-Z][a-zA-Z]+)(, ?|\))/g,
+                restoreFakerTreeInvocations
+              )
               // Locale Access
               .replaceAll(/\bfakerCore\.locale\b/g, 'faker.definitions');
 
             parts.push(description);
           }
+          //#endregion JSDocs
+          //#region Signature+Implementation
 
           const signature = child
             .getSignature()
@@ -263,19 +272,19 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
               'faker.defaultRefDate('
             )
             .replaceAll(
-              /(?<= +\* .*?)\b([a-z]+)([A-Z][a-zA-Z]+)\(fakerCore(?:, ?|(?=\)))/g,
+              /(?<= +\* .*?)\b([a-z]+)([A-Z][a-zA-Z]+)(\()fakerCore(?:, ?|(?=\)))/g,
               restoreFakerTreeInvocations
             )
             // moduleSample() => sample()
             .replaceAll(new RegExp(`^${moduleName}Sample\\(`, 'g'), 'sample(');
 
           parts.push(signature);
-          //#endregion
+          //#endregion Signature+Implementation
+          //#endregion Module Functions
         }
 
         cls.addMember(parts.join('\n'));
       }
-      //#endregion
 
       const classBody = cls
         .getText()
@@ -287,6 +296,7 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
 
       content.push(classBody, '');
     }
+    //#endregion Module Classes
 
     importHelper.removeUnusedImports(content.join('\n'));
     patchModuleImports(moduleName, importHelper);
@@ -304,8 +314,8 @@ export async function generateModuleTree(onlyModule?: string): Promise<void> {
       await formatTypescript(content.join('\n')),
       'utf8'
     );
-    //#endregion
+    //#endregion Module
   }
 
-  //#endregion
+  //#endregion Modules
 }

--- a/src/modules/helpers/module.ts
+++ b/src/modules/helpers/module.ts
@@ -1,3 +1,4 @@
+import type { FakerCore } from '../../core';
 import type { Faker } from '../../faker';
 import { SimpleModuleBase } from '../../internal/module-base';
 import type { NumberOrRange } from '../../utils/types';
@@ -252,7 +253,7 @@ export class SimpleHelpersModule extends SimpleModuleBase {
    * @since 6.0.0
    */
   uniqueArray<const T>(
-    source: ReadonlyArray<T> | (() => T),
+    source: ReadonlyArray<T> | ((fakerCore: FakerCore) => T),
     length: number
   ): T[] {
     return helpersUniqueArray(this.faker.fakerCore, source, length);

--- a/src/modules/helpers/unique-array.ts
+++ b/src/modules/helpers/unique-array.ts
@@ -18,7 +18,7 @@ import { shuffle } from './shuffle';
  * @param length The number of elements to generate.
  *
  * @example
- * uniqueArray(fakerCore, faker.word.sample, 3) // ['mob', 'junior', 'ripe']
+ * uniqueArray(fakerCore, wordSample, 3) // ['mob', 'junior', 'ripe']
  * uniqueArray(fakerCore, fakerCore.locale.color.human, 6) // ['lavender', 'green', 'indigo', 'orange', 'tan', 'teal']
  * uniqueArray(fakerCore, ["Hello", "World", "Goodbye"], 2) // ['World', 'Goodbye']
  * uniqueArray(fakerCore, ["one"], 1000) // ['one']
@@ -29,7 +29,7 @@ import { shuffle } from './shuffle';
  */
 export function uniqueArray<const T>(
   fakerCore: FakerCore,
-  source: ReadonlyArray<T> | (() => T),
+  source: ReadonlyArray<T> | ((fakerCore: FakerCore) => T),
   length: number
 ): T[] {
   if (Array.isArray(source)) {
@@ -44,7 +44,7 @@ export function uniqueArray<const T>(
       const maxAttempts = 1000 * length;
       let attempts = 0;
       while (set.size < length && attempts < maxAttempts) {
-        set.add(source());
+        set.add(source(fakerCore));
         attempts++;
       }
     }

--- a/test/modules/__snapshots__/helpers.spec.ts.snap
+++ b/test/modules/__snapshots__/helpers.spec.ts.snap
@@ -208,6 +208,14 @@ exports[`helpers > 42 > uniqueArray > with array 1`] = `
 ]
 `;
 
+exports[`helpers > 42 > uniqueArray > with generator function 1`] = `
+[
+  "CyeX//&qXb",
+  ""{n412=QI<",
+  "Y-<CKj3PX%",
+]
+`;
+
 exports[`helpers > 42 > weightedArrayElement > with array 1`] = `"sunny"`;
 
 exports[`helpers > 42 > weightedArrayElement > with array with percentages 1`] = `"sunny"`;
@@ -436,6 +444,14 @@ exports[`helpers > 1211 > uniqueArray > with array 1`] = `
 ]
 `;
 
+exports[`helpers > 1211 > uniqueArray > with generator function 1`] = `
+[
+  "wt5}_\`hAal",
+  "h]nIqp5W3C",
+  "|hExR{5<bQ",
+]
+`;
+
 exports[`helpers > 1211 > weightedArrayElement > with array 1`] = `"snowy"`;
 
 exports[`helpers > 1211 > weightedArrayElement > with array with percentages 1`] = `"snowy"`;
@@ -643,6 +659,14 @@ exports[`helpers > 1337 > uniqueArray > with array 1`] = `
   "o",
   " ",
   "H",
+]
+`;
+
+exports[`helpers > 1337 > uniqueArray > with generator function 1`] = `
+[
+  "9/:K>Q9{e+",
+  "D[,|JjjBGW",
+  "g2;_O1G3Rn",
 ]
 `;
 

--- a/test/modules/helpers.spec.ts
+++ b/test/modules/helpers.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { FakerError, faker } from '../../src';
 import { luhnCheck } from '../../src/modules/helpers/_luhn-check';
+import { word as loremWord } from '../../src/modules/lorem/word';
 import { stringSample } from '../../src/modules/string/sample';
 import { seededTests } from '../support/seeded-runs';
 import { times } from '../support/times';
@@ -814,13 +815,19 @@ describe('helpers', () => {
           expect(unique).toHaveLength(length);
         });
 
-        it('function returns unique array', () => {
+        it('function returns unique array (independent function)', () => {
           const length = faker.number.int({ min: 1, max: 6 });
-          // TODO @ST-DDT 2026-09-09: Fix after word module has been migrated
           const unique = faker.helpers.uniqueArray(
             () => faker.lorem.word(),
             length
           );
+          expect(unique).not.toContainDuplicates();
+          expect(unique).toHaveLength(length);
+        });
+
+        it('function returns unique array (SMF)', () => {
+          const length = faker.number.int({ min: 1, max: 6 });
+          const unique = faker.helpers.uniqueArray(loremWord, length);
           expect(unique).not.toContainDuplicates();
           expect(unique).toHaveLength(length);
         });

--- a/test/modules/helpers.spec.ts
+++ b/test/modules/helpers.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { FakerError, faker } from '../../src';
 import { luhnCheck } from '../../src/modules/helpers/_luhn-check';
+import { stringSample } from '../../src/modules/string/sample';
 import { seededTests } from '../support/seeded-runs';
 import { times } from '../support/times';
 
@@ -121,7 +122,11 @@ describe('helpers', () => {
     });
 
     t.describe('uniqueArray', (t) => {
-      t.it('with array', [...'Hello World!'], 3);
+      t.it('with array', [...'Hello World!'], 3).it(
+        'with generator function',
+        stringSample,
+        3
+      );
     });
 
     t.describe('maybe', (t) => {
@@ -811,7 +816,11 @@ describe('helpers', () => {
 
         it('function returns unique array', () => {
           const length = faker.number.int({ min: 1, max: 6 });
-          const unique = faker.helpers.uniqueArray(faker.lorem.word, length);
+          // TODO @ST-DDT 2026-09-09: Fix after word module has been migrated
+          const unique = faker.helpers.uniqueArray(
+            () => faker.lorem.word(),
+            length
+          );
           expect(unique).not.toContainDuplicates();
           expect(unique).toHaveLength(length);
         });


### PR DESCRIPTION
Continuation of #4085

- #4085

---

Forward `fakerCore` parameter to generator function in `uniqueArray`.

This can be considered a breaking change, because any previously passed method with only optional parameters, will now receive a `FakerCore` as first parameter.