### PR TITLE
infra: show preflight warning when the formatter needs to run

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           pnpm run generate:locales
           pnpm run generate:api-docs
+          pnpm run format
           pnpm run build
           pnpm run test -u
         continue-on-error: true

--- a/src/modules/animal/bear.ts
+++ b/src/modules/animal/bear.ts
@@ -14,6 +14,5 @@ import { arrayElement } from '../helpers/array-element';
  * @experimental
  */
 export function bear(fakerCore: FakerCore): string {
-
   return arrayElement(fakerCore, fakerCore.locale.animal.bear);
 }

--- a/src/modules/animal/bear.ts
+++ b/src/modules/animal/bear.ts
@@ -14,5 +14,6 @@ import { arrayElement } from '../helpers/array-element';
  * @experimental
  */
 export function bear(fakerCore: FakerCore): string {
+
   return arrayElement(fakerCore, fakerCore.locale.animal.bear);
 }


### PR DESCRIPTION
Adds `pnpm run format` to our code generation pipeline.

Currently, formatting changes inside the code cause the lint pipeline to fail, but it does not state which file or how to remediate.
The lint step does print the hints in the correct format, but since format does not support that we have to use our own.
And since we already have a step that detects diff and requests a `preflight`, which would remediate the issue, I added it to that.

Previously, one only Lint failed, now lint and code generation failed.

<img width="798" height="109" alt="grafik" src="https://github.com/user-attachments/assets/6e83c2b9-7152-40e0-a751-1641304f7a55" />

The later adds the following screen:

<img width="736" height="141" alt="grafik" src="https://github.com/user-attachments/assets/8c0a3176-bb8c-48bb-bde0-bb37690f8358" />

Formatting isn't really "code generation", but it is similar to updating test snapshots, which is already part of the same stack of checks.

